### PR TITLE
Add 403 to the list of known status codes

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -478,6 +478,7 @@ let statusCode = function
     | "404" -> Some (nameof HttpStatusCode.NotFound)
     | "400" -> Some (nameof HttpStatusCode.BadRequest)
     | "401" -> Some (nameof HttpStatusCode.Unauthorized)
+    | "403" -> Some (nameof HttpStatusCode.Forbidden)
     | "405" -> Some (nameof HttpStatusCode.MethodNotAllowed)
     | "500" -> Some (nameof HttpStatusCode.InternalServerError)
     | "default" -> Some "DefaultResponse"


### PR DESCRIPTION
Hi,

An observation I had while looking at the code generated by the 0.9 release:

I have a schema that has various instances of ```403``` response codes for functions, e.g.

```yaml
"403": {
     "description": "User is not authorized to delete agents.",
     "content": {
         "application/json": {
             "schema": {
                 "$ref": "#/components/schemas/ProblemDetails"
             }
         }
    }
}
```

and those weren't being included in the Hawaii generated response types.
Adding ```403``` here seems to fix that, so any objections to doing that?

Thanks.
