### PR TITLE
Use EscapeDataString to escape individual query string parameters

### DIFF
--- a/src/HttpLibrary.fs
+++ b/src/HttpLibrary.fs
@@ -122,7 +122,7 @@ module OpenApiHttp =
         else
             let combinedParamters =
                 queryParams
-                |> List.map (fun (key, value) -> $"{key}={Uri.EscapeUriString(serializeValue value)}")
+                |> List.map (fun (key, value) -> $"{key}={Uri.EscapeDataString(serializeValue value)}")
                 |> String.concat "&"
 
             cleanedPath + "?" + combinedParamters


### PR DESCRIPTION
When I was playing with #7 I got some runtime errors about the date-time strings being malformed, which I think might be because it needs to use ```EscapeDataString``` to escape individual query parameter values, rather than ```EscapeUriString```? (otherwise it looks like things like ':' don't get escaped properly)