### PR TITLE
accept 'guid' as a format for 'string' properties

### DIFF
--- a/Program.fs
+++ b/Program.fs
@@ -102,6 +102,7 @@ let rec createFieldType recordName required (propertyName: string) (propertySche
         | "number" ->  SynType.Double()
         | "boolean" -> SynType.Bool()
         | "string" when propertySchema.Format = "uuid" -> SynType.Guid()
+        | "string" when propertySchema.Format = "guid" -> SynType.Guid()
         | "string" when propertySchema.Format = "date-time" -> SynType.DateTimeOffset()
         | "string" when propertySchema.Format = "byte" ->
             // base64 encoded characters


### PR DESCRIPTION
Hi,

Not sure this is of interest, but in case it is:

I have an OpenApi schema (generated by NSwag from an ASP.Net Core C# service) which tags properties of type ```System.Guid``` as having a format of ```guid``` rather than ```uuid```:

```yaml
"id": {
    "type": "string",
    "description": "Gets or sets the unique ID for this job.",
    "format": "guid"
}
```

NSwags own client generator will generate properties of type System.Guid from either of uuid/guid, but some other generators (e.g. the OpenApi Type Provider) just leaves them as strings, so i'm not sure if you want to handle them like this or not?