### PR TITLE
Handle DateTimeOffset when building query strings

### DIFF
--- a/src/HttpLibrary.fs
+++ b/src/HttpLibrary.fs
@@ -50,6 +50,7 @@ type RequestPart =
     static member query(key: string, value: double) = Query(key, OpenApiValue.Double value)
     static member query(key: string, value: float32) = Query(key, OpenApiValue.Float value)
     static member query(key: string, value: Guid) = Query(key, OpenApiValue.String (value.ToString()))
+    static member query(key: string, value: DateTimeOffset) = Query(key, OpenApiValue.String (value.ToString("O")))
     static member path(key: string, value: int) = Path(key, OpenApiValue.Int value)
     static member path(key: string, value: int64) = Path(key, OpenApiValue.Int64 value)
     static member path(key: string, value: string) = Path(key, OpenApiValue.String value)


### PR DESCRIPTION
Hi,

I tried to use the 0.3.0 release to generate a client for a spec which passes DateTimes in query strings in various places, and the generated client failed to compile:

![image](https://user-images.githubusercontent.com/1178570/123658378-9598a600-d829-11eb-85af-9fe6870b5ee3.png)

So I had a go at adding a version of ```query``` that handles ```DateTimeOffset``` to get it building.

I *think* that ```"O"``` is the correct format string to use here, but that needs confirming.