### PR TITLE
Use asyncBuilder instead of async in sendBinaryAsync

### DIFF
--- a/src/HttpLibrary.fs
+++ b/src/HttpLibrary.fs
@@ -285,7 +285,7 @@ module OpenApiHttp =
             |> applyMultiPartFormData parts
             |> applyHeaders parts
 
-        async {
+        {asyncBuilder} {
             let! response = {getResponse}
             let! content = {getBinaryContent}
             return (response.StatusCode, content)


### PR DESCRIPTION
I tried to build a client lib with ```asyncReturnType``` set to ```task``` and got a build failure - I think that's because sendBinaryAsync should be using ```{asyncBuilder}``` instead of hard coding ```async``` ?