### PR TITLE
Add support for unlimited number of response status codes

### DIFF
--- a/build/Program.fs
+++ b/build/Program.fs
@@ -477,6 +477,42 @@ let integrationKnownSchemas() =
         emptyDefinitions = "ignore"
     }
 
+    let defaultUnlimitedResponses = {
+        schemaUrl = "./schemas/UnlimitedResponses.json"
+        title = "DefaultUnlimitedResponses"
+        synchronous = false
+        asyncReturnType = "async"
+        target = "fsharp"
+        emptyDefinitions = "ignore"
+    }
+
+    let syncUnlimitedResponses = {
+        schemaUrl = "./schemas/UnlimitedResponses.json"
+        title = "SyncUnlimitedResponses"
+        synchronous = true
+        asyncReturnType = "async"
+        target = "fsharp"
+        emptyDefinitions = "ignore"
+    }
+
+    let taskUnlimitedResponses = {
+        schemaUrl = "./schemas/UnlimitedResponses.json"
+        title = "TaskUnlimitedResponses"
+        synchronous = false
+        asyncReturnType = "task"
+        target = "fsharp"
+        emptyDefinitions = "ignore"
+    }
+
+    let fableUnlimitedResponses = {
+        schemaUrl = "./schemas/UnlimitedResponses.json"
+        title = "FableUnlimitedResponses"
+        synchronous = false
+        asyncReturnType = "async"
+        target = "fable"
+        emptyDefinitions = "ignore"
+    }
+
     let schemas = [
         defaultPetStore
         synchronousPetStore
@@ -512,6 +548,10 @@ let integrationKnownSchemas() =
         defaultSlicebox
         taskSlicebox
         fableSlicebox
+        defaultUnlimitedResponses
+        taskUnlimitedResponses
+        syncUnlimitedResponses
+        fableUnlimitedResponses
     ]
 
     for (index, schema) in List.indexed schemas do 

--- a/examples/DefaultPetStore/Client.fs
+++ b/examples/DefaultPetStore/Client.fs
@@ -23,10 +23,10 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/pet" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdatePet.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return UpdatePet.BadRequest
-            | HttpStatusCode.NotFound -> return UpdatePet.NotFound
+            match int status with
+            | 200 -> return UpdatePet.OK(Serializer.deserialize content)
+            | 400 -> return UpdatePet.BadRequest
+            | 404 -> return UpdatePet.NotFound
             | _ -> return UpdatePet.MethodNotAllowed
         }
 
@@ -38,8 +38,8 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return AddPet.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return AddPet.OK(Serializer.deserialize content)
             | _ -> return AddPet.MethodNotAllowed
         }
 
@@ -56,8 +56,8 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByStatus" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FindPetsByStatus.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FindPetsByStatus.OK(Serializer.deserialize content)
             | _ -> return FindPetsByStatus.BadRequest
         }
 
@@ -74,8 +74,8 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByTags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FindPetsByTags.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FindPetsByTags.OK(Serializer.deserialize content)
             | _ -> return FindPetsByTags.BadRequest
         }
 
@@ -89,9 +89,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("petId", petId) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetPetById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetPetById.BadRequest
+            match int status with
+            | 200 -> return GetPetById.OK(Serializer.deserialize content)
+            | 400 -> return GetPetById.BadRequest
             | _ -> return GetPetById.NotFound
         }
 
@@ -113,8 +113,8 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.MethodNotAllowed -> return UpdatePetWithForm.MethodNotAllowed
+            match int status with
+            | 405 -> return UpdatePetWithForm.MethodNotAllowed
             | _ -> return UpdatePetWithForm.DefaultResponse
         }
 
@@ -133,8 +133,8 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.BadRequest -> return DeletePet.BadRequest
+            match int status with
+            | 400 -> return DeletePet.BadRequest
             | _ -> return DeletePet.DefaultResponse
         }
 
@@ -184,8 +184,8 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/store/order" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PlaceOrder.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PlaceOrder.OK(Serializer.deserialize content)
             | _ -> return PlaceOrder.MethodNotAllowed
         }
 
@@ -202,9 +202,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetOrderById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetOrderById.BadRequest
+            match int status with
+            | 200 -> return GetOrderById.OK(Serializer.deserialize content)
+            | 400 -> return GetOrderById.BadRequest
             | _ -> return GetOrderById.NotFound
         }
 
@@ -221,9 +221,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.BadRequest -> return DeleteOrder.BadRequest
-            | HttpStatusCode.NotFound -> return DeleteOrder.NotFound
+            match int status with
+            | 400 -> return DeleteOrder.BadRequest
+            | 404 -> return DeleteOrder.NotFound
             | _ -> return DeleteOrder.DefaultResponse
         }
 
@@ -247,8 +247,8 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/user/createWithList" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
             | _ -> return CreateUsersWithListInput.DefaultResponse
         }
 
@@ -268,8 +268,8 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/login" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return LoginUser.OK content
+            match int status with
+            | 200 -> return LoginUser.OK content
             | _ -> return LoginUser.BadRequest
         }
 
@@ -295,9 +295,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUserByName.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetUserByName.BadRequest
+            match int status with
+            | 200 -> return GetUserByName.OK(Serializer.deserialize content)
+            | 400 -> return GetUserByName.BadRequest
             | _ -> return GetUserByName.NotFound
         }
 
@@ -330,8 +330,8 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.BadRequest -> return DeleteUser.BadRequest
-            | HttpStatusCode.NotFound -> return DeleteUser.NotFound
+            match int status with
+            | 400 -> return DeleteUser.BadRequest
+            | 404 -> return DeleteUser.NotFound
             | _ -> return DeleteUser.DefaultResponse
         }

--- a/examples/DefaultPetStore/Client.fs
+++ b/examples/DefaultPetStore/Client.fs
@@ -23,14 +23,11 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/pet" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdatePet.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return UpdatePet.BadRequest
-            else if status = HttpStatusCode.NotFound then
-                return UpdatePet.NotFound
-            else
-                return UpdatePet.MethodNotAllowed
+            match status with
+            | HttpStatusCode.OK -> return UpdatePet.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return UpdatePet.BadRequest
+            | HttpStatusCode.NotFound -> return UpdatePet.NotFound
+            | _ -> return UpdatePet.MethodNotAllowed
         }
 
     ///<summary>
@@ -41,10 +38,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return AddPet.OK(Serializer.deserialize content)
-            else
-                return AddPet.MethodNotAllowed
+            match status with
+            | HttpStatusCode.OK -> return AddPet.OK(Serializer.deserialize content)
+            | _ -> return AddPet.MethodNotAllowed
         }
 
     ///<summary>
@@ -60,10 +56,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByStatus" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FindPetsByStatus.OK(Serializer.deserialize content)
-            else
-                return FindPetsByStatus.BadRequest
+            match status with
+            | HttpStatusCode.OK -> return FindPetsByStatus.OK(Serializer.deserialize content)
+            | _ -> return FindPetsByStatus.BadRequest
         }
 
     ///<summary>
@@ -79,10 +74,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByTags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FindPetsByTags.OK(Serializer.deserialize content)
-            else
-                return FindPetsByTags.BadRequest
+            match status with
+            | HttpStatusCode.OK -> return FindPetsByTags.OK(Serializer.deserialize content)
+            | _ -> return FindPetsByTags.BadRequest
         }
 
     ///<summary>
@@ -95,12 +89,10 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("petId", petId) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetPetById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetPetById.BadRequest
-            else
-                return GetPetById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetPetById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetPetById.BadRequest
+            | _ -> return GetPetById.NotFound
         }
 
     ///<summary>
@@ -121,10 +113,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.MethodNotAllowed then
-                return UpdatePetWithForm.MethodNotAllowed
-            else
-                return UpdatePetWithForm.DefaultResponse
+            match status with
+            | HttpStatusCode.MethodNotAllowed -> return UpdatePetWithForm.MethodNotAllowed
+            | _ -> return UpdatePetWithForm.DefaultResponse
         }
 
     ///<summary>
@@ -142,10 +133,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.BadRequest then
-                return DeletePet.BadRequest
-            else
-                return DeletePet.DefaultResponse
+            match status with
+            | HttpStatusCode.BadRequest -> return DeletePet.BadRequest
+            | _ -> return DeletePet.DefaultResponse
         }
 
     ///<summary>
@@ -194,10 +184,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/store/order" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PlaceOrder.OK(Serializer.deserialize content)
-            else
-                return PlaceOrder.MethodNotAllowed
+            match status with
+            | HttpStatusCode.OK -> return PlaceOrder.OK(Serializer.deserialize content)
+            | _ -> return PlaceOrder.MethodNotAllowed
         }
 
     ///<summary>
@@ -213,12 +202,10 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetOrderById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetOrderById.BadRequest
-            else
-                return GetOrderById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetOrderById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetOrderById.BadRequest
+            | _ -> return GetOrderById.NotFound
         }
 
     ///<summary>
@@ -234,12 +221,10 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.BadRequest then
-                return DeleteOrder.BadRequest
-            else if status = HttpStatusCode.NotFound then
-                return DeleteOrder.NotFound
-            else
-                return DeleteOrder.DefaultResponse
+            match status with
+            | HttpStatusCode.BadRequest -> return DeleteOrder.BadRequest
+            | HttpStatusCode.NotFound -> return DeleteOrder.NotFound
+            | _ -> return DeleteOrder.DefaultResponse
         }
 
     ///<summary>
@@ -262,10 +247,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/user/createWithList" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateUsersWithListInput.OK(Serializer.deserialize content)
-            else
-                return CreateUsersWithListInput.DefaultResponse
+            match status with
+            | HttpStatusCode.OK -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
+            | _ -> return CreateUsersWithListInput.DefaultResponse
         }
 
     ///<summary>
@@ -284,10 +268,9 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/login" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return LoginUser.OK content
-            else
-                return LoginUser.BadRequest
+            match status with
+            | HttpStatusCode.OK -> return LoginUser.OK content
+            | _ -> return LoginUser.BadRequest
         }
 
     ///<summary>
@@ -312,12 +295,10 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUserByName.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetUserByName.BadRequest
-            else
-                return GetUserByName.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetUserByName.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetUserByName.BadRequest
+            | _ -> return GetUserByName.NotFound
         }
 
     ///<summary>
@@ -349,10 +330,8 @@ type DefaultPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            if status = HttpStatusCode.BadRequest then
-                return DeleteUser.BadRequest
-            else if status = HttpStatusCode.NotFound then
-                return DeleteUser.NotFound
-            else
-                return DeleteUser.DefaultResponse
+            match status with
+            | HttpStatusCode.BadRequest -> return DeleteUser.BadRequest
+            | HttpStatusCode.NotFound -> return DeleteUser.NotFound
+            | _ -> return DeleteUser.DefaultResponse
         }

--- a/examples/FableGhibli/Client.fs
+++ b/examples/FableGhibli/Client.fs
@@ -103,7 +103,7 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/films" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetFilms.OK(Serializer.deserialize content)
             | 400 -> return GetFilms.BadRequest
             | _ -> return GetFilms.NotFound
@@ -123,7 +123,7 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/films/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetFilmsById.OK(Serializer.deserialize content)
             | 400 -> return GetFilmsById.BadRequest
             | _ -> return GetFilmsById.NotFound
@@ -144,7 +144,7 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/people" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetPeople.OK(Serializer.deserialize content)
             | 400 -> return GetPeople.BadRequest
             | _ -> return GetPeople.NotFound
@@ -164,7 +164,7 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/people/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetPeopleById.OK(Serializer.deserialize content)
             | 400 -> return GetPeopleById.BadRequest
             | _ -> return GetPeopleById.NotFound
@@ -185,7 +185,7 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/locations" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetLocations.OK(Serializer.deserialize content)
             | 400 -> return GetLocations.BadRequest
             | _ -> return GetLocations.NotFound
@@ -205,7 +205,7 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/locations/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetLocationsById.OK(Serializer.deserialize content)
             | 400 -> return GetLocationsById.BadRequest
             | _ -> return GetLocationsById.NotFound
@@ -226,7 +226,7 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/species" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSpecies.OK(Serializer.deserialize content)
             | 400 -> return GetSpecies.BadRequest
             | _ -> return GetSpecies.NotFound
@@ -246,7 +246,7 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/species/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSpeciesById.OK(Serializer.deserialize content)
             | 400 -> return GetSpeciesById.BadRequest
             | _ -> return GetSpeciesById.NotFound
@@ -267,7 +267,7 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/vehicles" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetVehicles.OK(Serializer.deserialize content)
             | 400 -> return GetVehicles.BadRequest
             | _ -> return GetVehicles.NotFound
@@ -287,7 +287,7 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/vehicles/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetVehiclesById.OK(Serializer.deserialize content)
             | 400 -> return GetVehiclesById.BadRequest
             | _ -> return GetVehiclesById.NotFound

--- a/examples/FableGhibli/Client.fs
+++ b/examples/FableGhibli/Client.fs
@@ -103,12 +103,10 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/films" headers requestParts
 
-            if status = 200 then
-                return GetFilms.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetFilms.BadRequest
-            else
-                return GetFilms.NotFound
+            match status with
+            | 200 -> return GetFilms.OK(Serializer.deserialize content)
+            | 400 -> return GetFilms.BadRequest
+            | _ -> return GetFilms.NotFound
         }
 
     ///<summary>
@@ -125,12 +123,10 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/films/{id}" headers requestParts
 
-            if status = 200 then
-                return GetFilmsById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetFilmsById.BadRequest
-            else
-                return GetFilmsById.NotFound
+            match status with
+            | 200 -> return GetFilmsById.OK(Serializer.deserialize content)
+            | 400 -> return GetFilmsById.BadRequest
+            | _ -> return GetFilmsById.NotFound
         }
 
     ///<summary>
@@ -148,12 +144,10 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/people" headers requestParts
 
-            if status = 200 then
-                return GetPeople.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetPeople.BadRequest
-            else
-                return GetPeople.NotFound
+            match status with
+            | 200 -> return GetPeople.OK(Serializer.deserialize content)
+            | 400 -> return GetPeople.BadRequest
+            | _ -> return GetPeople.NotFound
         }
 
     ///<summary>
@@ -170,12 +164,10 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/people/{id}" headers requestParts
 
-            if status = 200 then
-                return GetPeopleById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetPeopleById.BadRequest
-            else
-                return GetPeopleById.NotFound
+            match status with
+            | 200 -> return GetPeopleById.OK(Serializer.deserialize content)
+            | 400 -> return GetPeopleById.BadRequest
+            | _ -> return GetPeopleById.NotFound
         }
 
     ///<summary>
@@ -193,12 +185,10 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/locations" headers requestParts
 
-            if status = 200 then
-                return GetLocations.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetLocations.BadRequest
-            else
-                return GetLocations.NotFound
+            match status with
+            | 200 -> return GetLocations.OK(Serializer.deserialize content)
+            | 400 -> return GetLocations.BadRequest
+            | _ -> return GetLocations.NotFound
         }
 
     ///<summary>
@@ -215,12 +205,10 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/locations/{id}" headers requestParts
 
-            if status = 200 then
-                return GetLocationsById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetLocationsById.BadRequest
-            else
-                return GetLocationsById.NotFound
+            match status with
+            | 200 -> return GetLocationsById.OK(Serializer.deserialize content)
+            | 400 -> return GetLocationsById.BadRequest
+            | _ -> return GetLocationsById.NotFound
         }
 
     ///<summary>
@@ -238,12 +226,10 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/species" headers requestParts
 
-            if status = 200 then
-                return GetSpecies.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetSpecies.BadRequest
-            else
-                return GetSpecies.NotFound
+            match status with
+            | 200 -> return GetSpecies.OK(Serializer.deserialize content)
+            | 400 -> return GetSpecies.BadRequest
+            | _ -> return GetSpecies.NotFound
         }
 
     ///<summary>
@@ -260,12 +246,10 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/species/{id}" headers requestParts
 
-            if status = 200 then
-                return GetSpeciesById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetSpeciesById.BadRequest
-            else
-                return GetSpeciesById.NotFound
+            match status with
+            | 200 -> return GetSpeciesById.OK(Serializer.deserialize content)
+            | 400 -> return GetSpeciesById.BadRequest
+            | _ -> return GetSpeciesById.NotFound
         }
 
     ///<summary>
@@ -283,12 +267,10 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/vehicles" headers requestParts
 
-            if status = 200 then
-                return GetVehicles.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetVehicles.BadRequest
-            else
-                return GetVehicles.NotFound
+            match status with
+            | 200 -> return GetVehicles.OK(Serializer.deserialize content)
+            | 400 -> return GetVehicles.BadRequest
+            | _ -> return GetVehicles.NotFound
         }
 
     ///<summary>
@@ -305,10 +287,8 @@ type FableGhibliClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/vehicles/{id}" headers requestParts
 
-            if status = 200 then
-                return GetVehiclesById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetVehiclesById.BadRequest
-            else
-                return GetVehiclesById.NotFound
+            match status with
+            | 200 -> return GetVehiclesById.OK(Serializer.deserialize content)
+            | 400 -> return GetVehiclesById.BadRequest
+            | _ -> return GetVehiclesById.NotFound
         }

--- a/examples/FableNSwag/Client.fs
+++ b/examples/FableNSwag/Client.fs
@@ -28,7 +28,7 @@ type FableNSwagClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/api/Brandings/upload" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UploadBrandingImage.OK
             | 400 -> return UploadBrandingImage.BadRequest(Serializer.deserialize content)
             | _ -> return UploadBrandingImage.Unauthorized(Serializer.deserialize content)
@@ -56,7 +56,7 @@ type FableNSwagClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/api/Datahub/datasources" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetDataSources.OK(Serializer.deserialize content)
             | _ -> return GetDataSources.Unauthorized content
         }
@@ -87,7 +87,7 @@ type FableNSwagClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/api/Datahub/import" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return ImportData.OK(Serializer.deserialize content)
             | _ -> return ImportData.Unauthorized content
         }
@@ -101,7 +101,7 @@ type FableNSwagClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/api/Documents/upload" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UploadFile.OK(Serializer.deserialize content)
             | 400 -> return UploadFile.BadRequest(Serializer.deserialize content)
             | _ -> return UploadFile.Unauthorized(Serializer.deserialize content)
@@ -117,7 +117,7 @@ type FableNSwagClient(url: string, headers: list<Header>) =
             let! (status, contentBinary) =
                 OpenApiHttp.postBinaryAsync url "/api/Documents/download" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DownloadFile.OK contentBinary
             | 400 ->
                 let! content = Utilities.readBytesAsText contentBinary

--- a/examples/FableNSwag/Client.fs
+++ b/examples/FableNSwag/Client.fs
@@ -28,12 +28,10 @@ type FableNSwagClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/api/Brandings/upload" headers requestParts
 
-            if status = 200 then
-                return UploadBrandingImage.OK
-            else if status = 400 then
-                return UploadBrandingImage.BadRequest(Serializer.deserialize content)
-            else
-                return UploadBrandingImage.Unauthorized(Serializer.deserialize content)
+            match status with
+            | 200 -> return UploadBrandingImage.OK
+            | 400 -> return UploadBrandingImage.BadRequest(Serializer.deserialize content)
+            | _ -> return UploadBrandingImage.Unauthorized(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -58,10 +56,9 @@ type FableNSwagClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/api/Datahub/datasources" headers requestParts
 
-            if status = 200 then
-                return GetDataSources.OK(Serializer.deserialize content)
-            else
-                return GetDataSources.Unauthorized content
+            match status with
+            | 200 -> return GetDataSources.OK(Serializer.deserialize content)
+            | _ -> return GetDataSources.Unauthorized content
         }
 
     ///<summary>
@@ -90,10 +87,9 @@ type FableNSwagClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/api/Datahub/import" headers requestParts
 
-            if status = 200 then
-                return ImportData.OK(Serializer.deserialize content)
-            else
-                return ImportData.Unauthorized content
+            match status with
+            | 200 -> return ImportData.OK(Serializer.deserialize content)
+            | _ -> return ImportData.Unauthorized content
         }
 
     member this.UploadFile(nodeId: int, ?path: string) =
@@ -105,12 +101,10 @@ type FableNSwagClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/api/Documents/upload" headers requestParts
 
-            if status = 200 then
-                return UploadFile.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return UploadFile.BadRequest(Serializer.deserialize content)
-            else
-                return UploadFile.Unauthorized(Serializer.deserialize content)
+            match status with
+            | 200 -> return UploadFile.OK(Serializer.deserialize content)
+            | 400 -> return UploadFile.BadRequest(Serializer.deserialize content)
+            | _ -> return UploadFile.Unauthorized(Serializer.deserialize content)
         }
 
     member this.DownloadFile(nodeId: int, ?path: string) =
@@ -123,12 +117,12 @@ type FableNSwagClient(url: string, headers: list<Header>) =
             let! (status, contentBinary) =
                 OpenApiHttp.postBinaryAsync url "/api/Documents/download" headers requestParts
 
-            if status = 200 then
-                return DownloadFile.OK contentBinary
-            else if status = 400 then
+            match status with
+            | 200 -> return DownloadFile.OK contentBinary
+            | 400 ->
                 let! content = Utilities.readBytesAsText contentBinary
                 return DownloadFile.BadRequest(Serializer.deserialize content)
-            else
+            | _ ->
                 let! content = Utilities.readBytesAsText contentBinary
                 return DownloadFile.Unauthorized(Serializer.deserialize content)
         }

--- a/examples/FablePetStore/Client.fs
+++ b/examples/FablePetStore/Client.fs
@@ -23,7 +23,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync url "/pet" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpdatePet.OK(Serializer.deserialize content)
             | 400 -> return UpdatePet.BadRequest
             | 404 -> return UpdatePet.NotFound
@@ -38,7 +38,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/pet" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return AddPet.OK(Serializer.deserialize content)
             | _ -> return AddPet.MethodNotAllowed
         }
@@ -55,7 +55,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/pet/findByStatus" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FindPetsByStatus.OK(Serializer.deserialize content)
             | _ -> return FindPetsByStatus.BadRequest
         }
@@ -72,7 +72,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/pet/findByTags" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FindPetsByTags.OK(Serializer.deserialize content)
             | _ -> return FindPetsByTags.BadRequest
         }
@@ -86,7 +86,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("petId", petId) ]
             let! (status, content) = OpenApiHttp.getAsync url "/pet/{petId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetPetById.OK(Serializer.deserialize content)
             | 400 -> return GetPetById.BadRequest
             | _ -> return GetPetById.NotFound
@@ -109,7 +109,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/pet/{petId}" headers requestParts
 
-            match status with
+            match int status with
             | 405 -> return UpdatePetWithForm.MethodNotAllowed
             | _ -> return UpdatePetWithForm.DefaultResponse
         }
@@ -128,7 +128,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/pet/{petId}" headers requestParts
 
-            match status with
+            match int status with
             | 400 -> return DeletePet.BadRequest
             | _ -> return DeletePet.DefaultResponse
         }
@@ -170,7 +170,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/store/order" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PlaceOrder.OK(Serializer.deserialize content)
             | _ -> return PlaceOrder.MethodNotAllowed
         }
@@ -186,7 +186,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/store/order/{orderId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetOrderById.OK(Serializer.deserialize content)
             | 400 -> return GetOrderById.BadRequest
             | _ -> return GetOrderById.NotFound
@@ -203,7 +203,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/store/order/{orderId}" headers requestParts
 
-            match status with
+            match int status with
             | 400 -> return DeleteOrder.BadRequest
             | 404 -> return DeleteOrder.NotFound
             | _ -> return DeleteOrder.DefaultResponse
@@ -227,7 +227,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/user/createWithList" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
             | _ -> return CreateUsersWithListInput.DefaultResponse
         }
@@ -247,7 +247,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/user/login" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return LoginUser.OK content
             | _ -> return LoginUser.BadRequest
         }
@@ -273,7 +273,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/user/{username}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetUserByName.OK(Serializer.deserialize content)
             | 400 -> return GetUserByName.BadRequest
             | _ -> return GetUserByName.NotFound
@@ -305,7 +305,7 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/user/{username}" headers requestParts
 
-            match status with
+            match int status with
             | 400 -> return DeleteUser.BadRequest
             | 404 -> return DeleteUser.NotFound
             | _ -> return DeleteUser.DefaultResponse

--- a/examples/FablePetStore/Client.fs
+++ b/examples/FablePetStore/Client.fs
@@ -23,14 +23,11 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync url "/pet" headers requestParts
 
-            if status = 200 then
-                return UpdatePet.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return UpdatePet.BadRequest
-            else if status = 404 then
-                return UpdatePet.NotFound
-            else
-                return UpdatePet.MethodNotAllowed
+            match status with
+            | 200 -> return UpdatePet.OK(Serializer.deserialize content)
+            | 400 -> return UpdatePet.BadRequest
+            | 404 -> return UpdatePet.NotFound
+            | _ -> return UpdatePet.MethodNotAllowed
         }
 
     ///<summary>
@@ -41,10 +38,9 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/pet" headers requestParts
 
-            if status = 200 then
-                return AddPet.OK(Serializer.deserialize content)
-            else
-                return AddPet.MethodNotAllowed
+            match status with
+            | 200 -> return AddPet.OK(Serializer.deserialize content)
+            | _ -> return AddPet.MethodNotAllowed
         }
 
     ///<summary>
@@ -59,10 +55,9 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/pet/findByStatus" headers requestParts
 
-            if status = 200 then
-                return FindPetsByStatus.OK(Serializer.deserialize content)
-            else
-                return FindPetsByStatus.BadRequest
+            match status with
+            | 200 -> return FindPetsByStatus.OK(Serializer.deserialize content)
+            | _ -> return FindPetsByStatus.BadRequest
         }
 
     ///<summary>
@@ -77,10 +72,9 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/pet/findByTags" headers requestParts
 
-            if status = 200 then
-                return FindPetsByTags.OK(Serializer.deserialize content)
-            else
-                return FindPetsByTags.BadRequest
+            match status with
+            | 200 -> return FindPetsByTags.OK(Serializer.deserialize content)
+            | _ -> return FindPetsByTags.BadRequest
         }
 
     ///<summary>
@@ -92,12 +86,10 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("petId", petId) ]
             let! (status, content) = OpenApiHttp.getAsync url "/pet/{petId}" headers requestParts
 
-            if status = 200 then
-                return GetPetById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetPetById.BadRequest
-            else
-                return GetPetById.NotFound
+            match status with
+            | 200 -> return GetPetById.OK(Serializer.deserialize content)
+            | 400 -> return GetPetById.BadRequest
+            | _ -> return GetPetById.NotFound
         }
 
     ///<summary>
@@ -117,10 +109,9 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/pet/{petId}" headers requestParts
 
-            if status = 405 then
-                return UpdatePetWithForm.MethodNotAllowed
-            else
-                return UpdatePetWithForm.DefaultResponse
+            match status with
+            | 405 -> return UpdatePetWithForm.MethodNotAllowed
+            | _ -> return UpdatePetWithForm.DefaultResponse
         }
 
     ///<summary>
@@ -137,10 +128,9 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/pet/{petId}" headers requestParts
 
-            if status = 400 then
-                return DeletePet.BadRequest
-            else
-                return DeletePet.DefaultResponse
+            match status with
+            | 400 -> return DeletePet.BadRequest
+            | _ -> return DeletePet.DefaultResponse
         }
 
     ///<summary>
@@ -180,10 +170,9 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/store/order" headers requestParts
 
-            if status = 200 then
-                return PlaceOrder.OK(Serializer.deserialize content)
-            else
-                return PlaceOrder.MethodNotAllowed
+            match status with
+            | 200 -> return PlaceOrder.OK(Serializer.deserialize content)
+            | _ -> return PlaceOrder.MethodNotAllowed
         }
 
     ///<summary>
@@ -197,12 +186,10 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/store/order/{orderId}" headers requestParts
 
-            if status = 200 then
-                return GetOrderById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetOrderById.BadRequest
-            else
-                return GetOrderById.NotFound
+            match status with
+            | 200 -> return GetOrderById.OK(Serializer.deserialize content)
+            | 400 -> return GetOrderById.BadRequest
+            | _ -> return GetOrderById.NotFound
         }
 
     ///<summary>
@@ -216,12 +203,10 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/store/order/{orderId}" headers requestParts
 
-            if status = 400 then
-                return DeleteOrder.BadRequest
-            else if status = 404 then
-                return DeleteOrder.NotFound
-            else
-                return DeleteOrder.DefaultResponse
+            match status with
+            | 400 -> return DeleteOrder.BadRequest
+            | 404 -> return DeleteOrder.NotFound
+            | _ -> return DeleteOrder.DefaultResponse
         }
 
     ///<summary>
@@ -242,10 +227,9 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/user/createWithList" headers requestParts
 
-            if status = 200 then
-                return CreateUsersWithListInput.OK(Serializer.deserialize content)
-            else
-                return CreateUsersWithListInput.DefaultResponse
+            match status with
+            | 200 -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
+            | _ -> return CreateUsersWithListInput.DefaultResponse
         }
 
     ///<summary>
@@ -263,10 +247,9 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/user/login" headers requestParts
 
-            if status = 200 then
-                return LoginUser.OK content
-            else
-                return LoginUser.BadRequest
+            match status with
+            | 200 -> return LoginUser.OK content
+            | _ -> return LoginUser.BadRequest
         }
 
     ///<summary>
@@ -290,12 +273,10 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/user/{username}" headers requestParts
 
-            if status = 200 then
-                return GetUserByName.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetUserByName.BadRequest
-            else
-                return GetUserByName.NotFound
+            match status with
+            | 200 -> return GetUserByName.OK(Serializer.deserialize content)
+            | 400 -> return GetUserByName.BadRequest
+            | _ -> return GetUserByName.NotFound
         }
 
     ///<summary>
@@ -324,10 +305,8 @@ type FablePetStoreClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/user/{username}" headers requestParts
 
-            if status = 400 then
-                return DeleteUser.BadRequest
-            else if status = 404 then
-                return DeleteUser.NotFound
-            else
-                return DeleteUser.DefaultResponse
+            match status with
+            | 400 -> return DeleteUser.BadRequest
+            | 404 -> return DeleteUser.NotFound
+            | _ -> return DeleteUser.DefaultResponse
         }

--- a/examples/FablePodiosuite/Client.fs
+++ b/examples/FablePodiosuite/Client.fs
@@ -16,7 +16,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/auth/token" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAuthToken.OK(Serializer.deserialize content)
             | 400 -> return PostAuthToken.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAuthToken.Unauthorized(Serializer.deserialize content)
@@ -31,7 +31,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/auth/recover-password" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAuthRecoverPassword.OK(Serializer.deserialize content)
             | 400 -> return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
@@ -51,7 +51,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/auth/reset/{mailtoken}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
             | 400 -> return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
@@ -69,7 +69,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/auth/revoke-token" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAuthRevokeToken.OK(Serializer.deserialize content)
             | 400 -> return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
@@ -87,7 +87,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/auth/change-password" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAuthChangePassword.OK(Serializer.deserialize content)
             | 400 -> return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
@@ -105,7 +105,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/users" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostUsers.OK(Serializer.deserialize content)
             | 400 -> return PostUsers.BadRequest(Serializer.deserialize content)
             | 401 -> return PostUsers.Unauthorized(Serializer.deserialize content)
@@ -173,7 +173,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/users" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetUsers.OK(Serializer.deserialize content)
             | 400 -> return GetUsers.BadRequest(Serializer.deserialize content)
             | 401 -> return GetUsers.Unauthorized(Serializer.deserialize content)
@@ -244,7 +244,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/usersbulk" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostUsersbulk.OK(Serializer.deserialize content)
             | 400 -> return PostUsersbulk.BadRequest(Serializer.deserialize content)
             | 401 -> return PostUsersbulk.Unauthorized(Serializer.deserialize content)
@@ -264,7 +264,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/users/me" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetUsersMe.OK(Serializer.deserialize content)
             | 400 -> return GetUsersMe.BadRequest(Serializer.deserialize content)
             | 401 -> return GetUsersMe.Unauthorized(Serializer.deserialize content)
@@ -281,7 +281,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/users/me/accept-tc" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return PostUsersMeAcceptTc.Created
             | 400 -> return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
             | 401 -> return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
@@ -303,7 +303,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/users/{userId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetUsersByUserId.OK(Serializer.deserialize content)
             | 400 -> return GetUsersByUserId.BadRequest(Serializer.deserialize content)
             | 401 -> return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
@@ -325,7 +325,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/users/{userId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutUsersByUserId.OK(Serializer.deserialize content)
             | 400 -> return PutUsersByUserId.BadRequest(Serializer.deserialize content)
             | 401 -> return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
@@ -347,7 +347,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/users/{userId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteUsersByUserId.OK(Serializer.deserialize content)
             | 400 -> return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
             | 401 -> return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
@@ -367,7 +367,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/users/{userId}/change-password" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
             | 400 -> return PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
             | 401 -> return PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
@@ -391,7 +391,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/users/{userId}/favorites" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
             | 400 -> return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
             | 401 -> return PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
@@ -415,7 +415,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/users/{userId}/customization" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
             | 400 -> return PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
             | 401 -> return PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
@@ -433,7 +433,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/users/{userId}/permissions" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
             | 400 -> return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
             | 401 -> return PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
@@ -448,7 +448,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/accounts/notifications" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAccountsNotifications.OK(Serializer.deserialize content)
             | 400 -> return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
@@ -465,7 +465,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.putAsync url "/accounts/notifications/{notificationId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAccountsNotificationsByNotificationId.OK
             | 400 -> return PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
@@ -482,7 +482,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync url "/accounts/notifications/{notificationId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
             | 400 -> return DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
             | 401 -> return DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
@@ -498,7 +498,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/accounts" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAccounts.OK(Serializer.deserialize content)
             | 400 -> return GetAccounts.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAccounts.Unauthorized(Serializer.deserialize content)
@@ -513,7 +513,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent account ]
             let! (status, content) = OpenApiHttp.postAsync url "/accounts" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAccounts.OK(Serializer.deserialize content)
             | 400 -> return PostAccounts.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAccounts.Unauthorized(Serializer.deserialize content)
@@ -528,7 +528,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync url "/accountsbulk" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAccountsbulk.OK(Serializer.deserialize content)
             | 400 -> return PostAccountsbulk.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
@@ -543,7 +543,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/accounts/{accountId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAccountsByAccountId.OK(Serializer.deserialize content)
             | 400 -> return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
@@ -558,7 +558,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent account ]
             let! (status, content) = OpenApiHttp.putAsync url "/accounts/{accountId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAccountsByAccountId.OK(Serializer.deserialize content)
             | 400 -> return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
@@ -573,7 +573,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/accounts/{accountId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
             | 400 -> return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
             | 401 -> return DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
@@ -588,7 +588,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent account ]
             let! (status, content) = OpenApiHttp.putAsync url "/accounts/{accountId}/branding" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
             | 400 -> return PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
@@ -605,7 +605,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/accounts/{accountId}/branding/verify" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
             | 400 -> return GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
@@ -620,7 +620,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/accounts/{accountId}/roles" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
             | 400 -> return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
@@ -637,7 +637,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/accounts/{accountId}/roles/{rolename}/actions" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
             | 400 -> return GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
@@ -653,7 +653,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/accounts/{accountId}/notifications" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
             | 400 -> return GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
@@ -670,7 +670,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.putAsync url "/accounts/{accountId}/notifications/{notificationId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAccountsNotificationsByAccountIdAndNotificationId.OK
             | 400 ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
@@ -693,7 +693,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync url "/accounts/{accountId}/notifications/{notificationId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
             | 400 ->
                 return
@@ -719,7 +719,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/accounts/{accountId}/products" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
             | 400 -> return GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
@@ -736,7 +736,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/accounts/products/alerts" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAccountsProductsAlerts.OK
             | 400 -> return PutAccountsProductsAlerts.BadRequest
             | 401 -> return PutAccountsProductsAlerts.Unauthorized
@@ -751,7 +751,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/accounts/{accountId}/topup-direct" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
             | 400 -> return PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
@@ -825,7 +825,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/accounts/{accountId}/security-settings/available-gaps" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
             | 400 ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.BadRequest(Serializer.deserialize content)
@@ -856,7 +856,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/accounts/{accountId}/security-settings/available-ips" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
             | 400 ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.BadRequest(Serializer.deserialize content)
@@ -890,7 +890,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/mail" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostMail.OK(Serializer.deserialize content)
             | 400 -> return PostMail.BadRequest(Serializer.deserialize content)
             | 401 -> return PostMail.Unauthorized(Serializer.deserialize content)
@@ -1060,7 +1060,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/products" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetProducts.OK(Serializer.deserialize content)
             | 400 -> return GetProducts.BadRequest
             | 401 -> return GetProducts.Unauthorized
@@ -1080,7 +1080,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/products" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostProducts.OK(Serializer.deserialize content)
             | 400 -> return PostProducts.BadRequest(Serializer.deserialize content)
             | 401 -> return PostProducts.Unauthorized(Serializer.deserialize content)
@@ -1097,7 +1097,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/products/{productId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetProductsByProductId.OK(Serializer.deserialize content)
             | 400 -> return GetProductsByProductId.BadRequest
             | 401 -> return GetProductsByProductId.Unauthorized
@@ -1117,7 +1117,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/products/{productId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PatchProductsByProductId.OK(Serializer.deserialize content)
             | 400 -> return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
             | 401 -> return PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
@@ -1134,7 +1134,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/products/{productId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteProductsByProductId.OK(Serializer.deserialize content)
             | 400 -> return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
             | 401 -> return DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
@@ -1154,7 +1154,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/schema/product" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSchemaProduct.OK
             | 400 -> return GetSchemaProduct.BadRequest(Serializer.deserialize content)
             | 401 -> return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
@@ -1172,7 +1172,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/products/{productId}/transfer" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostProductsTransferByProductId.OK(Serializer.deserialize content)
             | 400 -> return PostProductsTransferByProductId.BadRequest
             | 401 -> return PostProductsTransferByProductId.Unauthorized
@@ -1222,7 +1222,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/cdr" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetCdr.OK(Serializer.deserialize content)
             | 400 -> return GetCdr.BadRequest(Serializer.deserialize content)
             | 401 -> return GetCdr.Unauthorized(Serializer.deserialize content)
@@ -1256,7 +1256,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAssets.OK(Serializer.deserialize content)
             | 400 -> return GetAssets.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAssets.Unauthorized(Serializer.deserialize content)
@@ -1271,7 +1271,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAssets.OK(Serializer.deserialize content)
             | 400 -> return PostAssets.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAssets.Unauthorized(Serializer.deserialize content)
@@ -1286,7 +1286,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/assetsbulk" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAssetsbulk.OK(Serializer.deserialize content)
             | 400 -> return PostAssetsbulk.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
@@ -1301,7 +1301,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets/{iccid}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAssetsByIccid.OK(Serializer.deserialize content)
             | 400 -> return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
@@ -1316,7 +1316,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAssetsByIccid.OK(Serializer.deserialize content)
             | 400 -> return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
@@ -1331,7 +1331,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/assets/{iccid}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteAssetsByIccid.OK(Serializer.deserialize content)
             | 400 -> return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
@@ -1346,7 +1346,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/groupname" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
             | 400 -> return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
@@ -1361,7 +1361,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/transfer" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
             | 400 -> return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
@@ -1376,7 +1376,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/subscribe" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
             | 400 -> return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
@@ -1391,7 +1391,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/unsubscribe" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
             | 400 -> return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
@@ -1406,7 +1406,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/resubscribe" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
             | 400 -> return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
@@ -1421,7 +1421,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/suspend" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
             | 400 -> return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
@@ -1436,7 +1436,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/unsuspend" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
             | 400 -> return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
@@ -1453,7 +1453,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/alerts" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAssetsAlertsByIccid.OK
             | 400 -> return PutAssetsAlertsByIccid.BadRequest
             | 401 -> return PutAssetsAlertsByIccid.Unauthorized
@@ -1468,7 +1468,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/purge" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAssetsPurgeByIccid.OK
             | 400 -> return PostAssetsPurgeByIccid.BadRequest
             | 401 -> return PostAssetsPurgeByIccid.Unauthorized
@@ -1483,7 +1483,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent message ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/sms" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAssetsSmsByIccid.OK
             | 400 -> return PostAssetsSmsByIccid.BadRequest
             | 401 -> return PostAssetsSmsByIccid.Unauthorized
@@ -1498,7 +1498,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent message ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/limit" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAssetsLimitByIccid.OK
             | 400 -> return PostAssetsLimitByIccid.BadRequest
             | 401 -> return PostAssetsLimitByIccid.Unauthorized
@@ -1535,7 +1535,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/tags" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAssetsTagsByIccid.OK
             | 400 -> return PostAssetsTagsByIccid.BadRequest
             | 401 -> return PostAssetsTagsByIccid.Unauthorized
@@ -1550,7 +1550,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets/{iccid}/diagnostic" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
             | 401 -> return GetAssetsDiagnosticByIccid.Unauthorized
             | 500 -> return GetAssetsDiagnosticByIccid.InternalServerError
@@ -1565,7 +1565,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets/{iccid}/location" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
             | 400 -> return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
@@ -1581,7 +1581,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets/{iccid}/sessions" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
             | 400 -> return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
@@ -1607,7 +1607,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/reports/custom" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetReportsCustom.OK(Serializer.deserialize content)
             | 401 -> return GetReportsCustom.Unauthorized(Serializer.deserialize content)
             | _ -> return GetReportsCustom.InternalServerError(Serializer.deserialize content)
@@ -1621,7 +1621,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent report ]
             let! (status, content) = OpenApiHttp.postAsync url "/reports/custom" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostReportsCustom.OK
             | 401 -> return PostReportsCustom.Unauthorized(Serializer.deserialize content)
             | 403 -> return PostReportsCustom.Forbidden(Serializer.deserialize content)
@@ -1637,7 +1637,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.deleteAsync url "/reports/custom" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return DeleteReportsCustom.NoContent
             | 401 -> return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
@@ -1651,7 +1651,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/reports/custom/{reportId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetReportsCustomByReportId.OK(Serializer.deserialize content)
             | 401 -> return GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
             | 404 -> return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
@@ -1666,7 +1666,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.deleteAsync url "/reports/custom/{reportId}" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return DeleteReportsCustomByReportId.NoContent
             | 401 -> return DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
             | 404 -> return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
@@ -1734,7 +1734,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/events" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetEvents.OK(Serializer.deserialize content)
             | 400 -> return GetEvents.BadRequest(Serializer.deserialize content)
             | 401 -> return GetEvents.Unauthorized(Serializer.deserialize content)
@@ -1781,7 +1781,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/subscribe" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
             | 400 -> return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
             | 401 -> return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
@@ -1796,7 +1796,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/transfer" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
             | 400 -> return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
             | 401 -> return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
@@ -1811,7 +1811,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/return" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
             | 400 -> return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
             | 401 -> return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
@@ -1826,7 +1826,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.putAsync url "/bulk/assets/suspend" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
             | 400 -> return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
             | 401 -> return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
@@ -1841,7 +1841,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.putAsync url "/bulk/assets/unsuspend" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
             | 400 -> return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
             | 401 -> return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
@@ -1856,7 +1856,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/resubscribe" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
             | 400 -> return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
             | 401 -> return PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
@@ -1871,7 +1871,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PostBulkAssets.Accepted(Serializer.deserialize content)
             | 400 -> return PostBulkAssets.BadRequest(Serializer.deserialize content)
             | 401 -> return PostBulkAssets.Unauthorized(Serializer.deserialize content)
@@ -1886,7 +1886,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync url "/bulk/assets" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PutBulkAssets.Accepted(Serializer.deserialize content)
             | 400 -> return PutBulkAssets.BadRequest(Serializer.deserialize content)
             | 401 -> return PutBulkAssets.Unauthorized(Serializer.deserialize content)
@@ -1901,7 +1901,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync url "/bulk/assets/groupname" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
             | 400 -> return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
             | 401 -> return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
@@ -1916,7 +1916,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/limit" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
             | 400 -> return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
             | 401 -> return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
@@ -1933,7 +1933,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync url "/bulk/assets/alerts" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
             | 400 -> return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
             | 401 -> return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
@@ -1948,7 +1948,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/sms" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
             | 400 -> return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
             | 401 -> return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
@@ -1963,7 +1963,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/purge" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
             | 400 -> return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
             | 401 -> return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
@@ -2002,7 +2002,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/reallocate-ip" headers requestParts
 
-            match status with
+            match int status with
             | 202 -> return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
             | 400 -> return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
             | 401 -> return PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
@@ -2073,7 +2073,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/payments/topupPaypal" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
             | 400 -> return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
             | 401 -> return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
@@ -2091,7 +2091,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/payments/confirmTopupPaypal" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
             | 400 -> return PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
             | 401 -> return PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
@@ -2195,7 +2195,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/security/alerts" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSecurityAlerts.OK(Serializer.deserialize content)
             | 400 -> return GetSecurityAlerts.BadRequest
             | 401 -> return GetSecurityAlerts.Unauthorized
@@ -2219,7 +2219,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/security/alerts/{alertId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
             | 400 -> return GetSecurityAlertsByAlertId.BadRequest
             | 401 -> return GetSecurityAlertsByAlertId.Unauthorized
@@ -2251,7 +2251,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/security/alerts/{alertId}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
             | 400 -> return PutSecurityAlertsByAlertId.BadRequest
             | 401 -> return PutSecurityAlertsByAlertId.Unauthorized
@@ -2275,7 +2275,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/security/alerts/{alertId}" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return DeleteSecurityAlertsByAlertId.NoContent
             | 400 -> return DeleteSecurityAlertsByAlertId.BadRequest
             | 401 -> return DeleteSecurityAlertsByAlertId.Unauthorized
@@ -2313,7 +2313,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/security/topthreaten" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
             | 400 -> return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
@@ -2349,7 +2349,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/security/byalarmtype" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
             | 400 -> return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
@@ -2378,7 +2378,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/esims" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostEsims.OK(Serializer.deserialize content)
             | 400 -> return PostEsims.BadRequest(Serializer.deserialize content)
             | 401 -> return PostEsims.Unauthorized(Serializer.deserialize content)
@@ -2423,7 +2423,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/esims/{eid}/transfer" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostEsimsTransferByEid.OK(Serializer.deserialize content)
             | 400 -> return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
             | 401 -> return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
@@ -2438,7 +2438,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/esims/{eid}/return" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostEsimsReturnByEid.OK(Serializer.deserialize content)
             | 400 -> return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
             | 401 -> return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
@@ -2694,7 +2694,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/1" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph1.OK(Serializer.deserialize content)
             | 400 -> return GetGraph1.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph1.Unauthorized(Serializer.deserialize content)
@@ -2720,7 +2720,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/2" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph2.OK(Serializer.deserialize content)
             | 400 -> return GetGraph2.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph2.Unauthorized(Serializer.deserialize content)
@@ -2746,7 +2746,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/3" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph3.OK(Serializer.deserialize content)
             | 400 -> return GetGraph3.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph3.Unauthorized(Serializer.deserialize content)
@@ -2772,7 +2772,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/4" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph4.OK(Serializer.deserialize content)
             | 400 -> return GetGraph4.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph4.Unauthorized(Serializer.deserialize content)
@@ -2798,7 +2798,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/5" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph5.OK(Serializer.deserialize content)
             | 400 -> return GetGraph5.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph5.Unauthorized(Serializer.deserialize content)
@@ -2824,7 +2824,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/6" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph6.OK(Serializer.deserialize content)
             | 400 -> return GetGraph6.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph6.Unauthorized(Serializer.deserialize content)
@@ -2850,7 +2850,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/7" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph7.OK(Serializer.deserialize content)
             | 400 -> return GetGraph7.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph7.Unauthorized(Serializer.deserialize content)
@@ -2876,7 +2876,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/8" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph8.OK(Serializer.deserialize content)
             | 400 -> return GetGraph8.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph8.Unauthorized(Serializer.deserialize content)
@@ -2902,7 +2902,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/9" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph9.OK(Serializer.deserialize content)
             | 400 -> return GetGraph9.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph9.Unauthorized(Serializer.deserialize content)
@@ -2920,7 +2920,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/10" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph10.OK(Serializer.deserialize content)
             | 400 -> return GetGraph10.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph10.Unauthorized(Serializer.deserialize content)
@@ -2946,7 +2946,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/11" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph11.OK(Serializer.deserialize content)
             | 400 -> return GetGraph11.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph11.Unauthorized(Serializer.deserialize content)
@@ -2972,7 +2972,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/12" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraph12.OK(Serializer.deserialize content)
             | 400 -> return GetGraph12.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraph12.Unauthorized(Serializer.deserialize content)
@@ -2998,7 +2998,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/statusesperday" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetGraphStatusesperday.OK(Serializer.deserialize content)
             | 400 -> return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
             | 401 -> return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
@@ -3026,7 +3026,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/quick-dial" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
             | 400 -> return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
@@ -3041,7 +3041,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets/{iccid}/quick-dial" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
             | 400 -> return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
@@ -3058,7 +3058,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/assets/{iccid}/quick-dial/{location}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
             | 400 -> return GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
             | 401 -> return GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
@@ -3075,7 +3075,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.putAsync url "/assets/{iccid}/quick-dial/{location}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
             | 400 -> return PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
             | 401 -> return PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
@@ -3092,7 +3092,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync url "/assets/{iccid}/quick-dial/{location}" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return DeleteAssetsQuickDialByIccidAndLocation.NoContent
             | 400 -> return DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
             | 401 -> return DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
@@ -3107,7 +3107,7 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/dial" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostAssetsDialByIccid.OK(Serializer.deserialize content)
             | 400 -> return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
             | 401 -> return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)

--- a/examples/FablePodiosuite/Client.fs
+++ b/examples/FablePodiosuite/Client.fs
@@ -16,14 +16,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/auth/token" headers requestParts
 
-            if status = 200 then
-                return PostAuthToken.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAuthToken.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAuthToken.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthToken.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAuthToken.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthToken.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthToken.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthToken.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -34,14 +31,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/auth/recover-password" headers requestParts
 
-            if status = 200 then
-                return PostAuthRecoverPassword.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAuthRecoverPassword.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -57,14 +51,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/auth/reset/{mailtoken}" headers requestParts
 
-            if status = 200 then
-                return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -78,14 +69,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/auth/revoke-token" headers requestParts
 
-            if status = 200 then
-                return PostAuthRevokeToken.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAuthRevokeToken.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -99,14 +87,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/auth/change-password" headers requestParts
 
-            if status = 200 then
-                return PostAuthChangePassword.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAuthChangePassword.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -120,14 +105,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/users" headers requestParts
 
-            if status = 200 then
-                return PostUsers.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostUsers.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostUsers.Unauthorized(Serializer.deserialize content)
-            else
-                return PostUsers.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostUsers.OK(Serializer.deserialize content)
+            | 400 -> return PostUsers.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostUsers.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostUsers.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -191,14 +173,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/users" headers requestParts
 
-            if status = 200 then
-                return GetUsers.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetUsers.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetUsers.Unauthorized(Serializer.deserialize content)
-            else
-                return GetUsers.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetUsers.OK(Serializer.deserialize content)
+            | 400 -> return GetUsers.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetUsers.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetUsers.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -265,14 +244,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/usersbulk" headers requestParts
 
-            if status = 200 then
-                return PostUsersbulk.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostUsersbulk.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostUsersbulk.Unauthorized(Serializer.deserialize content)
-            else
-                return PostUsersbulk.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostUsersbulk.OK(Serializer.deserialize content)
+            | 400 -> return PostUsersbulk.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostUsersbulk.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostUsersbulk.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -288,14 +264,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/users/me" headers requestParts
 
-            if status = 200 then
-                return GetUsersMe.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetUsersMe.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetUsersMe.Unauthorized(Serializer.deserialize content)
-            else
-                return GetUsersMe.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetUsersMe.OK(Serializer.deserialize content)
+            | 400 -> return GetUsersMe.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetUsersMe.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetUsersMe.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -308,14 +281,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/users/me/accept-tc" headers requestParts
 
-            if status = 201 then
-                return PostUsersMeAcceptTc.Created
-            else if status = 400 then
-                return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
-            else
-                return PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 201 -> return PostUsersMeAcceptTc.Created
+            | 400 -> return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -333,14 +303,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/users/{userId}" headers requestParts
 
-            if status = 200 then
-                return GetUsersByUserId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetUsersByUserId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetUsersByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetUsersByUserId.OK(Serializer.deserialize content)
+            | 400 -> return GetUsersByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -358,14 +325,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/users/{userId}" headers requestParts
 
-            if status = 200 then
-                return PutUsersByUserId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutUsersByUserId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutUsersByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -383,14 +347,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/users/{userId}" headers requestParts
 
-            if status = 200 then
-                return DeleteUsersByUserId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return DeleteUsersByUserId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -406,14 +367,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/users/{userId}/change-password" headers requestParts
 
-            if status = 200 then
-                return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -433,14 +391,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/users/{userId}/favorites" headers requestParts
 
-            if status = 200 then
-                return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -460,14 +415,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/users/{userId}/customization" headers requestParts
 
-            if status = 200 then
-                return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -481,14 +433,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/users/{userId}/permissions" headers requestParts
 
-            if status = 200 then
-                return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -499,14 +448,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/accounts/notifications" headers requestParts
 
-            if status = 200 then
-                return GetAccountsNotifications.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAccountsNotifications.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -519,14 +465,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.putAsync url "/accounts/notifications/{notificationId}" headers requestParts
 
-            if status = 200 then
-                return PutAccountsNotificationsByNotificationId.OK
-            else if status = 400 then
-                return PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAccountsNotificationsByNotificationId.OK
+            | 400 -> return PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -539,13 +482,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync url "/accounts/notifications/{notificationId}" headers requestParts
 
-            if status = 200 then
-                return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
-            else
+            match status with
+            | 200 -> return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
+            | _ ->
                 return DeleteAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -557,14 +498,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/accounts" headers requestParts
 
-            if status = 200 then
-                return GetAccounts.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAccounts.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAccounts.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccounts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAccounts.OK(Serializer.deserialize content)
+            | 400 -> return GetAccounts.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccounts.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccounts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -575,14 +513,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent account ]
             let! (status, content) = OpenApiHttp.postAsync url "/accounts" headers requestParts
 
-            if status = 200 then
-                return PostAccounts.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAccounts.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAccounts.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAccounts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAccounts.OK(Serializer.deserialize content)
+            | 400 -> return PostAccounts.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAccounts.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAccounts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -593,14 +528,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync url "/accountsbulk" headers requestParts
 
-            if status = 200 then
-                return PostAccountsbulk.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAccountsbulk.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAccountsbulk.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAccountsbulk.OK(Serializer.deserialize content)
+            | 400 -> return PostAccountsbulk.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAccountsbulk.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -611,14 +543,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/accounts/{accountId}" headers requestParts
 
-            if status = 200 then
-                return GetAccountsByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAccountsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -629,14 +558,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent account ]
             let! (status, content) = OpenApiHttp.putAsync url "/accounts/{accountId}" headers requestParts
 
-            if status = 200 then
-                return PutAccountsByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAccountsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -647,14 +573,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/accounts/{accountId}" headers requestParts
 
-            if status = 200 then
-                return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -665,14 +588,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent account ]
             let! (status, content) = OpenApiHttp.putAsync url "/accounts/{accountId}/branding" headers requestParts
 
-            if status = 200 then
-                return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -685,14 +605,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/accounts/{accountId}/branding/verify" headers requestParts
 
-            if status = 200 then
-                return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -703,14 +620,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/accounts/{accountId}/roles" headers requestParts
 
-            if status = 200 then
-                return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -723,13 +637,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/accounts/{accountId}/roles/{rolename}/actions" headers requestParts
 
-            if status = 200 then
-                return GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
-            else
+            match status with
+            | 200 -> return GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
+            | _ ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.InternalServerError(Serializer.deserialize content)
         }
 
@@ -741,14 +653,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/accounts/{accountId}/notifications" headers requestParts
 
-            if status = 200 then
-                return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -761,13 +670,13 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.putAsync url "/accounts/{accountId}/notifications/{notificationId}" headers requestParts
 
-            if status = 200 then
-                return PutAccountsNotificationsByAccountIdAndNotificationId.OK
-            else if status = 400 then
+            match status with
+            | 200 -> return PutAccountsNotificationsByAccountIdAndNotificationId.OK
+            | 400 ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
+            | 401 ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     PutAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(
                         Serializer.deserialize content
@@ -784,15 +693,15 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync url "/accounts/{accountId}/notifications/{notificationId}" headers requestParts
 
-            if status = 200 then
-                return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
-            else if status = 400 then
+            match status with
+            | 200 -> return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
+            | 400 ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
+            | 401 ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(
                         Serializer.deserialize content
@@ -810,14 +719,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/accounts/{accountId}/products" headers requestParts
 
-            if status = 200 then
-                return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -830,14 +736,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/accounts/products/alerts" headers requestParts
 
-            if status = 200 then
-                return PutAccountsProductsAlerts.OK
-            else if status = 400 then
-                return PutAccountsProductsAlerts.BadRequest
-            else if status = 401 then
-                return PutAccountsProductsAlerts.Unauthorized
-            else
-                return PutAccountsProductsAlerts.InternalServerError
+            match status with
+            | 200 -> return PutAccountsProductsAlerts.OK
+            | 400 -> return PutAccountsProductsAlerts.BadRequest
+            | 401 -> return PutAccountsProductsAlerts.Unauthorized
+            | _ -> return PutAccountsProductsAlerts.InternalServerError
         }
 
     ///<summary>
@@ -848,14 +751,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/accounts/{accountId}/topup-direct" headers requestParts
 
-            if status = 200 then
-                return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -925,13 +825,13 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/accounts/{accountId}/security-settings/available-gaps" headers requestParts
 
-            if status = 200 then
-                return GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
+            match status with
+            | 200 -> return GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
+            | 400 ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
+            | 401 ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     GetAccountsSecuritySettingsAvailableGapsByAccountId.InternalServerError(
                         Serializer.deserialize content
@@ -956,13 +856,13 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/accounts/{accountId}/security-settings/available-ips" headers requestParts
 
-            if status = 200 then
-                return GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
-            else if status = 400 then
+            match status with
+            | 200 -> return GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
+            | 400 ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
+            | 401 ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     GetAccountsSecuritySettingsAvailableIpsByAccountId.InternalServerError(
                         Serializer.deserialize content
@@ -990,14 +890,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/mail" headers requestParts
 
-            if status = 200 then
-                return PostMail.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostMail.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostMail.Unauthorized(Serializer.deserialize content)
-            else
-                return PostMail.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostMail.OK(Serializer.deserialize content)
+            | 400 -> return PostMail.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostMail.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostMail.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1163,18 +1060,13 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/products" headers requestParts
 
-            if status = 200 then
-                return GetProducts.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetProducts.BadRequest
-            else if status = 401 then
-                return GetProducts.Unauthorized
-            else if status = 403 then
-                return GetProducts.Forbidden
-            else if status = 500 then
-                return GetProducts.InternalServerError
-            else
-                return GetProducts.ServiceUnavailable
+            match status with
+            | 200 -> return GetProducts.OK(Serializer.deserialize content)
+            | 400 -> return GetProducts.BadRequest
+            | 401 -> return GetProducts.Unauthorized
+            | 403 -> return GetProducts.Forbidden
+            | 500 -> return GetProducts.InternalServerError
+            | _ -> return GetProducts.ServiceUnavailable
         }
 
     ///<summary>
@@ -1188,14 +1080,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/products" headers requestParts
 
-            if status = 200 then
-                return PostProducts.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostProducts.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostProducts.Unauthorized(Serializer.deserialize content)
-            else
-                return PostProducts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostProducts.OK(Serializer.deserialize content)
+            | 400 -> return PostProducts.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostProducts.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostProducts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1208,18 +1097,13 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/products/{productId}" headers requestParts
 
-            if status = 200 then
-                return GetProductsByProductId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetProductsByProductId.BadRequest
-            else if status = 401 then
-                return GetProductsByProductId.Unauthorized
-            else if status = 403 then
-                return GetProductsByProductId.Forbidden
-            else if status = 500 then
-                return GetProductsByProductId.InternalServerError
-            else
-                return GetProductsByProductId.ServiceUnavailable
+            match status with
+            | 200 -> return GetProductsByProductId.OK(Serializer.deserialize content)
+            | 400 -> return GetProductsByProductId.BadRequest
+            | 401 -> return GetProductsByProductId.Unauthorized
+            | 403 -> return GetProductsByProductId.Forbidden
+            | 500 -> return GetProductsByProductId.InternalServerError
+            | _ -> return GetProductsByProductId.ServiceUnavailable
         }
 
     ///<summary>
@@ -1233,14 +1117,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/products/{productId}" headers requestParts
 
-            if status = 200 then
-                return PatchProductsByProductId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
-            else
-                return PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PatchProductsByProductId.OK(Serializer.deserialize content)
+            | 400 -> return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1253,14 +1134,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/products/{productId}" headers requestParts
 
-            if status = 200 then
-                return DeleteProductsByProductId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return DeleteProductsByProductId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1276,14 +1154,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/schema/product" headers requestParts
 
-            if status = 200 then
-                return GetSchemaProduct.OK
-            else if status = 400 then
-                return GetSchemaProduct.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
-            else
-                return GetSchemaProduct.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetSchemaProduct.OK
+            | 400 -> return GetSchemaProduct.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetSchemaProduct.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1297,18 +1172,13 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/products/{productId}/transfer" headers requestParts
 
-            if status = 200 then
-                return PostProductsTransferByProductId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostProductsTransferByProductId.BadRequest
-            else if status = 401 then
-                return PostProductsTransferByProductId.Unauthorized
-            else if status = 403 then
-                return PostProductsTransferByProductId.Forbidden
-            else if status = 500 then
-                return PostProductsTransferByProductId.InternalServerError
-            else
-                return PostProductsTransferByProductId.ServiceUnavailable
+            match status with
+            | 200 -> return PostProductsTransferByProductId.OK(Serializer.deserialize content)
+            | 400 -> return PostProductsTransferByProductId.BadRequest
+            | 401 -> return PostProductsTransferByProductId.Unauthorized
+            | 403 -> return PostProductsTransferByProductId.Forbidden
+            | 500 -> return PostProductsTransferByProductId.InternalServerError
+            | _ -> return PostProductsTransferByProductId.ServiceUnavailable
         }
 
     ///<summary>
@@ -1352,16 +1222,12 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/cdr" headers requestParts
 
-            if status = 200 then
-                return GetCdr.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetCdr.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetCdr.Unauthorized(Serializer.deserialize content)
-            else if status = 404 then
-                return GetCdr.NotFound(Serializer.deserialize content)
-            else
-                return GetCdr.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetCdr.OK(Serializer.deserialize content)
+            | 400 -> return GetCdr.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetCdr.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetCdr.NotFound(Serializer.deserialize content)
+            | _ -> return GetCdr.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1390,14 +1256,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets" headers requestParts
 
-            if status = 200 then
-                return GetAssets.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAssets.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAssets.OK(Serializer.deserialize content)
+            | 400 -> return GetAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1408,14 +1271,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets" headers requestParts
 
-            if status = 200 then
-                return PostAssets.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAssets.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAssets.OK(Serializer.deserialize content)
+            | 400 -> return PostAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1426,14 +1286,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/assetsbulk" headers requestParts
 
-            if status = 200 then
-                return PostAssetsbulk.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAssetsbulk.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsbulk.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAssetsbulk.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsbulk.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssetsbulk.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1444,14 +1301,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets/{iccid}" headers requestParts
 
-            if status = 200 then
-                return GetAssetsByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAssetsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1462,14 +1316,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}" headers requestParts
 
-            if status = 200 then
-                return PutAssetsByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAssetsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1480,14 +1331,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/assets/{iccid}" headers requestParts
 
-            if status = 200 then
-                return DeleteAssetsByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return DeleteAssetsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1498,14 +1346,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/groupname" headers requestParts
 
-            if status = 200 then
-                return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1516,14 +1361,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/transfer" headers requestParts
 
-            if status = 200 then
-                return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1534,14 +1376,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/subscribe" headers requestParts
 
-            if status = 200 then
-                return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1552,14 +1391,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/unsubscribe" headers requestParts
 
-            if status = 200 then
-                return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1570,14 +1406,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/resubscribe" headers requestParts
 
-            if status = 200 then
-                return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1588,14 +1421,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/suspend" headers requestParts
 
-            if status = 200 then
-                return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1606,14 +1436,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/unsuspend" headers requestParts
 
-            if status = 200 then
-                return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1626,14 +1453,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.putAsync url "/assets/{iccid}/alerts" headers requestParts
 
-            if status = 200 then
-                return PutAssetsAlertsByIccid.OK
-            else if status = 400 then
-                return PutAssetsAlertsByIccid.BadRequest
-            else if status = 401 then
-                return PutAssetsAlertsByIccid.Unauthorized
-            else
-                return PutAssetsAlertsByIccid.InternalServerError
+            match status with
+            | 200 -> return PutAssetsAlertsByIccid.OK
+            | 400 -> return PutAssetsAlertsByIccid.BadRequest
+            | 401 -> return PutAssetsAlertsByIccid.Unauthorized
+            | _ -> return PutAssetsAlertsByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1644,14 +1468,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/purge" headers requestParts
 
-            if status = 200 then
-                return PostAssetsPurgeByIccid.OK
-            else if status = 400 then
-                return PostAssetsPurgeByIccid.BadRequest
-            else if status = 401 then
-                return PostAssetsPurgeByIccid.Unauthorized
-            else
-                return PostAssetsPurgeByIccid.InternalServerError
+            match status with
+            | 200 -> return PostAssetsPurgeByIccid.OK
+            | 400 -> return PostAssetsPurgeByIccid.BadRequest
+            | 401 -> return PostAssetsPurgeByIccid.Unauthorized
+            | _ -> return PostAssetsPurgeByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1662,14 +1483,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent message ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/sms" headers requestParts
 
-            if status = 200 then
-                return PostAssetsSmsByIccid.OK
-            else if status = 400 then
-                return PostAssetsSmsByIccid.BadRequest
-            else if status = 401 then
-                return PostAssetsSmsByIccid.Unauthorized
-            else
-                return PostAssetsSmsByIccid.InternalServerError
+            match status with
+            | 200 -> return PostAssetsSmsByIccid.OK
+            | 400 -> return PostAssetsSmsByIccid.BadRequest
+            | 401 -> return PostAssetsSmsByIccid.Unauthorized
+            | _ -> return PostAssetsSmsByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1680,14 +1498,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent message ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/limit" headers requestParts
 
-            if status = 200 then
-                return PostAssetsLimitByIccid.OK
-            else if status = 400 then
-                return PostAssetsLimitByIccid.BadRequest
-            else if status = 401 then
-                return PostAssetsLimitByIccid.Unauthorized
-            else
-                return PostAssetsLimitByIccid.InternalServerError
+            match status with
+            | 200 -> return PostAssetsLimitByIccid.OK
+            | 400 -> return PostAssetsLimitByIccid.BadRequest
+            | 401 -> return PostAssetsLimitByIccid.Unauthorized
+            | _ -> return PostAssetsLimitByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1720,14 +1535,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/tags" headers requestParts
 
-            if status = 200 then
-                return PostAssetsTagsByIccid.OK
-            else if status = 400 then
-                return PostAssetsTagsByIccid.BadRequest
-            else if status = 401 then
-                return PostAssetsTagsByIccid.Unauthorized
-            else
-                return PostAssetsTagsByIccid.InternalServerError
+            match status with
+            | 200 -> return PostAssetsTagsByIccid.OK
+            | 400 -> return PostAssetsTagsByIccid.BadRequest
+            | 401 -> return PostAssetsTagsByIccid.Unauthorized
+            | _ -> return PostAssetsTagsByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1738,14 +1550,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets/{iccid}/diagnostic" headers requestParts
 
-            if status = 200 then
-                return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAssetsDiagnosticByIccid.Unauthorized
-            else if status = 500 then
-                return GetAssetsDiagnosticByIccid.InternalServerError
-            else
-                return GetAssetsDiagnosticByIccid.ServiceUnavailable
+            match status with
+            | 200 -> return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
+            | 401 -> return GetAssetsDiagnosticByIccid.Unauthorized
+            | 500 -> return GetAssetsDiagnosticByIccid.InternalServerError
+            | _ -> return GetAssetsDiagnosticByIccid.ServiceUnavailable
         }
 
     ///<summary>
@@ -1756,16 +1565,12 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets/{iccid}/location" headers requestParts
 
-            if status = 200 then
-                return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
-            else if status = 404 then
-                return GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
-            else
-                return GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
+            | _ -> return GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1776,16 +1581,12 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets/{iccid}/sessions" headers requestParts
 
-            if status = 200 then
-                return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
-            else if status = 404 then
-                return GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
-            else
-                return GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
+            | _ -> return GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1806,12 +1607,10 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/reports/custom" headers requestParts
 
-            if status = 200 then
-                return GetReportsCustom.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return GetReportsCustom.Unauthorized(Serializer.deserialize content)
-            else
-                return GetReportsCustom.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetReportsCustom.OK(Serializer.deserialize content)
+            | 401 -> return GetReportsCustom.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1822,16 +1621,12 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent report ]
             let! (status, content) = OpenApiHttp.postAsync url "/reports/custom" headers requestParts
 
-            if status = 200 then
-                return PostReportsCustom.OK
-            else if status = 401 then
-                return PostReportsCustom.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return PostReportsCustom.Forbidden(Serializer.deserialize content)
-            else if status = 404 then
-                return PostReportsCustom.NotFound(Serializer.deserialize content)
-            else
-                return PostReportsCustom.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostReportsCustom.OK
+            | 401 -> return PostReportsCustom.Unauthorized(Serializer.deserialize content)
+            | 403 -> return PostReportsCustom.Forbidden(Serializer.deserialize content)
+            | 404 -> return PostReportsCustom.NotFound(Serializer.deserialize content)
+            | _ -> return PostReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1842,12 +1637,10 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.deleteAsync url "/reports/custom" headers requestParts
 
-            if status = 204 then
-                return DeleteReportsCustom.NoContent
-            else if status = 401 then
-                return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 204 -> return DeleteReportsCustom.NoContent
+            | 401 -> return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1858,14 +1651,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/reports/custom/{reportId}" headers requestParts
 
-            if status = 200 then
-                return GetReportsCustomByReportId.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-            else if status = 404 then
-                return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
-            else
-                return GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetReportsCustomByReportId.OK(Serializer.deserialize content)
+            | 401 -> return GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
+            | _ -> return GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1876,14 +1666,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.deleteAsync url "/reports/custom/{reportId}" headers requestParts
 
-            if status = 204 then
-                return DeleteReportsCustomByReportId.NoContent
-            else if status = 401 then
-                return DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-            else if status = 404 then
-                return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
-            else
-                return DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 204 -> return DeleteReportsCustomByReportId.NoContent
+            | 401 -> return DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
+            | 404 -> return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
+            | _ -> return DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1947,14 +1734,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/events" headers requestParts
 
-            if status = 200 then
-                return GetEvents.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetEvents.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetEvents.Unauthorized(Serializer.deserialize content)
-            else
-                return GetEvents.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetEvents.OK(Serializer.deserialize content)
+            | 400 -> return GetEvents.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetEvents.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetEvents.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1997,14 +1781,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/subscribe" headers requestParts
 
-            if status = 202 then
-                return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2015,14 +1796,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/transfer" headers requestParts
 
-            if status = 202 then
-                return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2033,14 +1811,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/return" headers requestParts
 
-            if status = 202 then
-                return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2051,14 +1826,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.putAsync url "/bulk/assets/suspend" headers requestParts
 
-            if status = 202 then
-                return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2069,14 +1841,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.putAsync url "/bulk/assets/unsuspend" headers requestParts
 
-            if status = 202 then
-                return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2087,14 +1856,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/resubscribe" headers requestParts
 
-            if status = 202 then
-                return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2105,14 +1871,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets" headers requestParts
 
-            if status = 202 then
-                return PostBulkAssets.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PostBulkAssets.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostBulkAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PostBulkAssets.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2123,14 +1886,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync url "/bulk/assets" headers requestParts
 
-            if status = 202 then
-                return PutBulkAssets.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PutBulkAssets.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutBulkAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PutBulkAssets.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2141,14 +1901,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync url "/bulk/assets/groupname" headers requestParts
 
-            if status = 202 then
-                return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2159,14 +1916,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/limit" headers requestParts
 
-            if status = 202 then
-                return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2179,14 +1933,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync url "/bulk/assets/alerts" headers requestParts
 
-            if status = 202 then
-                return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2197,14 +1948,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/sms" headers requestParts
 
-            if status = 202 then
-                return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2215,14 +1963,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/purge" headers requestParts
 
-            if status = 202 then
-                return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2257,14 +2002,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/bulk/assets/reallocate-ip" headers requestParts
 
-            if status = 202 then
-                return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
-            else if status = 400 then
-                return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 202 -> return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2331,14 +2073,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/payments/topupPaypal" headers requestParts
 
-            if status = 200 then
-                return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
-            else
-                return PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
+            | 400 -> return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2352,14 +2091,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/payments/confirmTopupPaypal" headers requestParts
 
-            if status = 200 then
-                return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
-            else
-                return PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
+            | 400 -> return PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2459,18 +2195,13 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/security/alerts" headers requestParts
 
-            if status = 200 then
-                return GetSecurityAlerts.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetSecurityAlerts.BadRequest
-            else if status = 401 then
-                return GetSecurityAlerts.Unauthorized
-            else if status = 403 then
-                return GetSecurityAlerts.Forbidden
-            else if status = 500 then
-                return GetSecurityAlerts.InternalServerError
-            else
-                return GetSecurityAlerts.ServiceUnavailable
+            match status with
+            | 200 -> return GetSecurityAlerts.OK(Serializer.deserialize content)
+            | 400 -> return GetSecurityAlerts.BadRequest
+            | 401 -> return GetSecurityAlerts.Unauthorized
+            | 403 -> return GetSecurityAlerts.Forbidden
+            | 500 -> return GetSecurityAlerts.InternalServerError
+            | _ -> return GetSecurityAlerts.ServiceUnavailable
         }
 
     ///<summary>
@@ -2488,18 +2219,13 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/security/alerts/{alertId}" headers requestParts
 
-            if status = 200 then
-                return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetSecurityAlertsByAlertId.BadRequest
-            else if status = 401 then
-                return GetSecurityAlertsByAlertId.Unauthorized
-            else if status = 403 then
-                return GetSecurityAlertsByAlertId.Forbidden
-            else if status = 500 then
-                return GetSecurityAlertsByAlertId.InternalServerError
-            else
-                return GetSecurityAlertsByAlertId.ServiceUnavailable
+            match status with
+            | 200 -> return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+            | 400 -> return GetSecurityAlertsByAlertId.BadRequest
+            | 401 -> return GetSecurityAlertsByAlertId.Unauthorized
+            | 403 -> return GetSecurityAlertsByAlertId.Forbidden
+            | 500 -> return GetSecurityAlertsByAlertId.InternalServerError
+            | _ -> return GetSecurityAlertsByAlertId.ServiceUnavailable
         }
 
     ///<summary>
@@ -2525,18 +2251,13 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/security/alerts/{alertId}" headers requestParts
 
-            if status = 200 then
-                return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutSecurityAlertsByAlertId.BadRequest
-            else if status = 401 then
-                return PutSecurityAlertsByAlertId.Unauthorized
-            else if status = 403 then
-                return PutSecurityAlertsByAlertId.Forbidden
-            else if status = 500 then
-                return PutSecurityAlertsByAlertId.InternalServerError
-            else
-                return PutSecurityAlertsByAlertId.ServiceUnavailable
+            match status with
+            | 200 -> return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+            | 400 -> return PutSecurityAlertsByAlertId.BadRequest
+            | 401 -> return PutSecurityAlertsByAlertId.Unauthorized
+            | 403 -> return PutSecurityAlertsByAlertId.Forbidden
+            | 500 -> return PutSecurityAlertsByAlertId.InternalServerError
+            | _ -> return PutSecurityAlertsByAlertId.ServiceUnavailable
         }
 
     ///<summary>
@@ -2554,18 +2275,13 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/security/alerts/{alertId}" headers requestParts
 
-            if status = 204 then
-                return DeleteSecurityAlertsByAlertId.NoContent
-            else if status = 400 then
-                return DeleteSecurityAlertsByAlertId.BadRequest
-            else if status = 401 then
-                return DeleteSecurityAlertsByAlertId.Unauthorized
-            else if status = 403 then
-                return DeleteSecurityAlertsByAlertId.Forbidden
-            else if status = 500 then
-                return DeleteSecurityAlertsByAlertId.InternalServerError
-            else
-                return DeleteSecurityAlertsByAlertId.ServiceUnavailable
+            match status with
+            | 204 -> return DeleteSecurityAlertsByAlertId.NoContent
+            | 400 -> return DeleteSecurityAlertsByAlertId.BadRequest
+            | 401 -> return DeleteSecurityAlertsByAlertId.Unauthorized
+            | 403 -> return DeleteSecurityAlertsByAlertId.Forbidden
+            | 500 -> return DeleteSecurityAlertsByAlertId.InternalServerError
+            | _ -> return DeleteSecurityAlertsByAlertId.ServiceUnavailable
         }
 
     ///<summary>
@@ -2597,14 +2313,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/security/topthreaten" headers requestParts
 
-            if status = 200 then
-                return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
+            | 400 -> return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2636,14 +2349,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/security/byalarmtype" headers requestParts
 
-            if status = 200 then
-                return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
+            | 400 -> return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2668,14 +2378,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/esims" headers requestParts
 
-            if status = 200 then
-                return PostEsims.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostEsims.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostEsims.Unauthorized(Serializer.deserialize content)
-            else
-                return PostEsims.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostEsims.OK(Serializer.deserialize content)
+            | 400 -> return PostEsims.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostEsims.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostEsims.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2716,14 +2423,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/esims/{eid}/transfer" headers requestParts
 
-            if status = 200 then
-                return PostEsimsTransferByEid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostEsimsTransferByEid.OK(Serializer.deserialize content)
+            | 400 -> return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2734,14 +2438,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/esims/{eid}/return" headers requestParts
 
-            if status = 200 then
-                return PostEsimsReturnByEid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostEsimsReturnByEid.OK(Serializer.deserialize content)
+            | 400 -> return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2993,14 +2694,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/1" headers requestParts
 
-            if status = 200 then
-                return GetGraph1.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph1.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph1.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph1.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph1.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph1.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph1.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph1.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3022,14 +2720,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/2" headers requestParts
 
-            if status = 200 then
-                return GetGraph2.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph2.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph2.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph2.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph2.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph2.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph2.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph2.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3051,14 +2746,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/3" headers requestParts
 
-            if status = 200 then
-                return GetGraph3.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph3.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph3.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph3.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph3.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph3.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph3.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph3.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3080,14 +2772,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/4" headers requestParts
 
-            if status = 200 then
-                return GetGraph4.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph4.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph4.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph4.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph4.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph4.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph4.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph4.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3109,14 +2798,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/5" headers requestParts
 
-            if status = 200 then
-                return GetGraph5.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph5.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph5.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph5.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph5.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph5.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph5.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph5.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3138,14 +2824,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/6" headers requestParts
 
-            if status = 200 then
-                return GetGraph6.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph6.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph6.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph6.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph6.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph6.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph6.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph6.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3167,14 +2850,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/7" headers requestParts
 
-            if status = 200 then
-                return GetGraph7.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph7.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph7.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph7.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph7.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph7.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph7.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph7.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3196,14 +2876,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/8" headers requestParts
 
-            if status = 200 then
-                return GetGraph8.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph8.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph8.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph8.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph8.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph8.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph8.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph8.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3225,14 +2902,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/9" headers requestParts
 
-            if status = 200 then
-                return GetGraph9.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph9.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph9.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph9.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph9.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph9.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph9.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph9.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3246,14 +2920,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/10" headers requestParts
 
-            if status = 200 then
-                return GetGraph10.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph10.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph10.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph10.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph10.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph10.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph10.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph10.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3275,14 +2946,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/11" headers requestParts
 
-            if status = 200 then
-                return GetGraph11.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph11.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph11.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph11.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph11.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph11.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph11.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph11.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3304,14 +2972,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/12" headers requestParts
 
-            if status = 200 then
-                return GetGraph12.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraph12.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraph12.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph12.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraph12.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph12.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph12.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph12.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3333,14 +2998,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/graph/statusesperday" headers requestParts
 
-            if status = 200 then
-                return GetGraphStatusesperday.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetGraphStatusesperday.OK(Serializer.deserialize content)
+            | 400 -> return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3364,14 +3026,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/quick-dial" headers requestParts
 
-            if status = 200 then
-                return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3382,14 +3041,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/assets/{iccid}/quick-dial" headers requestParts
 
-            if status = 200 then
-                return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3402,14 +3058,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/assets/{iccid}/quick-dial/{location}" headers requestParts
 
-            if status = 200 then
-                return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3422,14 +3075,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.putAsync url "/assets/{iccid}/quick-dial/{location}" headers requestParts
 
-            if status = 200 then
-                return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3442,14 +3092,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync url "/assets/{iccid}/quick-dial/{location}" headers requestParts
 
-            if status = 204 then
-                return DeleteAssetsQuickDialByIccidAndLocation.NoContent
-            else if status = 400 then
-                return DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 204 -> return DeleteAssetsQuickDialByIccidAndLocation.NoContent
+            | 400 -> return DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3460,14 +3107,11 @@ type FablePodiosuiteClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync url "/assets/{iccid}/dial" headers requestParts
 
-            if status = 200 then
-                return PostAssetsDialByIccid.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
-            else if status = 401 then
-                return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostAssetsDialByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>

--- a/examples/FableSlicebox/Client.fs
+++ b/examples/FableSlicebox/Client.fs
@@ -92,10 +92,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/anonymization/keys/{id}" headers requestParts
 
-            if status = 200 then
-                return GetAnonymizationKeysById.OK(Serializer.deserialize content)
-            else
-                return GetAnonymizationKeysById.NotFound
+            match status with
+            | 200 -> return GetAnonymizationKeysById.OK(Serializer.deserialize content)
+            | _ -> return GetAnonymizationKeysById.NotFound
         }
 
     ///<summary>
@@ -107,10 +106,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/anonymization/keys/{id}/keyvalues" headers requestParts
 
-            if status = 200 then
-                return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
-            else
-                return GetAnonymizationKeysKeyvaluesById.NotFound
+            match status with
+            | 200 -> return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
+            | _ -> return GetAnonymizationKeysKeyvaluesById.NotFound
         }
 
     ///<summary>
@@ -199,10 +197,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/boxes/incoming/{id}/images" headers requestParts
 
-            if status = 200 then
-                return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
-            else
-                return GetBoxesIncomingImagesById.NotFound
+            match status with
+            | 200 -> return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetBoxesIncomingImagesById.NotFound
         }
 
     ///<summary>
@@ -242,10 +239,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/boxes/outgoing/{id}/images" headers requestParts
 
-            if status = 200 then
-                return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
-            else
-                return GetBoxesOutgoingImagesById.NotFound
+            match status with
+            | 200 -> return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetBoxesOutgoingImagesById.NotFound
         }
 
     ///<summary>
@@ -272,10 +268,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/boxes/{id}/send" headers requestParts
 
-            if status = 201 then
-                return PostBoxesSendById.Created
-            else
-                return PostBoxesSendById.NotFound
+            match status with
+            | 201 -> return PostBoxesSendById.Created
+            | _ -> return PostBoxesSendById.NotFound
         }
 
     ///<summary>
@@ -497,10 +492,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/images" headers requestParts
 
-            if status = 200 then
-                return PostImages.OK(Serializer.deserialize content)
-            else
-                return PostImages.Created(Serializer.deserialize content)
+            match status with
+            | 200 -> return PostImages.OK(Serializer.deserialize content)
+            | _ -> return PostImages.Created(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -536,10 +530,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/images/export" headers requestParts
 
-            if status = 200 then
-                return PostImagesExport.OK(Serializer.deserialize content)
-            else
-                return PostImagesExport.Created
+            match status with
+            | 200 -> return PostImagesExport.OK(Serializer.deserialize content)
+            | _ -> return PostImagesExport.Created
         }
 
     ///<summary>
@@ -581,10 +574,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, contentBinary) = OpenApiHttp.getBinaryAsync url "/images/{id}" headers requestParts
 
-            if status = 200 then
-                return GetImagesById.OK contentBinary
-            else
-                return GetImagesById.NotFound contentBinary
+            match status with
+            | 200 -> return GetImagesById.OK contentBinary
+            | _ -> return GetImagesById.NotFound contentBinary
         }
 
     ///<summary>
@@ -600,10 +592,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/images/{id}/anonymize" headers requestParts
 
-            if status = 200 then
-                return PutImagesAnonymizeById.OK(Serializer.deserialize content)
-            else
-                return PutImagesAnonymizeById.NotFound
+            match status with
+            | 200 -> return PutImagesAnonymizeById.OK(Serializer.deserialize content)
+            | _ -> return PutImagesAnonymizeById.NotFound
         }
 
     ///<summary>
@@ -619,10 +610,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/images/{id}/anonymized" headers requestParts
 
-            if status = 200 then
-                return PostImagesAnonymizedById.OK
-            else
-                return PostImagesAnonymizedById.NotFound
+            match status with
+            | 200 -> return PostImagesAnonymizedById.OK
+            | _ -> return PostImagesAnonymizedById.NotFound
         }
 
     ///<summary>
@@ -634,10 +624,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/images/{id}/attributes" headers requestParts
 
-            if status = 200 then
-                return GetImagesAttributesById.OK(Serializer.deserialize content)
-            else
-                return GetImagesAttributesById.NotFound
+            match status with
+            | 200 -> return GetImagesAttributesById.OK(Serializer.deserialize content)
+            | _ -> return GetImagesAttributesById.NotFound
         }
 
     ///<summary>
@@ -649,10 +638,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/images/{id}/imageinformation" headers requestParts
 
-            if status = 200 then
-                return GetImagesImageinformationById.OK(Serializer.deserialize content)
-            else
-                return GetImagesImageinformationById.NotFound
+            match status with
+            | 200 -> return GetImagesImageinformationById.OK(Serializer.deserialize content)
+            | _ -> return GetImagesImageinformationById.NotFound
         }
 
     ///<summary>
@@ -693,10 +681,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, contentBinary) = OpenApiHttp.getBinaryAsync url "/images/{id}/png" headers requestParts
 
-            if status = 200 then
-                return GetImagesPngById.OK contentBinary
-            else
-                return GetImagesPngById.NotFound contentBinary
+            match status with
+            | 200 -> return GetImagesPngById.OK contentBinary
+            | _ -> return GetImagesPngById.NotFound contentBinary
         }
 
     ///<summary>
@@ -748,10 +735,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/import/sessions/{id}" headers requestParts
 
-            if status = 200 then
-                return GetImportSessionsById.OK(Serializer.deserialize content)
-            else
-                return GetImportSessionsById.NotFound
+            match status with
+            | 200 -> return GetImportSessionsById.OK(Serializer.deserialize content)
+            | _ -> return GetImportSessionsById.NotFound
         }
 
     ///<summary>
@@ -763,10 +749,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/import/sessions/{id}/images" headers requestParts
 
-            if status = 200 then
-                return GetImportSessionsImagesById.OK(Serializer.deserialize content)
-            else
-                return GetImportSessionsImagesById.NotFound
+            match status with
+            | 200 -> return GetImportSessionsImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetImportSessionsImagesById.NotFound
         }
 
     ///<summary>
@@ -782,12 +767,10 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/import/sessions/{id}/images" headers requestParts
 
-            if status = 200 then
-                return PostImportSessionsImagesById.OK(Serializer.deserialize content)
-            else if status = 201 then
-                return PostImportSessionsImagesById.Created(Serializer.deserialize content)
-            else
-                return PostImportSessionsImagesById.NotFound
+            match status with
+            | 200 -> return PostImportSessionsImagesById.OK(Serializer.deserialize content)
+            | 201 -> return PostImportSessionsImagesById.Created(Serializer.deserialize content)
+            | _ -> return PostImportSessionsImagesById.NotFound
         }
 
     ///<summary>
@@ -898,10 +881,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/flatseries/{id}" headers requestParts
 
-            if status = 200 then
-                return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataFlatseriesById.NotFound
+            match status with
+            | 200 -> return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataFlatseriesById.NotFound
         }
 
     ///<summary>
@@ -942,10 +924,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/images/{id}" headers requestParts
 
-            if status = 200 then
-                return GetMetadataImagesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataImagesById.NotFound
+            match status with
+            | 200 -> return GetMetadataImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataImagesById.NotFound
         }
 
     ///<summary>
@@ -1012,10 +993,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/patients/{id}" headers requestParts
 
-            if status = 200 then
-                return GetMetadataPatientsById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataPatientsById.NotFound
+            match status with
+            | 200 -> return GetMetadataPatientsById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataPatientsById.NotFound
         }
 
     ///<summary>
@@ -1095,10 +1075,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/series/{id}" headers requestParts
 
-            if status = 200 then
-                return GetMetadataSeriesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesById.NotFound
+            match status with
+            | 200 -> return GetMetadataSeriesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesById.NotFound
         }
 
     ///<summary>
@@ -1110,10 +1089,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/series/{id}/seriestags" headers requestParts
 
-            if status = 200 then
-                return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesSeriestagsById.NotFound
+            match status with
+            | 200 -> return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesSeriestagsById.NotFound
         }
 
     ///<summary>
@@ -1129,10 +1107,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/metadata/series/{id}/seriestags" headers requestParts
 
-            if status = 201 then
-                return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
-            else
-                return PostMetadataSeriesSeriestagsById.NotFound
+            match status with
+            | 201 -> return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
+            | _ -> return PostMetadataSeriesSeriestagsById.NotFound
         }
 
     ///<summary>
@@ -1158,10 +1135,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/series/{id}/seriestypes" headers requestParts
 
-            if status = 200 then
-                return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesSeriestypesById.NotFound
+            match status with
+            | 200 -> return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesSeriestypesById.NotFound
         }
 
     ///<summary>
@@ -1173,10 +1149,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/series/{id}/source" headers requestParts
 
-            if status = 200 then
-                return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesSourceById.NotFound
+            match status with
+            | 200 -> return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesSourceById.NotFound
         }
 
     ///<summary>
@@ -1231,10 +1206,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.putAsync url "/metadata/series/{seriesId}/seriestypes/{seriesTypeId}" headers requestParts
 
-            if status = 204 then
-                return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
-            else
-                return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NotFound
+            match status with
+            | 204 -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
+            | _ -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NotFound
         }
 
     ///<summary>
@@ -1302,10 +1276,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/studies/{id}" headers requestParts
 
-            if status = 200 then
-                return GetMetadataStudiesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataStudiesById.NotFound
+            match status with
+            | 200 -> return GetMetadataStudiesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataStudiesById.NotFound
         }
 
     ///<summary>
@@ -1328,10 +1301,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/studies/{id}/images" headers requestParts
 
-            if status = 200 then
-                return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataStudiesImagesById.NotFound
+            match status with
+            | 200 -> return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataStudiesImagesById.NotFound
         }
 
     ///<summary>
@@ -1359,10 +1331,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent scp ]
             let! (status, content) = OpenApiHttp.postAsync url "/scps" headers requestParts
 
-            if status = 201 then
-                return PostScps.Created(Serializer.deserialize content)
-            else
-                return PostScps.BadRequest
+            match status with
+            | 201 -> return PostScps.Created(Serializer.deserialize content)
+            | _ -> return PostScps.BadRequest
         }
 
     ///<summary>
@@ -1401,10 +1372,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent scu ]
             let! (status, content) = OpenApiHttp.postAsync url "/scus" headers requestParts
 
-            if status = 201 then
-                return PostScus.Created(Serializer.deserialize content)
-            else
-                return PostScus.BadRequest
+            match status with
+            | 201 -> return PostScus.Created(Serializer.deserialize content)
+            | _ -> return PostScus.BadRequest
         }
 
     ///<summary>
@@ -1431,10 +1401,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/scus/{id}/send" headers requestParts
 
-            if status = 204 then
-                return PostScusSendById.NoContent
-            else
-                return PostScusSendById.NotFound
+            match status with
+            | 204 -> return PostScusSendById.NoContent
+            | _ -> return PostScusSendById.NotFound
         }
 
     ///<summary>
@@ -1642,10 +1611,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/transactions/{token}/image" headers requestParts
 
-            if status = 204 then
-                return PostTransactionsImageByToken.NoContent
-            else
-                return PostTransactionsImageByToken.Unauthorized
+            match status with
+            | 204 -> return PostTransactionsImageByToken.NoContent
+            | _ -> return PostTransactionsImageByToken.Unauthorized
         }
 
     ///<summary>
@@ -1664,12 +1632,10 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync url "/transactions/{token}/outgoing" headers requestParts
 
-            if status = 200 then
-                return GetTransactionsOutgoingByToken.OK contentBinary
-            else if status = 401 then
-                return GetTransactionsOutgoingByToken.Unauthorized contentBinary
-            else
-                return GetTransactionsOutgoingByToken.NotFound contentBinary
+            match status with
+            | 200 -> return GetTransactionsOutgoingByToken.OK contentBinary
+            | 401 -> return GetTransactionsOutgoingByToken.Unauthorized contentBinary
+            | _ -> return GetTransactionsOutgoingByToken.NotFound contentBinary
         }
 
     ///<summary>
@@ -1690,10 +1656,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.postAsync url "/transactions/{token}/outgoing/done" headers requestParts
 
-            if status = 204 then
-                return PostTransactionsOutgoingDoneByToken.NoContent
-            else
-                return PostTransactionsOutgoingDoneByToken.Unauthorized
+            match status with
+            | 204 -> return PostTransactionsOutgoingDoneByToken.NoContent
+            | _ -> return PostTransactionsOutgoingDoneByToken.Unauthorized
         }
 
     ///<summary>
@@ -1714,10 +1679,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.postAsync url "/transactions/{token}/outgoing/failed" headers requestParts
 
-            if status = 204 then
-                return PostTransactionsOutgoingFailedByToken.NoContent
-            else
-                return PostTransactionsOutgoingFailedByToken.Unauthorized
+            match status with
+            | 204 -> return PostTransactionsOutgoingFailedByToken.NoContent
+            | _ -> return PostTransactionsOutgoingFailedByToken.Unauthorized
         }
 
     ///<summary>
@@ -1729,12 +1693,10 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("token", token) ]
             let! (status, content) = OpenApiHttp.getAsync url "/transactions/{token}/outgoing/poll" headers requestParts
 
-            if status = 200 then
-                return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return GetTransactionsOutgoingPollByToken.Unauthorized
-            else
-                return GetTransactionsOutgoingPollByToken.NotFound
+            match status with
+            | 200 -> return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
+            | 401 -> return GetTransactionsOutgoingPollByToken.Unauthorized
+            | _ -> return GetTransactionsOutgoingPollByToken.NotFound
         }
 
     ///<summary>
@@ -1750,12 +1712,10 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/transactions/{token}/status" headers requestParts
 
-            if status = 200 then
-                return GetTransactionsStatusByToken.OK
-            else if status = 401 then
-                return GetTransactionsStatusByToken.Unauthorized
-            else
-                return GetTransactionsStatusByToken.NotFound
+            match status with
+            | 200 -> return GetTransactionsStatusByToken.OK
+            | 401 -> return GetTransactionsStatusByToken.Unauthorized
+            | _ -> return GetTransactionsStatusByToken.NotFound
         }
 
     ///<summary>
@@ -1773,10 +1733,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/transactions/{token}/status" headers requestParts
 
-            if status = 204 then
-                return PutTransactionsStatusByToken.NoContent
-            else
-                return PutTransactionsStatusByToken.NotFound
+            match status with
+            | 204 -> return PutTransactionsStatusByToken.NoContent
+            | _ -> return PutTransactionsStatusByToken.NotFound
         }
 
     ///<summary>
@@ -1814,10 +1773,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/users/current" headers requestParts
 
-            if status = 200 then
-                return GetUsersCurrent.OK(Serializer.deserialize content)
-            else
-                return GetUsersCurrent.NotFound
+            match status with
+            | 200 -> return GetUsersCurrent.OK(Serializer.deserialize content)
+            | _ -> return GetUsersCurrent.NotFound
         }
 
     ///<summary>
@@ -1828,10 +1786,9 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent userPass ]
             let! (status, content) = OpenApiHttp.postAsync url "/users/login" headers requestParts
 
-            if status = 201 then
-                return PostUsersLogin.Created
-            else
-                return PostUsersLogin.Unauthorized
+            match status with
+            | 201 -> return PostUsersLogin.Created
+            | _ -> return PostUsersLogin.Unauthorized
         }
 
     ///<summary>

--- a/examples/FableSlicebox/Client.fs
+++ b/examples/FableSlicebox/Client.fs
@@ -92,7 +92,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/anonymization/keys/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAnonymizationKeysById.OK(Serializer.deserialize content)
             | _ -> return GetAnonymizationKeysById.NotFound
         }
@@ -106,7 +106,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/anonymization/keys/{id}/keyvalues" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
             | _ -> return GetAnonymizationKeysKeyvaluesById.NotFound
         }
@@ -197,7 +197,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/boxes/incoming/{id}/images" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
             | _ -> return GetBoxesIncomingImagesById.NotFound
         }
@@ -239,7 +239,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/boxes/outgoing/{id}/images" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
             | _ -> return GetBoxesOutgoingImagesById.NotFound
         }
@@ -268,7 +268,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/boxes/{id}/send" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return PostBoxesSendById.Created
             | _ -> return PostBoxesSendById.NotFound
         }
@@ -492,7 +492,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/images" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostImages.OK(Serializer.deserialize content)
             | _ -> return PostImages.Created(Serializer.deserialize content)
         }
@@ -530,7 +530,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/images/export" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostImagesExport.OK(Serializer.deserialize content)
             | _ -> return PostImagesExport.Created
         }
@@ -574,7 +574,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, contentBinary) = OpenApiHttp.getBinaryAsync url "/images/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetImagesById.OK contentBinary
             | _ -> return GetImagesById.NotFound contentBinary
         }
@@ -592,7 +592,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/images/{id}/anonymize" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutImagesAnonymizeById.OK(Serializer.deserialize content)
             | _ -> return PutImagesAnonymizeById.NotFound
         }
@@ -610,7 +610,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/images/{id}/anonymized" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostImagesAnonymizedById.OK
             | _ -> return PostImagesAnonymizedById.NotFound
         }
@@ -624,7 +624,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/images/{id}/attributes" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetImagesAttributesById.OK(Serializer.deserialize content)
             | _ -> return GetImagesAttributesById.NotFound
         }
@@ -638,7 +638,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/images/{id}/imageinformation" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetImagesImageinformationById.OK(Serializer.deserialize content)
             | _ -> return GetImagesImageinformationById.NotFound
         }
@@ -681,7 +681,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, contentBinary) = OpenApiHttp.getBinaryAsync url "/images/{id}/png" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetImagesPngById.OK contentBinary
             | _ -> return GetImagesPngById.NotFound contentBinary
         }
@@ -735,7 +735,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/import/sessions/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetImportSessionsById.OK(Serializer.deserialize content)
             | _ -> return GetImportSessionsById.NotFound
         }
@@ -749,7 +749,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/import/sessions/{id}/images" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetImportSessionsImagesById.OK(Serializer.deserialize content)
             | _ -> return GetImportSessionsImagesById.NotFound
         }
@@ -767,7 +767,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/import/sessions/{id}/images" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostImportSessionsImagesById.OK(Serializer.deserialize content)
             | 201 -> return PostImportSessionsImagesById.Created(Serializer.deserialize content)
             | _ -> return PostImportSessionsImagesById.NotFound
@@ -881,7 +881,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/flatseries/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataFlatseriesById.NotFound
         }
@@ -924,7 +924,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/images/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetMetadataImagesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataImagesById.NotFound
         }
@@ -993,7 +993,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/patients/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetMetadataPatientsById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataPatientsById.NotFound
         }
@@ -1075,7 +1075,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/series/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetMetadataSeriesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesById.NotFound
         }
@@ -1089,7 +1089,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/series/{id}/seriestags" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesSeriestagsById.NotFound
         }
@@ -1107,7 +1107,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/metadata/series/{id}/seriestags" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
             | _ -> return PostMetadataSeriesSeriestagsById.NotFound
         }
@@ -1135,7 +1135,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/series/{id}/seriestypes" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesSeriestypesById.NotFound
         }
@@ -1149,7 +1149,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/series/{id}/source" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesSourceById.NotFound
         }
@@ -1206,7 +1206,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.putAsync url "/metadata/series/{seriesId}/seriestypes/{seriesTypeId}" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
             | _ -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NotFound
         }
@@ -1276,7 +1276,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/studies/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetMetadataStudiesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataStudiesById.NotFound
         }
@@ -1301,7 +1301,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/metadata/studies/{id}/images" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataStudiesImagesById.NotFound
         }
@@ -1331,7 +1331,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent scp ]
             let! (status, content) = OpenApiHttp.postAsync url "/scps" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return PostScps.Created(Serializer.deserialize content)
             | _ -> return PostScps.BadRequest
         }
@@ -1372,7 +1372,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent scu ]
             let! (status, content) = OpenApiHttp.postAsync url "/scus" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return PostScus.Created(Serializer.deserialize content)
             | _ -> return PostScus.BadRequest
         }
@@ -1401,7 +1401,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/scus/{id}/send" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PostScusSendById.NoContent
             | _ -> return PostScusSendById.NotFound
         }
@@ -1611,7 +1611,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/transactions/{token}/image" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PostTransactionsImageByToken.NoContent
             | _ -> return PostTransactionsImageByToken.Unauthorized
         }
@@ -1632,7 +1632,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync url "/transactions/{token}/outgoing" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetTransactionsOutgoingByToken.OK contentBinary
             | 401 -> return GetTransactionsOutgoingByToken.Unauthorized contentBinary
             | _ -> return GetTransactionsOutgoingByToken.NotFound contentBinary
@@ -1656,7 +1656,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.postAsync url "/transactions/{token}/outgoing/done" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PostTransactionsOutgoingDoneByToken.NoContent
             | _ -> return PostTransactionsOutgoingDoneByToken.Unauthorized
         }
@@ -1679,7 +1679,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.postAsync url "/transactions/{token}/outgoing/failed" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PostTransactionsOutgoingFailedByToken.NoContent
             | _ -> return PostTransactionsOutgoingFailedByToken.Unauthorized
         }
@@ -1693,7 +1693,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("token", token) ]
             let! (status, content) = OpenApiHttp.getAsync url "/transactions/{token}/outgoing/poll" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
             | 401 -> return GetTransactionsOutgoingPollByToken.Unauthorized
             | _ -> return GetTransactionsOutgoingPollByToken.NotFound
@@ -1712,7 +1712,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/transactions/{token}/status" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetTransactionsStatusByToken.OK
             | 401 -> return GetTransactionsStatusByToken.Unauthorized
             | _ -> return GetTransactionsStatusByToken.NotFound
@@ -1733,7 +1733,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/transactions/{token}/status" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PutTransactionsStatusByToken.NoContent
             | _ -> return PutTransactionsStatusByToken.NotFound
         }
@@ -1773,7 +1773,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/users/current" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetUsersCurrent.OK(Serializer.deserialize content)
             | _ -> return GetUsersCurrent.NotFound
         }
@@ -1786,7 +1786,7 @@ type FableSliceboxClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent userPass ]
             let! (status, content) = OpenApiHttp.postAsync url "/users/login" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return PostUsersLogin.Created
             | _ -> return PostUsersLogin.Unauthorized
         }

--- a/examples/FableTwinehealth/Client.fs
+++ b/examples/FableTwinehealth/Client.fs
@@ -52,14 +52,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/action" headers requestParts
 
-            if status = 201 then
-                return CreateAction.Created(Serializer.deserialize content)
-            else if status = 401 then
-                return CreateAction.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreateAction.Forbidden(Serializer.deserialize content)
-            else
-                return CreateAction.Conflict(Serializer.deserialize content)
+            match status with
+            | 201 -> return CreateAction.Created(Serializer.deserialize content)
+            | 401 -> return CreateAction.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateAction.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateAction.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -71,12 +68,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/action/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchAction.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchAction.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchAction.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchAction.OK(Serializer.deserialize content)
+            | 401 -> return FetchAction.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchAction.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -92,14 +87,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/action/{id}" headers requestParts
 
-            if status = 200 then
-                return UpdateAction.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return UpdateAction.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return UpdateAction.Forbidden(Serializer.deserialize content)
-            else
-                return UpdateAction.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return UpdateAction.OK(Serializer.deserialize content)
+            | 401 -> return UpdateAction.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpdateAction.Forbidden(Serializer.deserialize content)
+            | _ -> return UpdateAction.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -110,14 +102,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bundle" headers requestParts
 
-            if status = 200 then
-                return CreateBundle.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return CreateBundle.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreateBundle.Forbidden(Serializer.deserialize content)
-            else
-                return CreateBundle.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return CreateBundle.OK(Serializer.deserialize content)
+            | 401 -> return CreateBundle.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateBundle.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateBundle.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -129,12 +118,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/bundle/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchBundle.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchBundle.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchBundle.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchBundle.OK(Serializer.deserialize content)
+            | 401 -> return FetchBundle.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchBundle.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -150,14 +137,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/bundle/{id}" headers requestParts
 
-            if status = 200 then
-                return UpdateBundle.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return UpdateBundle.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return UpdateBundle.Forbidden(Serializer.deserialize content)
-            else
-                return UpdateBundle.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return UpdateBundle.OK(Serializer.deserialize content)
+            | 401 -> return UpdateBundle.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpdateBundle.Forbidden(Serializer.deserialize content)
+            | _ -> return UpdateBundle.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -235,14 +219,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/calendar_event" headers requestParts
 
-            if status = 200 then
-                return FetchCalendarEvents.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchCalendarEvents.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return FetchCalendarEvents.Forbidden(Serializer.deserialize content)
-            else
-                return FetchCalendarEvents.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchCalendarEvents.OK(Serializer.deserialize content)
+            | 401 -> return FetchCalendarEvents.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchCalendarEvents.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchCalendarEvents.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -253,14 +234,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/calendar_event" headers requestParts
 
-            if status = 201 then
-                return CreateCalendarEvent.Created(Serializer.deserialize content)
-            else if status = 401 then
-                return CreateCalendarEvent.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreateCalendarEvent.Forbidden(Serializer.deserialize content)
-            else
-                return CreateCalendarEvent.Conflict(Serializer.deserialize content)
+            match status with
+            | 201 -> return CreateCalendarEvent.Created(Serializer.deserialize content)
+            | 401 -> return CreateCalendarEvent.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateCalendarEvent.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateCalendarEvent.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -272,12 +250,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/calendar_event/{id}" headers requestParts
 
-            if status = 200 then
-                return DeleteCalendarEvent.OK
-            else if status = 401 then
-                return DeleteCalendarEvent.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteCalendarEvent.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return DeleteCalendarEvent.OK
+            | 401 -> return DeleteCalendarEvent.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteCalendarEvent.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -289,12 +265,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/calendar_event/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchCalendarEvent.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchCalendarEvent.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchCalendarEvent.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchCalendarEvent.OK(Serializer.deserialize content)
+            | 401 -> return FetchCalendarEvent.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchCalendarEvent.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -310,14 +284,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/calendar_event/{id}" headers requestParts
 
-            if status = 200 then
-                return UpdateCalendarEvent.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return UpdateCalendarEvent.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return UpdateCalendarEvent.Forbidden(Serializer.deserialize content)
-            else
-                return UpdateCalendarEvent.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return UpdateCalendarEvent.OK(Serializer.deserialize content)
+            | 401 -> return UpdateCalendarEvent.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpdateCalendarEvent.Forbidden(Serializer.deserialize content)
+            | _ -> return UpdateCalendarEvent.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -328,14 +299,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/calendar_event_response" headers requestParts
 
-            if status = 201 then
-                return PostCreateCalendarEventResponse.Created(Serializer.deserialize content)
-            else if status = 401 then
-                return PostCreateCalendarEventResponse.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return PostCreateCalendarEventResponse.Forbidden(Serializer.deserialize content)
-            else
-                return PostCreateCalendarEventResponse.Conflict(Serializer.deserialize content)
+            match status with
+            | 201 -> return PostCreateCalendarEventResponse.Created(Serializer.deserialize content)
+            | 401 -> return PostCreateCalendarEventResponse.Unauthorized(Serializer.deserialize content)
+            | 403 -> return PostCreateCalendarEventResponse.Forbidden(Serializer.deserialize content)
+            | _ -> return PostCreateCalendarEventResponse.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -353,12 +321,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/coach" headers requestParts
 
-            if status = 200 then
-                return FetchCoaches.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchCoaches.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchCoaches.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchCoaches.OK(Serializer.deserialize content)
+            | 401 -> return FetchCoaches.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchCoaches.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -370,12 +336,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/coach/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchCoach.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchCoach.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchCoach.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchCoach.OK(Serializer.deserialize content)
+            | 401 -> return FetchCoach.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchCoach.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -409,14 +373,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/email_history" headers requestParts
 
-            if status = 200 then
-                return FetchEmailHistories.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchEmailHistories.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return FetchEmailHistories.Forbidden(Serializer.deserialize content)
-            else
-                return FetchEmailHistories.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchEmailHistories.OK(Serializer.deserialize content)
+            | 401 -> return FetchEmailHistories.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchEmailHistories.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchEmailHistories.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -428,12 +389,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/email_history/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchEmailHistory.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchEmailHistory.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchEmailHistory.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchEmailHistory.OK(Serializer.deserialize content)
+            | 401 -> return FetchEmailHistory.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchEmailHistory.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -450,12 +409,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/group" headers requestParts
 
-            if status = 200 then
-                return FetchGroups.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchGroups.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchGroups.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchGroups.OK(Serializer.deserialize content)
+            | 401 -> return FetchGroups.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchGroups.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -466,14 +423,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/group" headers requestParts
 
-            if status = 201 then
-                return CreateGroup.Created(Serializer.deserialize content)
-            else if status = 401 then
-                return CreateGroup.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreateGroup.Forbidden(Serializer.deserialize content)
-            else
-                return CreateGroup.Conflict(Serializer.deserialize content)
+            match status with
+            | 201 -> return CreateGroup.Created(Serializer.deserialize content)
+            | 401 -> return CreateGroup.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateGroup.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateGroup.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -485,12 +439,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/group/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchGroup.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchGroup.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchGroup.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchGroup.OK(Serializer.deserialize content)
+            | 401 -> return FetchGroup.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchGroup.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -536,14 +488,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile" headers requestParts
 
-            if status = 200 then
-                return FetchHealthProfiles.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchHealthProfiles.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return FetchHealthProfiles.Forbidden(Serializer.deserialize content)
-            else
-                return FetchHealthProfiles.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchHealthProfiles.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfiles.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchHealthProfiles.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchHealthProfiles.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -560,12 +509,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchHealthProfile.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchHealthProfile.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchHealthProfile.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchHealthProfile.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfile.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchHealthProfile.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -611,14 +558,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile_answer" headers requestParts
 
-            if status = 200 then
-                return FetchHealthProfileAnswers.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchHealthProfileAnswers.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return FetchHealthProfileAnswers.Forbidden(Serializer.deserialize content)
-            else
-                return FetchHealthProfileAnswers.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchHealthProfileAnswers.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfileAnswers.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchHealthProfileAnswers.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchHealthProfileAnswers.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -635,12 +579,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile_answer/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchHealthProfileAnswer.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchHealthProfileAnswer.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchHealthProfileAnswer.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchHealthProfileAnswer.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfileAnswer.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchHealthProfileAnswer.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -670,14 +612,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile_question" headers requestParts
 
-            if status = 200 then
-                return FetchHealthProfileQuestions.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchHealthProfileQuestions.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return FetchHealthProfileQuestions.Forbidden(Serializer.deserialize content)
-            else
-                return FetchHealthProfileQuestions.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchHealthProfileQuestions.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfileQuestions.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchHealthProfileQuestions.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchHealthProfileQuestions.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -694,12 +633,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile_question/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchHealthProfileQuestion.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchHealthProfileQuestion.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchHealthProfileQuestion.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchHealthProfileQuestion.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfileQuestion.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchHealthProfileQuestion.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -710,14 +647,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/health_question_definition" headers requestParts
 
-            if status = 200 then
-                return FetchHealthQuestionDefinitions.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchHealthQuestionDefinitions.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return FetchHealthQuestionDefinitions.Forbidden(Serializer.deserialize content)
-            else
-                return FetchHealthQuestionDefinitions.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchHealthQuestionDefinitions.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthQuestionDefinitions.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchHealthQuestionDefinitions.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchHealthQuestionDefinitions.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -729,12 +663,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/health_question_definition/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchHealthQuestionDefinition.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchHealthQuestionDefinition.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchHealthQuestionDefinition.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchHealthQuestionDefinition.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthQuestionDefinition.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchHealthQuestionDefinition.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -762,14 +694,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/oauth/token" headers requestParts
 
-            if status = 201 then
-                return CreateToken.Created(Serializer.deserialize content)
-            else if status = 401 then
-                return CreateToken.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreateToken.Forbidden(Serializer.deserialize content)
-            else
-                return CreateToken.Conflict(Serializer.deserialize content)
+            match status with
+            | 201 -> return CreateToken.Created(Serializer.deserialize content)
+            | 401 -> return CreateToken.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateToken.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateToken.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -781,12 +710,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/oauth/token/{id}/groups" headers requestParts
 
-            if status = 200 then
-                return FetchTokenGroups.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchTokenGroups.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchTokenGroups.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchTokenGroups.OK(Serializer.deserialize content)
+            | 401 -> return FetchTokenGroups.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchTokenGroups.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -798,12 +725,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/oauth/token/{id}/organization" headers requestParts
 
-            if status = 200 then
-                return FetchTokenOrganization.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchTokenOrganization.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchTokenOrganization.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchTokenOrganization.OK(Serializer.deserialize content)
+            | 401 -> return FetchTokenOrganization.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchTokenOrganization.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -815,12 +740,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/organization/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchOrganization.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchOrganization.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchOrganization.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchOrganization.OK(Serializer.deserialize content)
+            | 401 -> return FetchOrganization.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchOrganization.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -878,14 +801,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/patient" headers requestParts
 
-            if status = 200 then
-                return FetchPatients.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchPatients.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return FetchPatients.Forbidden(Serializer.deserialize content)
-            else
-                return FetchPatients.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchPatients.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatients.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchPatients.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchPatients.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -923,14 +843,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/patient" headers requestParts
 
-            if status = 201 then
-                return CreatePatient.Created(Serializer.deserialize content)
-            else if status = 401 then
-                return CreatePatient.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreatePatient.Forbidden(Serializer.deserialize content)
-            else
-                return CreatePatient.Conflict(Serializer.deserialize content)
+            match status with
+            | 201 -> return CreatePatient.Created(Serializer.deserialize content)
+            | 401 -> return CreatePatient.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreatePatient.Forbidden(Serializer.deserialize content)
+            | _ -> return CreatePatient.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -941,14 +858,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync url "/patient" headers requestParts
 
-            if status = 200 then
-                return UpsertPatient.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return UpsertPatient.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return UpsertPatient.Forbidden(Serializer.deserialize content)
-            else
-                return UpsertPatient.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return UpsertPatient.OK(Serializer.deserialize content)
+            | 401 -> return UpsertPatient.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpsertPatient.Forbidden(Serializer.deserialize content)
+            | _ -> return UpsertPatient.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -960,12 +874,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/patient/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchPatient.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchPatient.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatient.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchPatient.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatient.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatient.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -981,14 +893,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/patient/{id}" headers requestParts
 
-            if status = 200 then
-                return UpdatePatient.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return UpdatePatient.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return UpdatePatient.Forbidden(Serializer.deserialize content)
-            else
-                return UpdatePatient.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return UpdatePatient.OK(Serializer.deserialize content)
+            | 401 -> return UpdatePatient.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpdatePatient.Forbidden(Serializer.deserialize content)
+            | _ -> return UpdatePatient.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1000,12 +909,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/patient/{id}/coaches" headers requestParts
 
-            if status = 200 then
-                return FetchPatientCoaches.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchPatientCoaches.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientCoaches.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchPatientCoaches.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientCoaches.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatientCoaches.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1017,12 +924,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/patient/{id}/groups" headers requestParts
 
-            if status = 200 then
-                return FetchPatientGroups.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchPatientGroups.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientGroups.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchPatientGroups.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientGroups.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatientGroups.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1064,14 +969,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/patient_health_metric" headers requestParts
 
-            if status = 200 then
-                return FetchPatientHealthMetrics.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchPatientHealthMetrics.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return FetchPatientHealthMetrics.Forbidden(Serializer.deserialize content)
-            else
-                return FetchPatientHealthMetrics.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchPatientHealthMetrics.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientHealthMetrics.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchPatientHealthMetrics.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchPatientHealthMetrics.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1116,14 +1018,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/patient_health_metric" headers requestParts
 
-            if status = 200 then
-                return CreatePatientHealthMetric.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return CreatePatientHealthMetric.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreatePatientHealthMetric.Forbidden(Serializer.deserialize content)
-            else
-                return CreatePatientHealthMetric.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return CreatePatientHealthMetric.OK(Serializer.deserialize content)
+            | 401 -> return CreatePatientHealthMetric.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreatePatientHealthMetric.Forbidden(Serializer.deserialize content)
+            | _ -> return CreatePatientHealthMetric.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1135,12 +1034,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/patient_health_metric/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchPatientHealthMetric.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchPatientHealthMetric.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientHealthMetric.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchPatientHealthMetric.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientHealthMetric.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatientHealthMetric.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1170,12 +1067,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/patient_plan_summary" headers requestParts
 
-            if status = 200 then
-                return FetchPatientPlanSummaries.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchPatientPlanSummaries.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientPlanSummaries.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchPatientPlanSummaries.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientPlanSummaries.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatientPlanSummaries.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1192,12 +1087,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/patient_plan_summary/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchPatientPlanSummary.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchPatientPlanSummary.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientPlanSummary.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchPatientPlanSummary.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientPlanSummary.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatientPlanSummary.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1213,14 +1106,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/patient_plan_summary/{id}" headers requestParts
 
-            if status = 200 then
-                return UpdatePatientPlanSummary.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return UpdatePatientPlanSummary.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return UpdatePatientPlanSummary.Forbidden(Serializer.deserialize content)
-            else
-                return UpdatePatientPlanSummary.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return UpdatePatientPlanSummary.OK(Serializer.deserialize content)
+            | 401 -> return UpdatePatientPlanSummary.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpdatePatientPlanSummary.Forbidden(Serializer.deserialize content)
+            | _ -> return UpdatePatientPlanSummary.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1277,14 +1167,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/result" headers requestParts
 
-            if status = 200 then
-                return FetchPatientHealthResults.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchPatientHealthResults.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return FetchPatientHealthResults.Forbidden(Serializer.deserialize content)
-            else
-                return FetchPatientHealthResults.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchPatientHealthResults.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientHealthResults.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchPatientHealthResults.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchPatientHealthResults.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1296,12 +1183,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/result/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchPatientHealthResult.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchPatientHealthResult.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientHealthResult.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchPatientHealthResult.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientHealthResult.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatientHealthResult.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1335,12 +1220,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/reward" headers requestParts
 
-            if status = 200 then
-                return FetchRewards.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchRewards.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewards.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchRewards.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewards.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewards.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1351,14 +1234,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/reward" headers requestParts
 
-            if status = 200 then
-                return CreateReward.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return CreateReward.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreateReward.Forbidden(Serializer.deserialize content)
-            else
-                return CreateReward.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return CreateReward.OK(Serializer.deserialize content)
+            | 401 -> return CreateReward.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateReward.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateReward.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1370,12 +1250,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchReward.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchReward.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchReward.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchReward.OK(Serializer.deserialize content)
+            | 401 -> return FetchReward.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchReward.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1394,12 +1272,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/reward_earning" headers requestParts
 
-            if status = 200 then
-                return FetchRewardEarnings.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchRewardEarnings.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardEarnings.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchRewardEarnings.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardEarnings.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardEarnings.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1410,14 +1286,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/reward_earning" headers requestParts
 
-            if status = 200 then
-                return CreateRewardEarning.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return CreateRewardEarning.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreateRewardEarning.Forbidden(Serializer.deserialize content)
-            else
-                return CreateRewardEarning.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return CreateRewardEarning.OK(Serializer.deserialize content)
+            | 401 -> return CreateRewardEarning.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateRewardEarning.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateRewardEarning.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1429,12 +1302,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward_earning/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchRewardEarning.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchRewardEarning.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardEarning.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchRewardEarning.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardEarning.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardEarning.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1448,12 +1319,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/reward_earning_fulfillment" headers requestParts
 
-            if status = 200 then
-                return FetchRewardEarningFulfillments.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchRewardEarningFulfillments.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardEarningFulfillments.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchRewardEarningFulfillments.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardEarningFulfillments.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardEarningFulfillments.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1464,14 +1333,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/reward_earning_fulfillment" headers requestParts
 
-            if status = 200 then
-                return CreateRewardEarningFulfillment.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return CreateRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreateRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
-            else
-                return CreateRewardEarningFulfillment.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return CreateRewardEarningFulfillment.OK(Serializer.deserialize content)
+            | 401 -> return CreateRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateRewardEarningFulfillment.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1483,12 +1349,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward_earning_fulfillment/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchRewardEarningFulfillment.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchRewardEarningFulfillment.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1506,12 +1370,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/reward_program" headers requestParts
 
-            if status = 200 then
-                return FetchRewardPrograms.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchRewardPrograms.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardPrograms.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchRewardPrograms.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardPrograms.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardPrograms.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1522,14 +1384,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/reward_program" headers requestParts
 
-            if status = 200 then
-                return CreateRewardProgram.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return CreateRewardProgram.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreateRewardProgram.Forbidden(Serializer.deserialize content)
-            else
-                return CreateRewardProgram.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return CreateRewardProgram.OK(Serializer.deserialize content)
+            | 401 -> return CreateRewardProgram.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateRewardProgram.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateRewardProgram.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1541,12 +1400,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward_program/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchRewardProgram.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchRewardProgram.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardProgram.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchRewardProgram.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardProgram.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardProgram.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1558,12 +1415,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward_program/{id}/group" headers requestParts
 
-            if status = 200 then
-                return FetchRewardProgramGroup.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchRewardProgramGroup.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardProgramGroup.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchRewardProgramGroup.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardProgramGroup.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardProgramGroup.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1589,12 +1444,10 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/reward_program_activation" headers requestParts
 
-            if status = 200 then
-                return FetchRewardProgramActivations.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchRewardProgramActivations.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardProgramActivations.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchRewardProgramActivations.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardProgramActivations.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardProgramActivations.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1605,14 +1458,11 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/reward_program_activation" headers requestParts
 
-            if status = 200 then
-                return CreateRewardProgramActivation.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return CreateRewardProgramActivation.Unauthorized(Serializer.deserialize content)
-            else if status = 403 then
-                return CreateRewardProgramActivation.Forbidden(Serializer.deserialize content)
-            else
-                return CreateRewardProgramActivation.Conflict(Serializer.deserialize content)
+            match status with
+            | 200 -> return CreateRewardProgramActivation.OK(Serializer.deserialize content)
+            | 401 -> return CreateRewardProgramActivation.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateRewardProgramActivation.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateRewardProgramActivation.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1624,10 +1474,8 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward_program_activation/{id}" headers requestParts
 
-            if status = 200 then
-                return FetchRewardProgramActivation.OK(Serializer.deserialize content)
-            else if status = 401 then
-                return FetchRewardProgramActivation.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardProgramActivation.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return FetchRewardProgramActivation.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardProgramActivation.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardProgramActivation.Forbidden(Serializer.deserialize content)
         }

--- a/examples/FableTwinehealth/Client.fs
+++ b/examples/FableTwinehealth/Client.fs
@@ -52,7 +52,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/action" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return CreateAction.Created(Serializer.deserialize content)
             | 401 -> return CreateAction.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreateAction.Forbidden(Serializer.deserialize content)
@@ -68,7 +68,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/action/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchAction.OK(Serializer.deserialize content)
             | 401 -> return FetchAction.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchAction.Forbidden(Serializer.deserialize content)
@@ -87,7 +87,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/action/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpdateAction.OK(Serializer.deserialize content)
             | 401 -> return UpdateAction.Unauthorized(Serializer.deserialize content)
             | 403 -> return UpdateAction.Forbidden(Serializer.deserialize content)
@@ -102,7 +102,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/bundle" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateBundle.OK(Serializer.deserialize content)
             | 401 -> return CreateBundle.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreateBundle.Forbidden(Serializer.deserialize content)
@@ -118,7 +118,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/bundle/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchBundle.OK(Serializer.deserialize content)
             | 401 -> return FetchBundle.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchBundle.Forbidden(Serializer.deserialize content)
@@ -137,7 +137,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/bundle/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpdateBundle.OK(Serializer.deserialize content)
             | 401 -> return UpdateBundle.Unauthorized(Serializer.deserialize content)
             | 403 -> return UpdateBundle.Forbidden(Serializer.deserialize content)
@@ -219,7 +219,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/calendar_event" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchCalendarEvents.OK(Serializer.deserialize content)
             | 401 -> return FetchCalendarEvents.Unauthorized(Serializer.deserialize content)
             | 403 -> return FetchCalendarEvents.Forbidden(Serializer.deserialize content)
@@ -234,7 +234,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/calendar_event" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return CreateCalendarEvent.Created(Serializer.deserialize content)
             | 401 -> return CreateCalendarEvent.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreateCalendarEvent.Forbidden(Serializer.deserialize content)
@@ -250,7 +250,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/calendar_event/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteCalendarEvent.OK
             | 401 -> return DeleteCalendarEvent.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteCalendarEvent.Forbidden(Serializer.deserialize content)
@@ -265,7 +265,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/calendar_event/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchCalendarEvent.OK(Serializer.deserialize content)
             | 401 -> return FetchCalendarEvent.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchCalendarEvent.Forbidden(Serializer.deserialize content)
@@ -284,7 +284,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/calendar_event/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpdateCalendarEvent.OK(Serializer.deserialize content)
             | 401 -> return UpdateCalendarEvent.Unauthorized(Serializer.deserialize content)
             | 403 -> return UpdateCalendarEvent.Forbidden(Serializer.deserialize content)
@@ -299,7 +299,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/calendar_event_response" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return PostCreateCalendarEventResponse.Created(Serializer.deserialize content)
             | 401 -> return PostCreateCalendarEventResponse.Unauthorized(Serializer.deserialize content)
             | 403 -> return PostCreateCalendarEventResponse.Forbidden(Serializer.deserialize content)
@@ -321,7 +321,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/coach" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchCoaches.OK(Serializer.deserialize content)
             | 401 -> return FetchCoaches.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchCoaches.Forbidden(Serializer.deserialize content)
@@ -336,7 +336,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/coach/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchCoach.OK(Serializer.deserialize content)
             | 401 -> return FetchCoach.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchCoach.Forbidden(Serializer.deserialize content)
@@ -373,7 +373,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/email_history" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchEmailHistories.OK(Serializer.deserialize content)
             | 401 -> return FetchEmailHistories.Unauthorized(Serializer.deserialize content)
             | 403 -> return FetchEmailHistories.Forbidden(Serializer.deserialize content)
@@ -389,7 +389,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/email_history/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchEmailHistory.OK(Serializer.deserialize content)
             | 401 -> return FetchEmailHistory.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchEmailHistory.Forbidden(Serializer.deserialize content)
@@ -409,7 +409,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/group" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchGroups.OK(Serializer.deserialize content)
             | 401 -> return FetchGroups.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchGroups.Forbidden(Serializer.deserialize content)
@@ -423,7 +423,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/group" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return CreateGroup.Created(Serializer.deserialize content)
             | 401 -> return CreateGroup.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreateGroup.Forbidden(Serializer.deserialize content)
@@ -439,7 +439,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/group/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchGroup.OK(Serializer.deserialize content)
             | 401 -> return FetchGroup.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchGroup.Forbidden(Serializer.deserialize content)
@@ -488,7 +488,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchHealthProfiles.OK(Serializer.deserialize content)
             | 401 -> return FetchHealthProfiles.Unauthorized(Serializer.deserialize content)
             | 403 -> return FetchHealthProfiles.Forbidden(Serializer.deserialize content)
@@ -509,7 +509,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchHealthProfile.OK(Serializer.deserialize content)
             | 401 -> return FetchHealthProfile.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchHealthProfile.Forbidden(Serializer.deserialize content)
@@ -558,7 +558,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile_answer" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchHealthProfileAnswers.OK(Serializer.deserialize content)
             | 401 -> return FetchHealthProfileAnswers.Unauthorized(Serializer.deserialize content)
             | 403 -> return FetchHealthProfileAnswers.Forbidden(Serializer.deserialize content)
@@ -579,7 +579,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile_answer/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchHealthProfileAnswer.OK(Serializer.deserialize content)
             | 401 -> return FetchHealthProfileAnswer.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchHealthProfileAnswer.Forbidden(Serializer.deserialize content)
@@ -612,7 +612,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile_question" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchHealthProfileQuestions.OK(Serializer.deserialize content)
             | 401 -> return FetchHealthProfileQuestions.Unauthorized(Serializer.deserialize content)
             | 403 -> return FetchHealthProfileQuestions.Forbidden(Serializer.deserialize content)
@@ -633,7 +633,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/health_profile_question/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchHealthProfileQuestion.OK(Serializer.deserialize content)
             | 401 -> return FetchHealthProfileQuestion.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchHealthProfileQuestion.Forbidden(Serializer.deserialize content)
@@ -647,7 +647,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/health_question_definition" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchHealthQuestionDefinitions.OK(Serializer.deserialize content)
             | 401 -> return FetchHealthQuestionDefinitions.Unauthorized(Serializer.deserialize content)
             | 403 -> return FetchHealthQuestionDefinitions.Forbidden(Serializer.deserialize content)
@@ -663,7 +663,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/health_question_definition/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchHealthQuestionDefinition.OK(Serializer.deserialize content)
             | 401 -> return FetchHealthQuestionDefinition.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchHealthQuestionDefinition.Forbidden(Serializer.deserialize content)
@@ -694,7 +694,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/oauth/token" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return CreateToken.Created(Serializer.deserialize content)
             | 401 -> return CreateToken.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreateToken.Forbidden(Serializer.deserialize content)
@@ -710,7 +710,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/oauth/token/{id}/groups" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchTokenGroups.OK(Serializer.deserialize content)
             | 401 -> return FetchTokenGroups.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchTokenGroups.Forbidden(Serializer.deserialize content)
@@ -725,7 +725,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/oauth/token/{id}/organization" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchTokenOrganization.OK(Serializer.deserialize content)
             | 401 -> return FetchTokenOrganization.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchTokenOrganization.Forbidden(Serializer.deserialize content)
@@ -740,7 +740,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/organization/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchOrganization.OK(Serializer.deserialize content)
             | 401 -> return FetchOrganization.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchOrganization.Forbidden(Serializer.deserialize content)
@@ -801,7 +801,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/patient" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchPatients.OK(Serializer.deserialize content)
             | 401 -> return FetchPatients.Unauthorized(Serializer.deserialize content)
             | 403 -> return FetchPatients.Forbidden(Serializer.deserialize content)
@@ -843,7 +843,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/patient" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return CreatePatient.Created(Serializer.deserialize content)
             | 401 -> return CreatePatient.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreatePatient.Forbidden(Serializer.deserialize content)
@@ -858,7 +858,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync url "/patient" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpsertPatient.OK(Serializer.deserialize content)
             | 401 -> return UpsertPatient.Unauthorized(Serializer.deserialize content)
             | 403 -> return UpsertPatient.Forbidden(Serializer.deserialize content)
@@ -874,7 +874,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/patient/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchPatient.OK(Serializer.deserialize content)
             | 401 -> return FetchPatient.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatient.Forbidden(Serializer.deserialize content)
@@ -893,7 +893,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/patient/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpdatePatient.OK(Serializer.deserialize content)
             | 401 -> return UpdatePatient.Unauthorized(Serializer.deserialize content)
             | 403 -> return UpdatePatient.Forbidden(Serializer.deserialize content)
@@ -909,7 +909,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/patient/{id}/coaches" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchPatientCoaches.OK(Serializer.deserialize content)
             | 401 -> return FetchPatientCoaches.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientCoaches.Forbidden(Serializer.deserialize content)
@@ -924,7 +924,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/patient/{id}/groups" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchPatientGroups.OK(Serializer.deserialize content)
             | 401 -> return FetchPatientGroups.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientGroups.Forbidden(Serializer.deserialize content)
@@ -969,7 +969,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/patient_health_metric" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchPatientHealthMetrics.OK(Serializer.deserialize content)
             | 401 -> return FetchPatientHealthMetrics.Unauthorized(Serializer.deserialize content)
             | 403 -> return FetchPatientHealthMetrics.Forbidden(Serializer.deserialize content)
@@ -1018,7 +1018,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/patient_health_metric" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreatePatientHealthMetric.OK(Serializer.deserialize content)
             | 401 -> return CreatePatientHealthMetric.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreatePatientHealthMetric.Forbidden(Serializer.deserialize content)
@@ -1034,7 +1034,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/patient_health_metric/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchPatientHealthMetric.OK(Serializer.deserialize content)
             | 401 -> return FetchPatientHealthMetric.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientHealthMetric.Forbidden(Serializer.deserialize content)
@@ -1067,7 +1067,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/patient_plan_summary" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchPatientPlanSummaries.OK(Serializer.deserialize content)
             | 401 -> return FetchPatientPlanSummaries.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientPlanSummaries.Forbidden(Serializer.deserialize content)
@@ -1087,7 +1087,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/patient_plan_summary/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchPatientPlanSummary.OK(Serializer.deserialize content)
             | 401 -> return FetchPatientPlanSummary.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientPlanSummary.Forbidden(Serializer.deserialize content)
@@ -1106,7 +1106,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/patient_plan_summary/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpdatePatientPlanSummary.OK(Serializer.deserialize content)
             | 401 -> return UpdatePatientPlanSummary.Unauthorized(Serializer.deserialize content)
             | 403 -> return UpdatePatientPlanSummary.Forbidden(Serializer.deserialize content)
@@ -1167,7 +1167,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/result" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchPatientHealthResults.OK(Serializer.deserialize content)
             | 401 -> return FetchPatientHealthResults.Unauthorized(Serializer.deserialize content)
             | 403 -> return FetchPatientHealthResults.Forbidden(Serializer.deserialize content)
@@ -1183,7 +1183,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/result/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchPatientHealthResult.OK(Serializer.deserialize content)
             | 401 -> return FetchPatientHealthResult.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientHealthResult.Forbidden(Serializer.deserialize content)
@@ -1220,7 +1220,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/reward" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchRewards.OK(Serializer.deserialize content)
             | 401 -> return FetchRewards.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewards.Forbidden(Serializer.deserialize content)
@@ -1234,7 +1234,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/reward" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateReward.OK(Serializer.deserialize content)
             | 401 -> return CreateReward.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreateReward.Forbidden(Serializer.deserialize content)
@@ -1250,7 +1250,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchReward.OK(Serializer.deserialize content)
             | 401 -> return FetchReward.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchReward.Forbidden(Serializer.deserialize content)
@@ -1272,7 +1272,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/reward_earning" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchRewardEarnings.OK(Serializer.deserialize content)
             | 401 -> return FetchRewardEarnings.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardEarnings.Forbidden(Serializer.deserialize content)
@@ -1286,7 +1286,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/reward_earning" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateRewardEarning.OK(Serializer.deserialize content)
             | 401 -> return CreateRewardEarning.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreateRewardEarning.Forbidden(Serializer.deserialize content)
@@ -1302,7 +1302,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward_earning/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchRewardEarning.OK(Serializer.deserialize content)
             | 401 -> return FetchRewardEarning.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardEarning.Forbidden(Serializer.deserialize content)
@@ -1319,7 +1319,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/reward_earning_fulfillment" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchRewardEarningFulfillments.OK(Serializer.deserialize content)
             | 401 -> return FetchRewardEarningFulfillments.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardEarningFulfillments.Forbidden(Serializer.deserialize content)
@@ -1333,7 +1333,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/reward_earning_fulfillment" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateRewardEarningFulfillment.OK(Serializer.deserialize content)
             | 401 -> return CreateRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreateRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
@@ -1349,7 +1349,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward_earning_fulfillment/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchRewardEarningFulfillment.OK(Serializer.deserialize content)
             | 401 -> return FetchRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
@@ -1370,7 +1370,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/reward_program" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchRewardPrograms.OK(Serializer.deserialize content)
             | 401 -> return FetchRewardPrograms.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardPrograms.Forbidden(Serializer.deserialize content)
@@ -1384,7 +1384,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/reward_program" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateRewardProgram.OK(Serializer.deserialize content)
             | 401 -> return CreateRewardProgram.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreateRewardProgram.Forbidden(Serializer.deserialize content)
@@ -1400,7 +1400,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward_program/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchRewardProgram.OK(Serializer.deserialize content)
             | 401 -> return FetchRewardProgram.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardProgram.Forbidden(Serializer.deserialize content)
@@ -1415,7 +1415,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward_program/{id}/group" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchRewardProgramGroup.OK(Serializer.deserialize content)
             | 401 -> return FetchRewardProgramGroup.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardProgramGroup.Forbidden(Serializer.deserialize content)
@@ -1444,7 +1444,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/reward_program_activation" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchRewardProgramActivations.OK(Serializer.deserialize content)
             | 401 -> return FetchRewardProgramActivations.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardProgramActivations.Forbidden(Serializer.deserialize content)
@@ -1458,7 +1458,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/reward_program_activation" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateRewardProgramActivation.OK(Serializer.deserialize content)
             | 401 -> return CreateRewardProgramActivation.Unauthorized(Serializer.deserialize content)
             | 403 -> return CreateRewardProgramActivation.Forbidden(Serializer.deserialize content)
@@ -1474,7 +1474,7 @@ type FableTwinehealthClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/reward_program_activation/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FetchRewardProgramActivation.OK(Serializer.deserialize content)
             | 401 -> return FetchRewardProgramActivation.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardProgramActivation.Forbidden(Serializer.deserialize content)

--- a/examples/FableWatchful/Client.fs
+++ b/examples/FableWatchful/Client.fs
@@ -26,10 +26,9 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/audits" headers requestParts
 
-            if status = 200 then
-                return GetAudits.OK(Serializer.deserialize content)
-            else
-                return GetAudits.Forbidden
+            match status with
+            | 200 -> return GetAudits.OK(Serializer.deserialize content)
+            | _ -> return GetAudits.Forbidden
         }
 
     ///<summary>
@@ -51,12 +50,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/audits/{id}" headers requestParts
 
-            if status = 200 then
-                return DeleteAuditById.OK content
-            else if status = 403 then
-                return DeleteAuditById.Forbidden
-            else
-                return DeleteAuditById.NotFound
+            match status with
+            | 200 -> return DeleteAuditById.OK content
+            | 403 -> return DeleteAuditById.Forbidden
+            | _ -> return DeleteAuditById.NotFound
         }
 
     ///<summary>
@@ -73,12 +70,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/audits/{id}" headers requestParts
 
-            if status = 200 then
-                return GetAuditById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetAuditById.BadRequest
-            else
-                return GetAuditById.Forbidden
+            match status with
+            | 200 -> return GetAuditById.OK(Serializer.deserialize content)
+            | 400 -> return GetAuditById.BadRequest
+            | _ -> return GetAuditById.Forbidden
         }
 
     ///<summary>
@@ -128,12 +123,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/extensions" headers requestParts
 
-            if status = 200 then
-                return GetExtensions.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return GetExtensions.Forbidden
-            else
-                return GetExtensions.NotFound
+            match status with
+            | 200 -> return GetExtensions.OK(Serializer.deserialize content)
+            | 403 -> return GetExtensions.Forbidden
+            | _ -> return GetExtensions.NotFound
         }
 
     ///<summary>
@@ -155,10 +148,9 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/extensions/{id}/ignore" headers requestParts
 
-            if status = 200 then
-                return IgnoreExtensionUpdate.OK content
-            else
-                return IgnoreExtensionUpdate.NotFound
+            match status with
+            | 200 -> return IgnoreExtensionUpdate.OK content
+            | _ -> return IgnoreExtensionUpdate.NotFound
         }
 
     ///<summary>
@@ -170,10 +162,9 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/extensions/{id}/unignore" headers requestParts
 
-            if status = 200 then
-                return UnignoreExtensionUpdate.OK content
-            else
-                return UnignoreExtensionUpdate.NotFound
+            match status with
+            | 200 -> return UnignoreExtensionUpdate.OK content
+            | _ -> return UnignoreExtensionUpdate.NotFound
         }
 
     ///<summary>
@@ -185,10 +176,9 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/extensions/{id}/update" headers requestParts
 
-            if status = 200 then
-                return UpdateExtension.OK content
-            else
-                return UpdateExtension.NotFound
+            match status with
+            | 200 -> return UpdateExtension.OK content
+            | _ -> return UpdateExtension.NotFound
         }
 
     ///<summary>
@@ -203,10 +193,9 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/feedbacks" headers requestParts
 
-            if status = 200 then
-                return GetFeedbacks.OK(Serializer.deserialize content)
-            else
-                return GetFeedbacks.Forbidden
+            match status with
+            | 200 -> return GetFeedbacks.OK(Serializer.deserialize content)
+            | _ -> return GetFeedbacks.Forbidden
         }
 
     ///<summary>
@@ -217,16 +206,12 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/feedbacks" headers requestParts
 
-            if status = 200 then
-                return CreateFeedbacks.OK(Serializer.deserialize content)
-            else if status = 201 then
-                return CreateFeedbacks.Created
-            else if status = 400 then
-                return CreateFeedbacks.BadRequest
-            else if status = 403 then
-                return CreateFeedbacks.Forbidden
-            else
-                return CreateFeedbacks.NotFound
+            match status with
+            | 200 -> return CreateFeedbacks.OK(Serializer.deserialize content)
+            | 201 -> return CreateFeedbacks.Created
+            | 400 -> return CreateFeedbacks.BadRequest
+            | 403 -> return CreateFeedbacks.Forbidden
+            | _ -> return CreateFeedbacks.NotFound
         }
 
     ///<summary>
@@ -282,10 +267,9 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/logs" headers requestParts
 
-            if status = 200 then
-                return GetLogs.OK(Serializer.deserialize content)
-            else
-                return GetLogs.Forbidden
+            match status with
+            | 200 -> return GetLogs.OK(Serializer.deserialize content)
+            | _ -> return GetLogs.Forbidden
         }
 
     ///<summary>
@@ -330,10 +314,9 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/logs/export" headers requestParts
 
-            if status = 200 then
-                return GetExportLogs.OK
-            else
-                return GetExportLogs.Forbidden
+            match status with
+            | 200 -> return GetExportLogs.OK
+            | _ -> return GetExportLogs.Forbidden
         }
 
     ///<summary>
@@ -365,12 +348,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/logs/{id}" headers requestParts
 
-            if status = 200 then
-                return DeleteLogById.OK content
-            else if status = 403 then
-                return DeleteLogById.Forbidden
-            else
-                return DeleteLogById.NotFound
+            match status with
+            | 200 -> return DeleteLogById.OK content
+            | 403 -> return DeleteLogById.Forbidden
+            | _ -> return DeleteLogById.NotFound
         }
 
     member this.PostPackages() =
@@ -414,12 +395,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, contentBinary) = OpenApiHttp.getBinaryAsync url "/reports/sites/{id}" headers requestParts
 
-            if status = 200 then
-                return GetReportsSitesById.OK contentBinary
-            else if status = 403 then
-                return GetReportsSitesById.Forbidden contentBinary
-            else
-                return GetReportsSitesById.NotFound contentBinary
+            match status with
+            | 200 -> return GetReportsSitesById.OK contentBinary
+            | 403 -> return GetReportsSitesById.Forbidden contentBinary
+            | _ -> return GetReportsSitesById.NotFound contentBinary
         }
 
     ///<summary>
@@ -456,12 +435,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, contentBinary) = OpenApiHttp.getBinaryAsync url "/reports/tags/{id}" headers requestParts
 
-            if status = 200 then
-                return GetReportsTagsById.OK contentBinary
-            else if status = 403 then
-                return GetReportsTagsById.Forbidden contentBinary
-            else
-                return GetReportsTagsById.NotFound contentBinary
+            match status with
+            | 200 -> return GetReportsTagsById.OK contentBinary
+            | 403 -> return GetReportsTagsById.Forbidden contentBinary
+            | _ -> return GetReportsTagsById.NotFound contentBinary
         }
 
     ///<summary>
@@ -535,12 +512,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites" headers requestParts
 
-            if status = 200 then
-                return GetSites.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return GetSites.Forbidden
-            else
-                return GetSites.NotFound
+            match status with
+            | 200 -> return GetSites.OK(Serializer.deserialize content)
+            | 403 -> return GetSites.Forbidden
+            | _ -> return GetSites.NotFound
         }
 
     ///<summary>
@@ -551,16 +526,12 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites" headers requestParts
 
-            if status = 200 then
-                return CreateSite.OK(Serializer.deserialize content)
-            else if status = 201 then
-                return CreateSite.Created
-            else if status = 400 then
-                return CreateSite.BadRequest
-            else if status = 403 then
-                return CreateSite.Forbidden
-            else
-                return CreateSite.NotFound
+            match status with
+            | 200 -> return CreateSite.OK(Serializer.deserialize content)
+            | 201 -> return CreateSite.Created
+            | 400 -> return CreateSite.BadRequest
+            | 403 -> return CreateSite.Forbidden
+            | _ -> return CreateSite.NotFound
         }
 
     ///<summary>
@@ -582,12 +553,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/sites/{id}" headers requestParts
 
-            if status = 200 then
-                return DeleteSitesById.OK content
-            else if status = 403 then
-                return DeleteSitesById.Forbidden
-            else
-                return DeleteSitesById.NotFound
+            match status with
+            | 200 -> return DeleteSitesById.OK content
+            | 403 -> return DeleteSitesById.Forbidden
+            | _ -> return DeleteSitesById.NotFound
         }
 
     ///<summary>
@@ -604,12 +573,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}" headers requestParts
 
-            if status = 200 then
-                return GetSiteById.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return GetSiteById.Forbidden
-            else
-                return GetSiteById.NotFound
+            match status with
+            | 200 -> return GetSiteById.OK(Serializer.deserialize content)
+            | 403 -> return GetSiteById.Forbidden
+            | _ -> return GetSiteById.NotFound
         }
 
     ///<summary>
@@ -625,14 +592,11 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/sites/{id}" headers requestParts
 
-            if status = 200 then
-                return PutSitesById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return PutSitesById.BadRequest
-            else if status = 403 then
-                return PutSitesById.Forbidden
-            else
-                return PutSitesById.NotFound
+            match status with
+            | 200 -> return PutSitesById.OK(Serializer.deserialize content)
+            | 400 -> return PutSitesById.BadRequest
+            | 403 -> return PutSitesById.Forbidden
+            | _ -> return PutSitesById.NotFound
         }
 
     ///<summary>
@@ -658,12 +622,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/audits" headers requestParts
 
-            if status = 200 then
-                return GetSiteAudits.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return GetSiteAudits.Forbidden
-            else
-                return GetSiteAudits.NotFound
+            match status with
+            | 200 -> return GetSiteAudits.OK(Serializer.deserialize content)
+            | 403 -> return GetSiteAudits.Forbidden
+            | _ -> return GetSiteAudits.NotFound
         }
 
     ///<summary>
@@ -675,16 +637,12 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/audits" headers requestParts
 
-            if status = 200 then
-                return CreateAudits.OK(Serializer.deserialize content)
-            else if status = 201 then
-                return CreateAudits.Created
-            else if status = 400 then
-                return CreateAudits.BadRequest
-            else if status = 403 then
-                return CreateAudits.Forbidden
-            else
-                return CreateAudits.NotFound
+            match status with
+            | 200 -> return CreateAudits.OK(Serializer.deserialize content)
+            | 201 -> return CreateAudits.Created
+            | 400 -> return CreateAudits.BadRequest
+            | 403 -> return CreateAudits.Forbidden
+            | _ -> return CreateAudits.NotFound
         }
 
     ///<summary>
@@ -696,12 +654,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/backupnow" headers requestParts
 
-            if status = 200 then
-                return AddSiteToBackupQueue.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return AddSiteToBackupQueue.Forbidden
-            else
-                return AddSiteToBackupQueue.NotFound
+            match status with
+            | 200 -> return AddSiteToBackupQueue.OK(Serializer.deserialize content)
+            | 403 -> return AddSiteToBackupQueue.Forbidden
+            | _ -> return AddSiteToBackupQueue.NotFound
         }
 
     ///<summary>
@@ -713,12 +669,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/backupprofiles" headers requestParts
 
-            if status = 200 then
-                return GetBackupProfiles.OK
-            else if status = 403 then
-                return GetBackupProfiles.Forbidden
-            else
-                return GetBackupProfiles.NotFound
+            match status with
+            | 200 -> return GetBackupProfiles.OK
+            | 403 -> return GetBackupProfiles.Forbidden
+            | _ -> return GetBackupProfiles.NotFound
         }
 
     ///<summary>
@@ -730,12 +684,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/backups" headers requestParts
 
-            if status = 200 then
-                return GetListBackups.OK
-            else if status = 403 then
-                return GetListBackups.Forbidden
-            else
-                return GetListBackups.NotFound
+            match status with
+            | 200 -> return GetListBackups.OK
+            | 403 -> return GetListBackups.Forbidden
+            | _ -> return GetListBackups.NotFound
         }
 
     ///<summary>
@@ -747,12 +699,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/backupstart" headers requestParts
 
-            if status = 200 then
-                return StartSiteBackup.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return StartSiteBackup.Forbidden
-            else
-                return StartSiteBackup.NotFound
+            match status with
+            | 200 -> return StartSiteBackup.OK(Serializer.deserialize content)
+            | 403 -> return StartSiteBackup.Forbidden
+            | _ -> return StartSiteBackup.NotFound
         }
 
     ///<summary>
@@ -764,12 +714,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/backupstep" headers requestParts
 
-            if status = 200 then
-                return StepSiteBackup.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return StepSiteBackup.Forbidden
-            else
-                return StepSiteBackup.NotFound
+            match status with
+            | 200 -> return StepSiteBackup.OK(Serializer.deserialize content)
+            | 403 -> return StepSiteBackup.Forbidden
+            | _ -> return StepSiteBackup.NotFound
         }
 
     ///<summary>
@@ -795,12 +743,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/extensions" headers requestParts
 
-            if status = 200 then
-                return GetSitesExtensionsById.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return GetSitesExtensionsById.Forbidden
-            else
-                return GetSitesExtensionsById.NotFound
+            match status with
+            | 200 -> return GetSitesExtensionsById.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesExtensionsById.Forbidden
+            | _ -> return GetSitesExtensionsById.NotFound
         }
 
     ///<summary>
@@ -816,12 +762,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/extensions" headers requestParts
 
-            if status = 200 then
-                return InstallExtension.OK
-            else if status = 403 then
-                return InstallExtension.Forbidden
-            else
-                return InstallExtension.NotFound
+            match status with
+            | 200 -> return InstallExtension.OK
+            | 403 -> return InstallExtension.Forbidden
+            | _ -> return InstallExtension.NotFound
         }
 
     ///<summary>
@@ -870,12 +814,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/logs" headers requestParts
 
-            if status = 200 then
-                return GetSitesLogsById.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return GetSitesLogsById.Forbidden
-            else
-                return GetSitesLogsById.NotFound
+            match status with
+            | 200 -> return GetSitesLogsById.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesLogsById.Forbidden
+            | _ -> return GetSitesLogsById.NotFound
         }
 
     ///<summary>
@@ -891,16 +833,12 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/logs" headers requestParts
 
-            if status = 200 then
-                return CreateLog.OK(Serializer.deserialize content)
-            else if status = 201 then
-                return CreateLog.Created
-            else if status = 400 then
-                return CreateLog.BadRequest
-            else if status = 403 then
-                return CreateLog.Forbidden
-            else
-                return CreateLog.NotFound
+            match status with
+            | 200 -> return CreateLog.OK(Serializer.deserialize content)
+            | 201 -> return CreateLog.Created
+            | 400 -> return CreateLog.BadRequest
+            | 403 -> return CreateLog.Forbidden
+            | _ -> return CreateLog.NotFound
         }
 
     ///<summary>
@@ -912,12 +850,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/sites/{id}/monitor" headers requestParts
 
-            if status = 200 then
-                return DeleteMonitor.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return DeleteMonitor.Forbidden
-            else
-                return DeleteMonitor.NotFound
+            match status with
+            | 200 -> return DeleteMonitor.OK(Serializer.deserialize content)
+            | 403 -> return DeleteMonitor.Forbidden
+            | _ -> return DeleteMonitor.NotFound
         }
 
     ///<summary>
@@ -929,12 +865,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/monitor" headers requestParts
 
-            if status = 200 then
-                return PostMonitor.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return PostMonitor.Forbidden
-            else
-                return PostMonitor.NotFound
+            match status with
+            | 200 -> return PostMonitor.OK(Serializer.deserialize content)
+            | 403 -> return PostMonitor.Forbidden
+            | _ -> return PostMonitor.NotFound
         }
 
     ///<summary>
@@ -946,12 +880,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/scanner" headers requestParts
 
-            if status = 200 then
-                return Scanner.OK content
-            else if status = 403 then
-                return Scanner.Forbidden
-            else
-                return Scanner.NotFound
+            match status with
+            | 200 -> return Scanner.OK content
+            | 403 -> return Scanner.Forbidden
+            | _ -> return Scanner.NotFound
         }
 
     ///<summary>
@@ -963,12 +895,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/seo" headers requestParts
 
-            if status = 200 then
-                return SeoAnalyze.OK content
-            else if status = 403 then
-                return SeoAnalyze.Forbidden
-            else
-                return SeoAnalyze.NotFound
+            match status with
+            | 200 -> return SeoAnalyze.OK content
+            | 403 -> return SeoAnalyze.Forbidden
+            | _ -> return SeoAnalyze.NotFound
         }
 
     ///<summary>
@@ -1009,12 +939,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/tags" headers requestParts
 
-            if status = 200 then
-                return GetSitesTagsById.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return GetSitesTagsById.Forbidden
-            else
-                return GetSitesTagsById.NotFound
+            match status with
+            | 200 -> return GetSitesTagsById.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesTagsById.Forbidden
+            | _ -> return GetSitesTagsById.NotFound
         }
 
     ///<summary>
@@ -1030,14 +958,11 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/tags" headers requestParts
 
-            if status = 200 then
-                return PostTags.OK(Serializer.deserialize content)
-            else if status = 201 then
-                return PostTags.Created
-            else if status = 403 then
-                return PostTags.Forbidden
-            else
-                return PostTags.NotFound
+            match status with
+            | 200 -> return PostTags.OK(Serializer.deserialize content)
+            | 201 -> return PostTags.Created
+            | 403 -> return PostTags.Forbidden
+            | _ -> return PostTags.NotFound
         }
 
     ///<summary>
@@ -1049,12 +974,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/updatejoomla" headers requestParts
 
-            if status = 200 then
-                return UpdateJoomla.OK content
-            else if status = 403 then
-                return UpdateJoomla.Forbidden
-            else
-                return UpdateJoomla.NotFound
+            match status with
+            | 200 -> return UpdateJoomla.OK content
+            | 403 -> return UpdateJoomla.Forbidden
+            | _ -> return UpdateJoomla.NotFound
         }
 
     ///<summary>
@@ -1066,12 +989,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/uptime" headers requestParts
 
-            if status = 200 then
-                return GetUptime.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return GetUptime.Forbidden
-            else
-                return GetUptime.NotFound
+            match status with
+            | 200 -> return GetUptime.OK(Serializer.deserialize content)
+            | 403 -> return GetUptime.Forbidden
+            | _ -> return GetUptime.NotFound
         }
 
     ///<summary>
@@ -1083,12 +1004,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/validate" headers requestParts
 
-            if status = 200 then
-                return ValidateSite.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return ValidateSite.Forbidden
-            else
-                return ValidateSite.NotFound
+            match status with
+            | 200 -> return ValidateSite.OK(Serializer.deserialize content)
+            | 403 -> return ValidateSite.Forbidden
+            | _ -> return ValidateSite.NotFound
         }
 
     ///<summary>
@@ -1100,12 +1019,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/validatedebug" headers requestParts
 
-            if status = 200 then
-                return ValidateDebugSite.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return ValidateDebugSite.Forbidden
-            else
-                return ValidateDebugSite.NotFound
+            match status with
+            | 200 -> return ValidateDebugSite.OK(Serializer.deserialize content)
+            | 403 -> return ValidateDebugSite.Forbidden
+            | _ -> return ValidateDebugSite.NotFound
         }
 
     ///<summary>
@@ -1116,10 +1033,9 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/ssousers" headers requestParts
 
-            if status = 200 then
-                return GetSsoUsers.OK(Serializer.deserialize content)
-            else
-                return GetSsoUsers.Forbidden
+            match status with
+            | 200 -> return GetSsoUsers.OK(Serializer.deserialize content)
+            | _ -> return GetSsoUsers.Forbidden
         }
 
     ///<summary>
@@ -1130,16 +1046,12 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/ssousers" headers requestParts
 
-            if status = 200 then
-                return CreateSsoUsers.OK(Serializer.deserialize content)
-            else if status = 201 then
-                return CreateSsoUsers.Created
-            else if status = 400 then
-                return CreateSsoUsers.BadRequest
-            else if status = 403 then
-                return CreateSsoUsers.Forbidden
-            else
-                return CreateSsoUsers.NotFound
+            match status with
+            | 200 -> return CreateSsoUsers.OK(Serializer.deserialize content)
+            | 201 -> return CreateSsoUsers.Created
+            | 400 -> return CreateSsoUsers.BadRequest
+            | 403 -> return CreateSsoUsers.Forbidden
+            | _ -> return CreateSsoUsers.NotFound
         }
 
     ///<summary>
@@ -1151,12 +1063,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/ssousers/{id}" headers requestParts
 
-            if status = 200 then
-                return DeleteSsoUserById.OK content
-            else if status = 403 then
-                return DeleteSsoUserById.Forbidden
-            else
-                return DeleteSsoUserById.NotFound
+            match status with
+            | 200 -> return DeleteSsoUserById.OK content
+            | 403 -> return DeleteSsoUserById.Forbidden
+            | _ -> return DeleteSsoUserById.NotFound
         }
 
     ///<summary>
@@ -1173,12 +1083,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/ssousers/{id}" headers requestParts
 
-            if status = 200 then
-                return GetSsoUsersById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetSsoUsersById.BadRequest
-            else
-                return GetSsoUsersById.Forbidden
+            match status with
+            | 200 -> return GetSsoUsersById.OK(Serializer.deserialize content)
+            | 400 -> return GetSsoUsersById.BadRequest
+            | _ -> return GetSsoUsersById.Forbidden
         }
 
     ///<summary>
@@ -1194,16 +1102,12 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/ssousers/{id}" headers requestParts
 
-            if status = 200 then
-                return UpdateSsoUsers.OK(Serializer.deserialize content)
-            else if status = 201 then
-                return UpdateSsoUsers.Created
-            else if status = 400 then
-                return UpdateSsoUsers.BadRequest
-            else if status = 403 then
-                return UpdateSsoUsers.Forbidden
-            else
-                return UpdateSsoUsers.NotFound
+            match status with
+            | 200 -> return UpdateSsoUsers.OK(Serializer.deserialize content)
+            | 201 -> return UpdateSsoUsers.Created
+            | 400 -> return UpdateSsoUsers.BadRequest
+            | 403 -> return UpdateSsoUsers.Forbidden
+            | _ -> return UpdateSsoUsers.NotFound
         }
 
     ///<summary>
@@ -1241,10 +1145,9 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/tags" headers requestParts
 
-            if status = 200 then
-                return GetTags.OK(Serializer.deserialize content)
-            else
-                return GetTags.Forbidden
+            match status with
+            | 200 -> return GetTags.OK(Serializer.deserialize content)
+            | _ -> return GetTags.Forbidden
         }
 
     ///<summary>
@@ -1255,16 +1158,12 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/tags" headers requestParts
 
-            if status = 200 then
-                return CreateTags.OK(Serializer.deserialize content)
-            else if status = 201 then
-                return CreateTags.Created
-            else if status = 400 then
-                return CreateTags.BadRequest
-            else if status = 403 then
-                return CreateTags.Forbidden
-            else
-                return CreateTags.NotFound
+            match status with
+            | 200 -> return CreateTags.OK(Serializer.deserialize content)
+            | 201 -> return CreateTags.Created
+            | 400 -> return CreateTags.BadRequest
+            | 403 -> return CreateTags.Forbidden
+            | _ -> return CreateTags.NotFound
         }
 
     ///<summary>
@@ -1286,12 +1185,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/tags/{id}" headers requestParts
 
-            if status = 200 then
-                return DeleteTagsById.OK content
-            else if status = 403 then
-                return DeleteTagsById.Forbidden
-            else
-                return DeleteTagsById.NotFound
+            match status with
+            | 200 -> return DeleteTagsById.OK content
+            | 403 -> return DeleteTagsById.Forbidden
+            | _ -> return DeleteTagsById.NotFound
         }
 
     ///<summary>
@@ -1308,12 +1205,10 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/tags/{id}" headers requestParts
 
-            if status = 200 then
-                return GetTagById.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetTagById.BadRequest
-            else
-                return GetTagById.Forbidden
+            match status with
+            | 200 -> return GetTagById.OK(Serializer.deserialize content)
+            | 400 -> return GetTagById.BadRequest
+            | _ -> return GetTagById.Forbidden
         }
 
     ///<summary>
@@ -1329,14 +1224,11 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/tags/{id}" headers requestParts
 
-            if status = 200 then
-                return UpdateTag.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return UpdateTag.BadRequest
-            else if status = 403 then
-                return UpdateTag.Forbidden
-            else
-                return UpdateTag.NotFound
+            match status with
+            | 200 -> return UpdateTag.OK(Serializer.deserialize content)
+            | 400 -> return UpdateTag.BadRequest
+            | 403 -> return UpdateTag.Forbidden
+            | _ -> return UpdateTag.NotFound
         }
 
     ///<summary>
@@ -1405,10 +1297,8 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/tags/{id}/sites" headers requestParts
 
-            if status = 200 then
-                return GetSitesByTags.OK(Serializer.deserialize content)
-            else if status = 403 then
-                return GetSitesByTags.Forbidden
-            else
-                return GetSitesByTags.NotFound
+            match status with
+            | 200 -> return GetSitesByTags.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesByTags.Forbidden
+            | _ -> return GetSitesByTags.NotFound
         }

--- a/examples/FableWatchful/Client.fs
+++ b/examples/FableWatchful/Client.fs
@@ -26,7 +26,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/audits" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAudits.OK(Serializer.deserialize content)
             | _ -> return GetAudits.Forbidden
         }
@@ -50,7 +50,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/audits/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteAuditById.OK content
             | 403 -> return DeleteAuditById.Forbidden
             | _ -> return DeleteAuditById.NotFound
@@ -70,7 +70,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/audits/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetAuditById.OK(Serializer.deserialize content)
             | 400 -> return GetAuditById.BadRequest
             | _ -> return GetAuditById.Forbidden
@@ -123,7 +123,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/extensions" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetExtensions.OK(Serializer.deserialize content)
             | 403 -> return GetExtensions.Forbidden
             | _ -> return GetExtensions.NotFound
@@ -148,7 +148,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/extensions/{id}/ignore" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return IgnoreExtensionUpdate.OK content
             | _ -> return IgnoreExtensionUpdate.NotFound
         }
@@ -162,7 +162,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/extensions/{id}/unignore" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UnignoreExtensionUpdate.OK content
             | _ -> return UnignoreExtensionUpdate.NotFound
         }
@@ -176,7 +176,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/extensions/{id}/update" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpdateExtension.OK content
             | _ -> return UpdateExtension.NotFound
         }
@@ -193,7 +193,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/feedbacks" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetFeedbacks.OK(Serializer.deserialize content)
             | _ -> return GetFeedbacks.Forbidden
         }
@@ -206,7 +206,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/feedbacks" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateFeedbacks.OK(Serializer.deserialize content)
             | 201 -> return CreateFeedbacks.Created
             | 400 -> return CreateFeedbacks.BadRequest
@@ -267,7 +267,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/logs" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetLogs.OK(Serializer.deserialize content)
             | _ -> return GetLogs.Forbidden
         }
@@ -314,7 +314,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/logs/export" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetExportLogs.OK
             | _ -> return GetExportLogs.Forbidden
         }
@@ -348,7 +348,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/logs/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteLogById.OK content
             | 403 -> return DeleteLogById.Forbidden
             | _ -> return DeleteLogById.NotFound
@@ -395,7 +395,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, contentBinary) = OpenApiHttp.getBinaryAsync url "/reports/sites/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetReportsSitesById.OK contentBinary
             | 403 -> return GetReportsSitesById.Forbidden contentBinary
             | _ -> return GetReportsSitesById.NotFound contentBinary
@@ -435,7 +435,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, contentBinary) = OpenApiHttp.getBinaryAsync url "/reports/tags/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetReportsTagsById.OK contentBinary
             | 403 -> return GetReportsTagsById.Forbidden contentBinary
             | _ -> return GetReportsTagsById.NotFound contentBinary
@@ -512,7 +512,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSites.OK(Serializer.deserialize content)
             | 403 -> return GetSites.Forbidden
             | _ -> return GetSites.NotFound
@@ -526,7 +526,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateSite.OK(Serializer.deserialize content)
             | 201 -> return CreateSite.Created
             | 400 -> return CreateSite.BadRequest
@@ -553,7 +553,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/sites/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteSitesById.OK content
             | 403 -> return DeleteSitesById.Forbidden
             | _ -> return DeleteSitesById.NotFound
@@ -573,7 +573,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSiteById.OK(Serializer.deserialize content)
             | 403 -> return GetSiteById.Forbidden
             | _ -> return GetSiteById.NotFound
@@ -592,7 +592,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/sites/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PutSitesById.OK(Serializer.deserialize content)
             | 400 -> return PutSitesById.BadRequest
             | 403 -> return PutSitesById.Forbidden
@@ -622,7 +622,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/audits" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSiteAudits.OK(Serializer.deserialize content)
             | 403 -> return GetSiteAudits.Forbidden
             | _ -> return GetSiteAudits.NotFound
@@ -637,7 +637,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/audits" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateAudits.OK(Serializer.deserialize content)
             | 201 -> return CreateAudits.Created
             | 400 -> return CreateAudits.BadRequest
@@ -654,7 +654,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/backupnow" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return AddSiteToBackupQueue.OK(Serializer.deserialize content)
             | 403 -> return AddSiteToBackupQueue.Forbidden
             | _ -> return AddSiteToBackupQueue.NotFound
@@ -669,7 +669,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/backupprofiles" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetBackupProfiles.OK
             | 403 -> return GetBackupProfiles.Forbidden
             | _ -> return GetBackupProfiles.NotFound
@@ -684,7 +684,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/backups" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetListBackups.OK
             | 403 -> return GetListBackups.Forbidden
             | _ -> return GetListBackups.NotFound
@@ -699,7 +699,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/backupstart" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return StartSiteBackup.OK(Serializer.deserialize content)
             | 403 -> return StartSiteBackup.Forbidden
             | _ -> return StartSiteBackup.NotFound
@@ -714,7 +714,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/backupstep" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return StepSiteBackup.OK(Serializer.deserialize content)
             | 403 -> return StepSiteBackup.Forbidden
             | _ -> return StepSiteBackup.NotFound
@@ -743,7 +743,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/extensions" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSitesExtensionsById.OK(Serializer.deserialize content)
             | 403 -> return GetSitesExtensionsById.Forbidden
             | _ -> return GetSitesExtensionsById.NotFound
@@ -762,7 +762,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/extensions" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return InstallExtension.OK
             | 403 -> return InstallExtension.Forbidden
             | _ -> return InstallExtension.NotFound
@@ -814,7 +814,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/logs" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSitesLogsById.OK(Serializer.deserialize content)
             | 403 -> return GetSitesLogsById.Forbidden
             | _ -> return GetSitesLogsById.NotFound
@@ -833,7 +833,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/logs" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateLog.OK(Serializer.deserialize content)
             | 201 -> return CreateLog.Created
             | 400 -> return CreateLog.BadRequest
@@ -850,7 +850,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/sites/{id}/monitor" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteMonitor.OK(Serializer.deserialize content)
             | 403 -> return DeleteMonitor.Forbidden
             | _ -> return DeleteMonitor.NotFound
@@ -865,7 +865,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/monitor" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostMonitor.OK(Serializer.deserialize content)
             | 403 -> return PostMonitor.Forbidden
             | _ -> return PostMonitor.NotFound
@@ -880,7 +880,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/scanner" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return Scanner.OK content
             | 403 -> return Scanner.Forbidden
             | _ -> return Scanner.NotFound
@@ -895,7 +895,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/seo" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return SeoAnalyze.OK content
             | 403 -> return SeoAnalyze.Forbidden
             | _ -> return SeoAnalyze.NotFound
@@ -939,7 +939,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/tags" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSitesTagsById.OK(Serializer.deserialize content)
             | 403 -> return GetSitesTagsById.Forbidden
             | _ -> return GetSitesTagsById.NotFound
@@ -958,7 +958,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/tags" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PostTags.OK(Serializer.deserialize content)
             | 201 -> return PostTags.Created
             | 403 -> return PostTags.Forbidden
@@ -974,7 +974,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.postAsync url "/sites/{id}/updatejoomla" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpdateJoomla.OK content
             | 403 -> return UpdateJoomla.Forbidden
             | _ -> return UpdateJoomla.NotFound
@@ -989,7 +989,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/uptime" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetUptime.OK(Serializer.deserialize content)
             | 403 -> return GetUptime.Forbidden
             | _ -> return GetUptime.NotFound
@@ -1004,7 +1004,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/validate" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return ValidateSite.OK(Serializer.deserialize content)
             | 403 -> return ValidateSite.Forbidden
             | _ -> return ValidateSite.NotFound
@@ -1019,7 +1019,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync url "/sites/{id}/validatedebug" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return ValidateDebugSite.OK(Serializer.deserialize content)
             | 403 -> return ValidateDebugSite.Forbidden
             | _ -> return ValidateDebugSite.NotFound
@@ -1033,7 +1033,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/ssousers" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSsoUsers.OK(Serializer.deserialize content)
             | _ -> return GetSsoUsers.Forbidden
         }
@@ -1046,7 +1046,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/ssousers" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateSsoUsers.OK(Serializer.deserialize content)
             | 201 -> return CreateSsoUsers.Created
             | 400 -> return CreateSsoUsers.BadRequest
@@ -1063,7 +1063,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/ssousers/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteSsoUserById.OK content
             | 403 -> return DeleteSsoUserById.Forbidden
             | _ -> return DeleteSsoUserById.NotFound
@@ -1083,7 +1083,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/ssousers/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSsoUsersById.OK(Serializer.deserialize content)
             | 400 -> return GetSsoUsersById.BadRequest
             | _ -> return GetSsoUsersById.Forbidden
@@ -1102,7 +1102,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/ssousers/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpdateSsoUsers.OK(Serializer.deserialize content)
             | 201 -> return UpdateSsoUsers.Created
             | 400 -> return UpdateSsoUsers.BadRequest
@@ -1145,7 +1145,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/tags" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetTags.OK(Serializer.deserialize content)
             | _ -> return GetTags.Forbidden
         }
@@ -1158,7 +1158,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/tags" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return CreateTags.OK(Serializer.deserialize content)
             | 201 -> return CreateTags.Created
             | 400 -> return CreateTags.BadRequest
@@ -1185,7 +1185,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync url "/tags/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return DeleteTagsById.OK content
             | 403 -> return DeleteTagsById.Forbidden
             | _ -> return DeleteTagsById.NotFound
@@ -1205,7 +1205,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/tags/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetTagById.OK(Serializer.deserialize content)
             | 400 -> return GetTagById.BadRequest
             | _ -> return GetTagById.Forbidden
@@ -1224,7 +1224,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/tags/{id}" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return UpdateTag.OK(Serializer.deserialize content)
             | 400 -> return UpdateTag.BadRequest
             | 403 -> return UpdateTag.Forbidden
@@ -1297,7 +1297,7 @@ type FableWatchfulClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/tags/{id}/sites" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetSitesByTags.OK(Serializer.deserialize content)
             | 403 -> return GetSitesByTags.Forbidden
             | _ -> return GetSitesByTags.NotFound

--- a/examples/Fablewashbuckle/Client.fs
+++ b/examples/Fablewashbuckle/Client.fs
@@ -13,10 +13,8 @@ type FablewashbuckleClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/Time" headers requestParts
 
-            if status = 200 then
-                return GetTime.OK(Serializer.deserialize content)
-            else if status = 400 then
-                return GetTime.BadRequest(Serializer.deserialize content)
-            else
-                return GetTime.Forbidden(Serializer.deserialize content)
+            match status with
+            | 200 -> return GetTime.OK(Serializer.deserialize content)
+            | 400 -> return GetTime.BadRequest(Serializer.deserialize content)
+            | _ -> return GetTime.Forbidden(Serializer.deserialize content)
         }

--- a/examples/Fablewashbuckle/Client.fs
+++ b/examples/Fablewashbuckle/Client.fs
@@ -13,7 +13,7 @@ type FablewashbuckleClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/Time" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return GetTime.OK(Serializer.deserialize content)
             | 400 -> return GetTime.BadRequest(Serializer.deserialize content)
             | _ -> return GetTime.Forbidden(Serializer.deserialize content)

--- a/examples/FreeFormWatchful/Client.fs
+++ b/examples/FreeFormWatchful/Client.fs
@@ -27,8 +27,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/audits" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAudits.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAudits.OK(Serializer.deserialize content)
             | _ -> return GetAudits.Forbidden
         }
 
@@ -52,9 +52,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/audits/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteAuditById.OK content
-            | HttpStatusCode.Forbidden -> return DeleteAuditById.Forbidden
+            match int status with
+            | 200 -> return DeleteAuditById.OK content
+            | 403 -> return DeleteAuditById.Forbidden
             | _ -> return DeleteAuditById.NotFound
         }
 
@@ -73,9 +73,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/audits/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAuditById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAuditById.BadRequest
+            match int status with
+            | 200 -> return GetAuditById.OK(Serializer.deserialize content)
+            | 400 -> return GetAuditById.BadRequest
             | _ -> return GetAuditById.Forbidden
         }
 
@@ -128,9 +128,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/extensions" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetExtensions.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetExtensions.Forbidden
+            match int status with
+            | 200 -> return GetExtensions.OK(Serializer.deserialize content)
+            | 403 -> return GetExtensions.Forbidden
             | _ -> return GetExtensions.NotFound
         }
 
@@ -159,8 +159,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/ignore" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return IgnoreExtensionUpdate.OK content
+            match int status with
+            | 200 -> return IgnoreExtensionUpdate.OK content
             | _ -> return IgnoreExtensionUpdate.NotFound
         }
 
@@ -176,8 +176,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/unignore" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UnignoreExtensionUpdate.OK content
+            match int status with
+            | 200 -> return UnignoreExtensionUpdate.OK content
             | _ -> return UnignoreExtensionUpdate.NotFound
         }
 
@@ -193,8 +193,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/update" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateExtension.OK content
+            match int status with
+            | 200 -> return UpdateExtension.OK content
             | _ -> return UpdateExtension.NotFound
         }
 
@@ -211,8 +211,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/feedbacks" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetFeedbacks.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetFeedbacks.OK(Serializer.deserialize content)
             | _ -> return GetFeedbacks.Forbidden
         }
 
@@ -224,11 +224,11 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/feedbacks" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateFeedbacks.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateFeedbacks.Created
-            | HttpStatusCode.BadRequest -> return CreateFeedbacks.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateFeedbacks.Forbidden
+            match int status with
+            | 200 -> return CreateFeedbacks.OK(Serializer.deserialize content)
+            | 201 -> return CreateFeedbacks.Created
+            | 400 -> return CreateFeedbacks.BadRequest
+            | 403 -> return CreateFeedbacks.Forbidden
             | _ -> return CreateFeedbacks.NotFound
         }
 
@@ -290,8 +290,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/logs" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetLogs.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetLogs.OK(Serializer.deserialize content)
             | _ -> return GetLogs.Forbidden
         }
 
@@ -339,8 +339,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/logs/export" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetExportLogs.OK
+            match int status with
+            | 200 -> return GetExportLogs.OK
             | _ -> return GetExportLogs.Forbidden
         }
 
@@ -374,9 +374,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/logs/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteLogById.OK content
-            | HttpStatusCode.Forbidden -> return DeleteLogById.Forbidden
+            match int status with
+            | 200 -> return DeleteLogById.OK content
+            | 403 -> return DeleteLogById.Forbidden
             | _ -> return DeleteLogById.NotFound
         }
 
@@ -424,9 +424,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/reports/sites/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetReportsSitesById.OK contentBinary
-            | HttpStatusCode.Forbidden -> return GetReportsSitesById.Forbidden contentBinary
+            match int status with
+            | 200 -> return GetReportsSitesById.OK contentBinary
+            | 403 -> return GetReportsSitesById.Forbidden contentBinary
             | _ -> return GetReportsSitesById.NotFound contentBinary
         }
 
@@ -467,9 +467,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/reports/tags/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetReportsTagsById.OK contentBinary
-            | HttpStatusCode.Forbidden -> return GetReportsTagsById.Forbidden contentBinary
+            match int status with
+            | 200 -> return GetReportsTagsById.OK contentBinary
+            | 403 -> return GetReportsTagsById.Forbidden contentBinary
             | _ -> return GetReportsTagsById.NotFound contentBinary
         }
 
@@ -546,9 +546,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSites.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSites.Forbidden
+            match int status with
+            | 200 -> return GetSites.OK(Serializer.deserialize content)
+            | 403 -> return GetSites.Forbidden
             | _ -> return GetSites.NotFound
         }
 
@@ -560,11 +560,11 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateSite.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateSite.Created
-            | HttpStatusCode.BadRequest -> return CreateSite.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateSite.Forbidden
+            match int status with
+            | 200 -> return CreateSite.OK(Serializer.deserialize content)
+            | 201 -> return CreateSite.Created
+            | 400 -> return CreateSite.BadRequest
+            | 403 -> return CreateSite.Forbidden
             | _ -> return CreateSite.NotFound
         }
 
@@ -588,9 +588,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteSitesById.OK content
-            | HttpStatusCode.Forbidden -> return DeleteSitesById.Forbidden
+            match int status with
+            | 200 -> return DeleteSitesById.OK content
+            | 403 -> return DeleteSitesById.Forbidden
             | _ -> return DeleteSitesById.NotFound
         }
 
@@ -609,9 +609,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSiteById.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSiteById.Forbidden
+            match int status with
+            | 200 -> return GetSiteById.OK(Serializer.deserialize content)
+            | 403 -> return GetSiteById.Forbidden
             | _ -> return GetSiteById.NotFound
         }
 
@@ -629,10 +629,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutSitesById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutSitesById.BadRequest
-            | HttpStatusCode.Forbidden -> return PutSitesById.Forbidden
+            match int status with
+            | 200 -> return PutSitesById.OK(Serializer.deserialize content)
+            | 400 -> return PutSitesById.BadRequest
+            | 403 -> return PutSitesById.Forbidden
             | _ -> return PutSitesById.NotFound
         }
 
@@ -668,9 +668,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSiteAudits.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSiteAudits.Forbidden
+            match int status with
+            | 200 -> return GetSiteAudits.OK(Serializer.deserialize content)
+            | 403 -> return GetSiteAudits.Forbidden
             | _ -> return GetSiteAudits.NotFound
         }
 
@@ -686,11 +686,11 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateAudits.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateAudits.Created
-            | HttpStatusCode.BadRequest -> return CreateAudits.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateAudits.Forbidden
+            match int status with
+            | 200 -> return CreateAudits.OK(Serializer.deserialize content)
+            | 201 -> return CreateAudits.Created
+            | 400 -> return CreateAudits.BadRequest
+            | 403 -> return CreateAudits.Forbidden
             | _ -> return CreateAudits.NotFound
         }
 
@@ -706,9 +706,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupnow" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return AddSiteToBackupQueue.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return AddSiteToBackupQueue.Forbidden
+            match int status with
+            | 200 -> return AddSiteToBackupQueue.OK(Serializer.deserialize content)
+            | 403 -> return AddSiteToBackupQueue.Forbidden
             | _ -> return AddSiteToBackupQueue.NotFound
         }
 
@@ -724,9 +724,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/backupprofiles" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetBackupProfiles.OK
-            | HttpStatusCode.Forbidden -> return GetBackupProfiles.Forbidden
+            match int status with
+            | 200 -> return GetBackupProfiles.OK
+            | 403 -> return GetBackupProfiles.Forbidden
             | _ -> return GetBackupProfiles.NotFound
         }
 
@@ -742,9 +742,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/backups" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetListBackups.OK
-            | HttpStatusCode.Forbidden -> return GetListBackups.Forbidden
+            match int status with
+            | 200 -> return GetListBackups.OK
+            | 403 -> return GetListBackups.Forbidden
             | _ -> return GetListBackups.NotFound
         }
 
@@ -760,9 +760,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupstart" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return StartSiteBackup.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return StartSiteBackup.Forbidden
+            match int status with
+            | 200 -> return StartSiteBackup.OK(Serializer.deserialize content)
+            | 403 -> return StartSiteBackup.Forbidden
             | _ -> return StartSiteBackup.NotFound
         }
 
@@ -778,9 +778,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupstep" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return StepSiteBackup.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return StepSiteBackup.Forbidden
+            match int status with
+            | 200 -> return StepSiteBackup.OK(Serializer.deserialize content)
+            | 403 -> return StepSiteBackup.Forbidden
             | _ -> return StepSiteBackup.NotFound
         }
 
@@ -817,9 +817,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSitesExtensionsById.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSitesExtensionsById.Forbidden
+            match int status with
+            | 200 -> return GetSitesExtensionsById.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesExtensionsById.Forbidden
             | _ -> return GetSitesExtensionsById.NotFound
         }
 
@@ -838,9 +838,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return InstallExtension.OK
-            | HttpStatusCode.Forbidden -> return InstallExtension.Forbidden
+            match int status with
+            | 200 -> return InstallExtension.OK
+            | 403 -> return InstallExtension.Forbidden
             | _ -> return InstallExtension.NotFound
         }
 
@@ -892,9 +892,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSitesLogsById.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSitesLogsById.Forbidden
+            match int status with
+            | 200 -> return GetSitesLogsById.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesLogsById.Forbidden
             | _ -> return GetSitesLogsById.NotFound
         }
 
@@ -912,11 +912,11 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateLog.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateLog.Created
-            | HttpStatusCode.BadRequest -> return CreateLog.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateLog.Forbidden
+            match int status with
+            | 200 -> return CreateLog.OK(Serializer.deserialize content)
+            | 201 -> return CreateLog.Created
+            | 400 -> return CreateLog.BadRequest
+            | 403 -> return CreateLog.Forbidden
             | _ -> return CreateLog.NotFound
         }
 
@@ -932,9 +932,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteMonitor.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return DeleteMonitor.Forbidden
+            match int status with
+            | 200 -> return DeleteMonitor.OK(Serializer.deserialize content)
+            | 403 -> return DeleteMonitor.Forbidden
             | _ -> return DeleteMonitor.NotFound
         }
 
@@ -950,9 +950,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostMonitor.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return PostMonitor.Forbidden
+            match int status with
+            | 200 -> return PostMonitor.OK(Serializer.deserialize content)
+            | 403 -> return PostMonitor.Forbidden
             | _ -> return PostMonitor.NotFound
         }
 
@@ -968,9 +968,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/scanner" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return Scanner.OK content
-            | HttpStatusCode.Forbidden -> return Scanner.Forbidden
+            match int status with
+            | 200 -> return Scanner.OK content
+            | 403 -> return Scanner.Forbidden
             | _ -> return Scanner.NotFound
         }
 
@@ -984,9 +984,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/seo" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return SeoAnalyze.OK content
-            | HttpStatusCode.Forbidden -> return SeoAnalyze.Forbidden
+            match int status with
+            | 200 -> return SeoAnalyze.OK content
+            | 403 -> return SeoAnalyze.Forbidden
             | _ -> return SeoAnalyze.NotFound
         }
 
@@ -1030,9 +1030,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSitesTagsById.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSitesTagsById.Forbidden
+            match int status with
+            | 200 -> return GetSitesTagsById.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesTagsById.Forbidden
             | _ -> return GetSitesTagsById.NotFound
         }
 
@@ -1050,10 +1050,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostTags.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return PostTags.Created
-            | HttpStatusCode.Forbidden -> return PostTags.Forbidden
+            match int status with
+            | 200 -> return PostTags.OK(Serializer.deserialize content)
+            | 201 -> return PostTags.Created
+            | 403 -> return PostTags.Forbidden
             | _ -> return PostTags.NotFound
         }
 
@@ -1069,9 +1069,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/updatejoomla" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateJoomla.OK content
-            | HttpStatusCode.Forbidden -> return UpdateJoomla.Forbidden
+            match int status with
+            | 200 -> return UpdateJoomla.OK content
+            | 403 -> return UpdateJoomla.Forbidden
             | _ -> return UpdateJoomla.NotFound
         }
 
@@ -1085,9 +1085,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/uptime" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUptime.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetUptime.Forbidden
+            match int status with
+            | 200 -> return GetUptime.OK(Serializer.deserialize content)
+            | 403 -> return GetUptime.Forbidden
             | _ -> return GetUptime.NotFound
         }
 
@@ -1103,9 +1103,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/validate" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return ValidateSite.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return ValidateSite.Forbidden
+            match int status with
+            | 200 -> return ValidateSite.OK(Serializer.deserialize content)
+            | 403 -> return ValidateSite.Forbidden
             | _ -> return ValidateSite.NotFound
         }
 
@@ -1121,9 +1121,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/validatedebug" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return ValidateDebugSite.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return ValidateDebugSite.Forbidden
+            match int status with
+            | 200 -> return ValidateDebugSite.OK(Serializer.deserialize content)
+            | 403 -> return ValidateDebugSite.Forbidden
             | _ -> return ValidateDebugSite.NotFound
         }
 
@@ -1135,8 +1135,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/ssousers" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSsoUsers.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetSsoUsers.OK(Serializer.deserialize content)
             | _ -> return GetSsoUsers.Forbidden
         }
 
@@ -1148,11 +1148,11 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/ssousers" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateSsoUsers.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateSsoUsers.Created
-            | HttpStatusCode.BadRequest -> return CreateSsoUsers.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateSsoUsers.Forbidden
+            match int status with
+            | 200 -> return CreateSsoUsers.OK(Serializer.deserialize content)
+            | 201 -> return CreateSsoUsers.Created
+            | 400 -> return CreateSsoUsers.BadRequest
+            | 403 -> return CreateSsoUsers.Forbidden
             | _ -> return CreateSsoUsers.NotFound
         }
 
@@ -1166,9 +1166,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteSsoUserById.OK content
-            | HttpStatusCode.Forbidden -> return DeleteSsoUserById.Forbidden
+            match int status with
+            | 200 -> return DeleteSsoUserById.OK content
+            | 403 -> return DeleteSsoUserById.Forbidden
             | _ -> return DeleteSsoUserById.NotFound
         }
 
@@ -1187,9 +1187,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSsoUsersById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetSsoUsersById.BadRequest
+            match int status with
+            | 200 -> return GetSsoUsersById.OK(Serializer.deserialize content)
+            | 400 -> return GetSsoUsersById.BadRequest
             | _ -> return GetSsoUsersById.Forbidden
         }
 
@@ -1207,11 +1207,11 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateSsoUsers.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return UpdateSsoUsers.Created
-            | HttpStatusCode.BadRequest -> return UpdateSsoUsers.BadRequest
-            | HttpStatusCode.Forbidden -> return UpdateSsoUsers.Forbidden
+            match int status with
+            | 200 -> return UpdateSsoUsers.OK(Serializer.deserialize content)
+            | 201 -> return UpdateSsoUsers.Created
+            | 400 -> return UpdateSsoUsers.BadRequest
+            | 403 -> return UpdateSsoUsers.Forbidden
             | _ -> return UpdateSsoUsers.NotFound
         }
 
@@ -1252,8 +1252,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTags.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetTags.OK(Serializer.deserialize content)
             | _ -> return GetTags.Forbidden
         }
 
@@ -1265,11 +1265,11 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/tags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateTags.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateTags.Created
-            | HttpStatusCode.BadRequest -> return CreateTags.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateTags.Forbidden
+            match int status with
+            | 200 -> return CreateTags.OK(Serializer.deserialize content)
+            | 201 -> return CreateTags.Created
+            | 400 -> return CreateTags.BadRequest
+            | 403 -> return CreateTags.Forbidden
             | _ -> return CreateTags.NotFound
         }
 
@@ -1293,9 +1293,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteTagsById.OK content
-            | HttpStatusCode.Forbidden -> return DeleteTagsById.Forbidden
+            match int status with
+            | 200 -> return DeleteTagsById.OK content
+            | 403 -> return DeleteTagsById.Forbidden
             | _ -> return DeleteTagsById.NotFound
         }
 
@@ -1314,9 +1314,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTagById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetTagById.BadRequest
+            match int status with
+            | 200 -> return GetTagById.OK(Serializer.deserialize content)
+            | 400 -> return GetTagById.BadRequest
             | _ -> return GetTagById.Forbidden
         }
 
@@ -1334,10 +1334,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateTag.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return UpdateTag.BadRequest
-            | HttpStatusCode.Forbidden -> return UpdateTag.Forbidden
+            match int status with
+            | 200 -> return UpdateTag.OK(Serializer.deserialize content)
+            | 400 -> return UpdateTag.BadRequest
+            | 403 -> return UpdateTag.Forbidden
             | _ -> return UpdateTag.NotFound
         }
 
@@ -1409,8 +1409,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags/{id}/sites" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSitesByTags.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSitesByTags.Forbidden
+            match int status with
+            | 200 -> return GetSitesByTags.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesByTags.Forbidden
             | _ -> return GetSitesByTags.NotFound
         }

--- a/examples/FreeFormWatchful/Client.fs
+++ b/examples/FreeFormWatchful/Client.fs
@@ -27,10 +27,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/audits" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAudits.OK(Serializer.deserialize content)
-            else
-                return GetAudits.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetAudits.OK(Serializer.deserialize content)
+            | _ -> return GetAudits.Forbidden
         }
 
     ///<summary>
@@ -53,12 +52,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/audits/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteAuditById.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteAuditById.Forbidden
-            else
-                return DeleteAuditById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteAuditById.OK content
+            | HttpStatusCode.Forbidden -> return DeleteAuditById.Forbidden
+            | _ -> return DeleteAuditById.NotFound
         }
 
     ///<summary>
@@ -76,12 +73,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/audits/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAuditById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAuditById.BadRequest
-            else
-                return GetAuditById.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetAuditById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAuditById.BadRequest
+            | _ -> return GetAuditById.Forbidden
         }
 
     ///<summary>
@@ -133,12 +128,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/extensions" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetExtensions.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetExtensions.Forbidden
-            else
-                return GetExtensions.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetExtensions.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetExtensions.Forbidden
+            | _ -> return GetExtensions.NotFound
         }
 
     ///<summary>
@@ -166,10 +159,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/ignore" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return IgnoreExtensionUpdate.OK content
-            else
-                return IgnoreExtensionUpdate.NotFound
+            match status with
+            | HttpStatusCode.OK -> return IgnoreExtensionUpdate.OK content
+            | _ -> return IgnoreExtensionUpdate.NotFound
         }
 
     ///<summary>
@@ -184,10 +176,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/unignore" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UnignoreExtensionUpdate.OK content
-            else
-                return UnignoreExtensionUpdate.NotFound
+            match status with
+            | HttpStatusCode.OK -> return UnignoreExtensionUpdate.OK content
+            | _ -> return UnignoreExtensionUpdate.NotFound
         }
 
     ///<summary>
@@ -202,10 +193,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/update" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateExtension.OK content
-            else
-                return UpdateExtension.NotFound
+            match status with
+            | HttpStatusCode.OK -> return UpdateExtension.OK content
+            | _ -> return UpdateExtension.NotFound
         }
 
     ///<summary>
@@ -221,10 +211,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/feedbacks" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetFeedbacks.OK(Serializer.deserialize content)
-            else
-                return GetFeedbacks.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetFeedbacks.OK(Serializer.deserialize content)
+            | _ -> return GetFeedbacks.Forbidden
         }
 
     ///<summary>
@@ -235,16 +224,12 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/feedbacks" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateFeedbacks.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateFeedbacks.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateFeedbacks.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateFeedbacks.Forbidden
-            else
-                return CreateFeedbacks.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateFeedbacks.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateFeedbacks.Created
+            | HttpStatusCode.BadRequest -> return CreateFeedbacks.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateFeedbacks.Forbidden
+            | _ -> return CreateFeedbacks.NotFound
         }
 
     ///<summary>
@@ -305,10 +290,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/logs" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetLogs.OK(Serializer.deserialize content)
-            else
-                return GetLogs.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetLogs.OK(Serializer.deserialize content)
+            | _ -> return GetLogs.Forbidden
         }
 
     ///<summary>
@@ -355,10 +339,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/logs/export" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetExportLogs.OK
-            else
-                return GetExportLogs.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetExportLogs.OK
+            | _ -> return GetExportLogs.Forbidden
         }
 
     ///<summary>
@@ -391,12 +374,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/logs/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteLogById.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteLogById.Forbidden
-            else
-                return DeleteLogById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteLogById.OK content
+            | HttpStatusCode.Forbidden -> return DeleteLogById.Forbidden
+            | _ -> return DeleteLogById.NotFound
         }
 
     member this.PostPackages(?cancellationToken: CancellationToken) =
@@ -443,12 +424,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/reports/sites/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetReportsSitesById.OK contentBinary
-            else if status = HttpStatusCode.Forbidden then
-                return GetReportsSitesById.Forbidden contentBinary
-            else
-                return GetReportsSitesById.NotFound contentBinary
+            match status with
+            | HttpStatusCode.OK -> return GetReportsSitesById.OK contentBinary
+            | HttpStatusCode.Forbidden -> return GetReportsSitesById.Forbidden contentBinary
+            | _ -> return GetReportsSitesById.NotFound contentBinary
         }
 
     ///<summary>
@@ -488,12 +467,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/reports/tags/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetReportsTagsById.OK contentBinary
-            else if status = HttpStatusCode.Forbidden then
-                return GetReportsTagsById.Forbidden contentBinary
-            else
-                return GetReportsTagsById.NotFound contentBinary
+            match status with
+            | HttpStatusCode.OK -> return GetReportsTagsById.OK contentBinary
+            | HttpStatusCode.Forbidden -> return GetReportsTagsById.Forbidden contentBinary
+            | _ -> return GetReportsTagsById.NotFound contentBinary
         }
 
     ///<summary>
@@ -569,12 +546,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSites.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSites.Forbidden
-            else
-                return GetSites.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSites.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSites.Forbidden
+            | _ -> return GetSites.NotFound
         }
 
     ///<summary>
@@ -585,16 +560,12 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateSite.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateSite.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateSite.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateSite.Forbidden
-            else
-                return CreateSite.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateSite.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateSite.Created
+            | HttpStatusCode.BadRequest -> return CreateSite.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateSite.Forbidden
+            | _ -> return CreateSite.NotFound
         }
 
     ///<summary>
@@ -617,12 +588,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteSitesById.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteSitesById.Forbidden
-            else
-                return DeleteSitesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteSitesById.OK content
+            | HttpStatusCode.Forbidden -> return DeleteSitesById.Forbidden
+            | _ -> return DeleteSitesById.NotFound
         }
 
     ///<summary>
@@ -640,12 +609,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSiteById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSiteById.Forbidden
-            else
-                return GetSiteById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSiteById.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSiteById.Forbidden
+            | _ -> return GetSiteById.NotFound
         }
 
     ///<summary>
@@ -662,14 +629,11 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutSitesById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutSitesById.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return PutSitesById.Forbidden
-            else
-                return PutSitesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PutSitesById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutSitesById.BadRequest
+            | HttpStatusCode.Forbidden -> return PutSitesById.Forbidden
+            | _ -> return PutSitesById.NotFound
         }
 
     ///<summary>
@@ -704,12 +668,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSiteAudits.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSiteAudits.Forbidden
-            else
-                return GetSiteAudits.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSiteAudits.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSiteAudits.Forbidden
+            | _ -> return GetSiteAudits.NotFound
         }
 
     ///<summary>
@@ -724,16 +686,12 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateAudits.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateAudits.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateAudits.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateAudits.Forbidden
-            else
-                return CreateAudits.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateAudits.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateAudits.Created
+            | HttpStatusCode.BadRequest -> return CreateAudits.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateAudits.Forbidden
+            | _ -> return CreateAudits.NotFound
         }
 
     ///<summary>
@@ -748,12 +706,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupnow" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return AddSiteToBackupQueue.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return AddSiteToBackupQueue.Forbidden
-            else
-                return AddSiteToBackupQueue.NotFound
+            match status with
+            | HttpStatusCode.OK -> return AddSiteToBackupQueue.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return AddSiteToBackupQueue.Forbidden
+            | _ -> return AddSiteToBackupQueue.NotFound
         }
 
     ///<summary>
@@ -768,12 +724,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/backupprofiles" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetBackupProfiles.OK
-            else if status = HttpStatusCode.Forbidden then
-                return GetBackupProfiles.Forbidden
-            else
-                return GetBackupProfiles.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetBackupProfiles.OK
+            | HttpStatusCode.Forbidden -> return GetBackupProfiles.Forbidden
+            | _ -> return GetBackupProfiles.NotFound
         }
 
     ///<summary>
@@ -788,12 +742,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/backups" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetListBackups.OK
-            else if status = HttpStatusCode.Forbidden then
-                return GetListBackups.Forbidden
-            else
-                return GetListBackups.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetListBackups.OK
+            | HttpStatusCode.Forbidden -> return GetListBackups.Forbidden
+            | _ -> return GetListBackups.NotFound
         }
 
     ///<summary>
@@ -808,12 +760,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupstart" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return StartSiteBackup.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return StartSiteBackup.Forbidden
-            else
-                return StartSiteBackup.NotFound
+            match status with
+            | HttpStatusCode.OK -> return StartSiteBackup.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return StartSiteBackup.Forbidden
+            | _ -> return StartSiteBackup.NotFound
         }
 
     ///<summary>
@@ -828,12 +778,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupstep" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return StepSiteBackup.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return StepSiteBackup.Forbidden
-            else
-                return StepSiteBackup.NotFound
+            match status with
+            | HttpStatusCode.OK -> return StepSiteBackup.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return StepSiteBackup.Forbidden
+            | _ -> return StepSiteBackup.NotFound
         }
 
     ///<summary>
@@ -869,12 +817,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSitesExtensionsById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSitesExtensionsById.Forbidden
-            else
-                return GetSitesExtensionsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSitesExtensionsById.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSitesExtensionsById.Forbidden
+            | _ -> return GetSitesExtensionsById.NotFound
         }
 
     ///<summary>
@@ -892,12 +838,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return InstallExtension.OK
-            else if status = HttpStatusCode.Forbidden then
-                return InstallExtension.Forbidden
-            else
-                return InstallExtension.NotFound
+            match status with
+            | HttpStatusCode.OK -> return InstallExtension.OK
+            | HttpStatusCode.Forbidden -> return InstallExtension.Forbidden
+            | _ -> return InstallExtension.NotFound
         }
 
     ///<summary>
@@ -948,12 +892,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSitesLogsById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSitesLogsById.Forbidden
-            else
-                return GetSitesLogsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSitesLogsById.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSitesLogsById.Forbidden
+            | _ -> return GetSitesLogsById.NotFound
         }
 
     ///<summary>
@@ -970,16 +912,12 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateLog.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateLog.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateLog.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateLog.Forbidden
-            else
-                return CreateLog.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateLog.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateLog.Created
+            | HttpStatusCode.BadRequest -> return CreateLog.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateLog.Forbidden
+            | _ -> return CreateLog.NotFound
         }
 
     ///<summary>
@@ -994,12 +932,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteMonitor.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteMonitor.Forbidden
-            else
-                return DeleteMonitor.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteMonitor.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return DeleteMonitor.Forbidden
+            | _ -> return DeleteMonitor.NotFound
         }
 
     ///<summary>
@@ -1014,12 +950,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostMonitor.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return PostMonitor.Forbidden
-            else
-                return PostMonitor.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PostMonitor.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return PostMonitor.Forbidden
+            | _ -> return PostMonitor.NotFound
         }
 
     ///<summary>
@@ -1034,12 +968,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/scanner" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return Scanner.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return Scanner.Forbidden
-            else
-                return Scanner.NotFound
+            match status with
+            | HttpStatusCode.OK -> return Scanner.OK content
+            | HttpStatusCode.Forbidden -> return Scanner.Forbidden
+            | _ -> return Scanner.NotFound
         }
 
     ///<summary>
@@ -1052,12 +984,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/seo" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return SeoAnalyze.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return SeoAnalyze.Forbidden
-            else
-                return SeoAnalyze.NotFound
+            match status with
+            | HttpStatusCode.OK -> return SeoAnalyze.OK content
+            | HttpStatusCode.Forbidden -> return SeoAnalyze.Forbidden
+            | _ -> return SeoAnalyze.NotFound
         }
 
     ///<summary>
@@ -1100,12 +1030,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSitesTagsById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSitesTagsById.Forbidden
-            else
-                return GetSitesTagsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSitesTagsById.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSitesTagsById.Forbidden
+            | _ -> return GetSitesTagsById.NotFound
         }
 
     ///<summary>
@@ -1122,14 +1050,11 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostTags.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return PostTags.Created
-            else if status = HttpStatusCode.Forbidden then
-                return PostTags.Forbidden
-            else
-                return PostTags.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PostTags.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return PostTags.Created
+            | HttpStatusCode.Forbidden -> return PostTags.Forbidden
+            | _ -> return PostTags.NotFound
         }
 
     ///<summary>
@@ -1144,12 +1069,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/updatejoomla" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateJoomla.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return UpdateJoomla.Forbidden
-            else
-                return UpdateJoomla.NotFound
+            match status with
+            | HttpStatusCode.OK -> return UpdateJoomla.OK content
+            | HttpStatusCode.Forbidden -> return UpdateJoomla.Forbidden
+            | _ -> return UpdateJoomla.NotFound
         }
 
     ///<summary>
@@ -1162,12 +1085,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/uptime" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUptime.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetUptime.Forbidden
-            else
-                return GetUptime.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetUptime.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetUptime.Forbidden
+            | _ -> return GetUptime.NotFound
         }
 
     ///<summary>
@@ -1182,12 +1103,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/validate" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return ValidateSite.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return ValidateSite.Forbidden
-            else
-                return ValidateSite.NotFound
+            match status with
+            | HttpStatusCode.OK -> return ValidateSite.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return ValidateSite.Forbidden
+            | _ -> return ValidateSite.NotFound
         }
 
     ///<summary>
@@ -1202,12 +1121,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/validatedebug" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return ValidateDebugSite.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return ValidateDebugSite.Forbidden
-            else
-                return ValidateDebugSite.NotFound
+            match status with
+            | HttpStatusCode.OK -> return ValidateDebugSite.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return ValidateDebugSite.Forbidden
+            | _ -> return ValidateDebugSite.NotFound
         }
 
     ///<summary>
@@ -1218,10 +1135,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/ssousers" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSsoUsers.OK(Serializer.deserialize content)
-            else
-                return GetSsoUsers.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetSsoUsers.OK(Serializer.deserialize content)
+            | _ -> return GetSsoUsers.Forbidden
         }
 
     ///<summary>
@@ -1232,16 +1148,12 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/ssousers" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateSsoUsers.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateSsoUsers.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateSsoUsers.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateSsoUsers.Forbidden
-            else
-                return CreateSsoUsers.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateSsoUsers.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateSsoUsers.Created
+            | HttpStatusCode.BadRequest -> return CreateSsoUsers.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateSsoUsers.Forbidden
+            | _ -> return CreateSsoUsers.NotFound
         }
 
     ///<summary>
@@ -1254,12 +1166,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteSsoUserById.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteSsoUserById.Forbidden
-            else
-                return DeleteSsoUserById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteSsoUserById.OK content
+            | HttpStatusCode.Forbidden -> return DeleteSsoUserById.Forbidden
+            | _ -> return DeleteSsoUserById.NotFound
         }
 
     ///<summary>
@@ -1277,12 +1187,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSsoUsersById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetSsoUsersById.BadRequest
-            else
-                return GetSsoUsersById.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetSsoUsersById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetSsoUsersById.BadRequest
+            | _ -> return GetSsoUsersById.Forbidden
         }
 
     ///<summary>
@@ -1299,16 +1207,12 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateSsoUsers.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return UpdateSsoUsers.Created
-            else if status = HttpStatusCode.BadRequest then
-                return UpdateSsoUsers.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return UpdateSsoUsers.Forbidden
-            else
-                return UpdateSsoUsers.NotFound
+            match status with
+            | HttpStatusCode.OK -> return UpdateSsoUsers.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return UpdateSsoUsers.Created
+            | HttpStatusCode.BadRequest -> return UpdateSsoUsers.BadRequest
+            | HttpStatusCode.Forbidden -> return UpdateSsoUsers.Forbidden
+            | _ -> return UpdateSsoUsers.NotFound
         }
 
     ///<summary>
@@ -1348,10 +1252,9 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTags.OK(Serializer.deserialize content)
-            else
-                return GetTags.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetTags.OK(Serializer.deserialize content)
+            | _ -> return GetTags.Forbidden
         }
 
     ///<summary>
@@ -1362,16 +1265,12 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/tags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateTags.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateTags.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateTags.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateTags.Forbidden
-            else
-                return CreateTags.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateTags.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateTags.Created
+            | HttpStatusCode.BadRequest -> return CreateTags.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateTags.Forbidden
+            | _ -> return CreateTags.NotFound
         }
 
     ///<summary>
@@ -1394,12 +1293,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteTagsById.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteTagsById.Forbidden
-            else
-                return DeleteTagsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteTagsById.OK content
+            | HttpStatusCode.Forbidden -> return DeleteTagsById.Forbidden
+            | _ -> return DeleteTagsById.NotFound
         }
 
     ///<summary>
@@ -1417,12 +1314,10 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTagById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetTagById.BadRequest
-            else
-                return GetTagById.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetTagById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetTagById.BadRequest
+            | _ -> return GetTagById.Forbidden
         }
 
     ///<summary>
@@ -1439,14 +1334,11 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateTag.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return UpdateTag.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return UpdateTag.Forbidden
-            else
-                return UpdateTag.NotFound
+            match status with
+            | HttpStatusCode.OK -> return UpdateTag.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return UpdateTag.BadRequest
+            | HttpStatusCode.Forbidden -> return UpdateTag.Forbidden
+            | _ -> return UpdateTag.NotFound
         }
 
     ///<summary>
@@ -1517,10 +1409,8 @@ type FreeFormWatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags/{id}/sites" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSitesByTags.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSitesByTags.Forbidden
-            else
-                return GetSitesByTags.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSitesByTags.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSitesByTags.Forbidden
+            | _ -> return GetSitesByTags.NotFound
         }

--- a/examples/Ghibli/Client.fs
+++ b/examples/Ghibli/Client.fs
@@ -104,12 +104,10 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/films" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetFilms.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetFilms.BadRequest
-            else
-                return GetFilms.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetFilms.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetFilms.BadRequest
+            | _ -> return GetFilms.NotFound
         }
 
     ///<summary>
@@ -127,12 +125,10 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/films/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetFilmsById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetFilmsById.BadRequest
-            else
-                return GetFilmsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetFilmsById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetFilmsById.BadRequest
+            | _ -> return GetFilmsById.NotFound
         }
 
     ///<summary>
@@ -151,12 +147,10 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/people" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetPeople.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetPeople.BadRequest
-            else
-                return GetPeople.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetPeople.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetPeople.BadRequest
+            | _ -> return GetPeople.NotFound
         }
 
     ///<summary>
@@ -174,12 +168,10 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/people/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetPeopleById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetPeopleById.BadRequest
-            else
-                return GetPeopleById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetPeopleById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetPeopleById.BadRequest
+            | _ -> return GetPeopleById.NotFound
         }
 
     ///<summary>
@@ -198,12 +190,10 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/locations" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetLocations.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetLocations.BadRequest
-            else
-                return GetLocations.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetLocations.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetLocations.BadRequest
+            | _ -> return GetLocations.NotFound
         }
 
     ///<summary>
@@ -221,12 +211,10 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/locations/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetLocationsById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetLocationsById.BadRequest
-            else
-                return GetLocationsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetLocationsById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetLocationsById.BadRequest
+            | _ -> return GetLocationsById.NotFound
         }
 
     ///<summary>
@@ -245,12 +233,10 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/species" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSpecies.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetSpecies.BadRequest
-            else
-                return GetSpecies.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSpecies.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetSpecies.BadRequest
+            | _ -> return GetSpecies.NotFound
         }
 
     ///<summary>
@@ -268,12 +254,10 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/species/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSpeciesById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetSpeciesById.BadRequest
-            else
-                return GetSpeciesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSpeciesById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetSpeciesById.BadRequest
+            | _ -> return GetSpeciesById.NotFound
         }
 
     ///<summary>
@@ -292,12 +276,10 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/vehicles" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetVehicles.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetVehicles.BadRequest
-            else
-                return GetVehicles.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetVehicles.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetVehicles.BadRequest
+            | _ -> return GetVehicles.NotFound
         }
 
     ///<summary>
@@ -315,10 +297,8 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/vehicles/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetVehiclesById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetVehiclesById.BadRequest
-            else
-                return GetVehiclesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetVehiclesById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetVehiclesById.BadRequest
+            | _ -> return GetVehiclesById.NotFound
         }

--- a/examples/Ghibli/Client.fs
+++ b/examples/Ghibli/Client.fs
@@ -104,9 +104,9 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/films" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetFilms.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetFilms.BadRequest
+            match int status with
+            | 200 -> return GetFilms.OK(Serializer.deserialize content)
+            | 400 -> return GetFilms.BadRequest
             | _ -> return GetFilms.NotFound
         }
 
@@ -125,9 +125,9 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/films/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetFilmsById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetFilmsById.BadRequest
+            match int status with
+            | 200 -> return GetFilmsById.OK(Serializer.deserialize content)
+            | 400 -> return GetFilmsById.BadRequest
             | _ -> return GetFilmsById.NotFound
         }
 
@@ -147,9 +147,9 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/people" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetPeople.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetPeople.BadRequest
+            match int status with
+            | 200 -> return GetPeople.OK(Serializer.deserialize content)
+            | 400 -> return GetPeople.BadRequest
             | _ -> return GetPeople.NotFound
         }
 
@@ -168,9 +168,9 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/people/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetPeopleById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetPeopleById.BadRequest
+            match int status with
+            | 200 -> return GetPeopleById.OK(Serializer.deserialize content)
+            | 400 -> return GetPeopleById.BadRequest
             | _ -> return GetPeopleById.NotFound
         }
 
@@ -190,9 +190,9 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/locations" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetLocations.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetLocations.BadRequest
+            match int status with
+            | 200 -> return GetLocations.OK(Serializer.deserialize content)
+            | 400 -> return GetLocations.BadRequest
             | _ -> return GetLocations.NotFound
         }
 
@@ -211,9 +211,9 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/locations/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetLocationsById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetLocationsById.BadRequest
+            match int status with
+            | 200 -> return GetLocationsById.OK(Serializer.deserialize content)
+            | 400 -> return GetLocationsById.BadRequest
             | _ -> return GetLocationsById.NotFound
         }
 
@@ -233,9 +233,9 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/species" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSpecies.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetSpecies.BadRequest
+            match int status with
+            | 200 -> return GetSpecies.OK(Serializer.deserialize content)
+            | 400 -> return GetSpecies.BadRequest
             | _ -> return GetSpecies.NotFound
         }
 
@@ -254,9 +254,9 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/species/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSpeciesById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetSpeciesById.BadRequest
+            match int status with
+            | 200 -> return GetSpeciesById.OK(Serializer.deserialize content)
+            | 400 -> return GetSpeciesById.BadRequest
             | _ -> return GetSpeciesById.NotFound
         }
 
@@ -276,9 +276,9 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/vehicles" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetVehicles.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetVehicles.BadRequest
+            match int status with
+            | 200 -> return GetVehicles.OK(Serializer.deserialize content)
+            | 400 -> return GetVehicles.BadRequest
             | _ -> return GetVehicles.NotFound
         }
 
@@ -297,8 +297,8 @@ type GhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/vehicles/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetVehiclesById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetVehiclesById.BadRequest
+            match int status with
+            | 200 -> return GetVehiclesById.OK(Serializer.deserialize content)
+            | 400 -> return GetVehiclesById.BadRequest
             | _ -> return GetVehiclesById.NotFound
         }

--- a/examples/NSwagWithFiles/Client.fs
+++ b/examples/NSwagWithFiles/Client.fs
@@ -37,9 +37,9 @@ type NSwagWithFilesClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/api/Brandings/upload" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UploadBrandingImage.OK
-            | HttpStatusCode.BadRequest -> return UploadBrandingImage.BadRequest(Serializer.deserialize content)
+            match int status with
+            | 200 -> return UploadBrandingImage.OK
+            | 400 -> return UploadBrandingImage.BadRequest(Serializer.deserialize content)
             | _ -> return UploadBrandingImage.Unauthorized(Serializer.deserialize content)
         }
 
@@ -73,8 +73,8 @@ type NSwagWithFilesClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/api/Datahub/datasources" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetDataSources.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetDataSources.OK(Serializer.deserialize content)
             | _ -> return GetDataSources.Unauthorized content
         }
 
@@ -106,8 +106,8 @@ type NSwagWithFilesClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/api/Datahub/import" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return ImportData.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return ImportData.OK(Serializer.deserialize content)
             | _ -> return ImportData.Unauthorized content
         }
 
@@ -121,9 +121,9 @@ type NSwagWithFilesClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/api/Documents/upload" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UploadFile.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return UploadFile.BadRequest(Serializer.deserialize content)
+            match int status with
+            | 200 -> return UploadFile.OK(Serializer.deserialize content)
+            | 400 -> return UploadFile.BadRequest(Serializer.deserialize content)
             | _ -> return UploadFile.Unauthorized(Serializer.deserialize content)
         }
 
@@ -137,9 +137,9 @@ type NSwagWithFilesClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.postBinaryAsync httpClient "/api/Documents/download" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DownloadFile.OK contentBinary
-            | HttpStatusCode.BadRequest ->
+            match int status with
+            | 200 -> return DownloadFile.OK contentBinary
+            | 400 ->
                 let content = Encoding.UTF8.GetString contentBinary
                 return DownloadFile.BadRequest(Serializer.deserialize content)
             | _ ->

--- a/examples/NSwagWithFiles/Client.fs
+++ b/examples/NSwagWithFiles/Client.fs
@@ -37,12 +37,10 @@ type NSwagWithFilesClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/api/Brandings/upload" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UploadBrandingImage.OK
-            else if status = HttpStatusCode.BadRequest then
-                return UploadBrandingImage.BadRequest(Serializer.deserialize content)
-            else
-                return UploadBrandingImage.Unauthorized(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return UploadBrandingImage.OK
+            | HttpStatusCode.BadRequest -> return UploadBrandingImage.BadRequest(Serializer.deserialize content)
+            | _ -> return UploadBrandingImage.Unauthorized(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -75,10 +73,9 @@ type NSwagWithFilesClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/api/Datahub/datasources" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetDataSources.OK(Serializer.deserialize content)
-            else
-                return GetDataSources.Unauthorized content
+            match status with
+            | HttpStatusCode.OK -> return GetDataSources.OK(Serializer.deserialize content)
+            | _ -> return GetDataSources.Unauthorized content
         }
 
     ///<summary>
@@ -109,10 +106,9 @@ type NSwagWithFilesClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/api/Datahub/import" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return ImportData.OK(Serializer.deserialize content)
-            else
-                return ImportData.Unauthorized content
+            match status with
+            | HttpStatusCode.OK -> return ImportData.OK(Serializer.deserialize content)
+            | _ -> return ImportData.Unauthorized content
         }
 
     member this.UploadFile(nodeId: int, ?path: string, ?cancellationToken: CancellationToken) =
@@ -125,12 +121,10 @@ type NSwagWithFilesClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/api/Documents/upload" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UploadFile.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return UploadFile.BadRequest(Serializer.deserialize content)
-            else
-                return UploadFile.Unauthorized(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return UploadFile.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return UploadFile.BadRequest(Serializer.deserialize content)
+            | _ -> return UploadFile.Unauthorized(Serializer.deserialize content)
         }
 
     member this.DownloadFile(nodeId: int, ?path: string, ?cancellationToken: CancellationToken) =
@@ -143,12 +137,12 @@ type NSwagWithFilesClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.postBinaryAsync httpClient "/api/Documents/download" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DownloadFile.OK contentBinary
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return DownloadFile.OK contentBinary
+            | HttpStatusCode.BadRequest ->
                 let content = Encoding.UTF8.GetString contentBinary
                 return DownloadFile.BadRequest(Serializer.deserialize content)
-            else
+            | _ ->
                 let content = Encoding.UTF8.GetString contentBinary
                 return DownloadFile.Unauthorized(Serializer.deserialize content)
         }

--- a/examples/Podiosuite/Client.fs
+++ b/examples/Podiosuite/Client.fs
@@ -16,14 +16,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/auth/token" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAuthToken.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAuthToken.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAuthToken.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthToken.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAuthToken.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAuthToken.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAuthToken.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthToken.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -40,14 +37,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/recover-password" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAuthRecoverPassword.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAuthRecoverPassword.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -70,14 +64,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/reset/{mailtoken}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -97,14 +89,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/revoke-token" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAuthRevokeToken.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAuthRevokeToken.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -124,14 +113,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/change-password" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAuthChangePassword.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAuthChangePassword.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -145,14 +131,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/users" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostUsers.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostUsers.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostUsers.Unauthorized(Serializer.deserialize content)
-            else
-                return PostUsers.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostUsers.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostUsers.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostUsers.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostUsers.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -218,14 +201,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUsers.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetUsers.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetUsers.Unauthorized(Serializer.deserialize content)
-            else
-                return GetUsers.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetUsers.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetUsers.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetUsers.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetUsers.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -294,14 +274,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/usersbulk" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostUsersbulk.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostUsersbulk.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostUsersbulk.Unauthorized(Serializer.deserialize content)
-            else
-                return PostUsersbulk.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostUsersbulk.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostUsersbulk.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostUsersbulk.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostUsersbulk.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -318,14 +295,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/me" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUsersMe.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetUsersMe.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetUsersMe.Unauthorized(Serializer.deserialize content)
-            else
-                return GetUsersMe.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetUsersMe.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetUsersMe.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetUsersMe.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetUsersMe.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -339,14 +313,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/users/me/accept-tc" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostUsersMeAcceptTc.Created
-            else if status = HttpStatusCode.BadRequest then
-                return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
-            else
-                return PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return PostUsersMeAcceptTc.Created
+            | HttpStatusCode.BadRequest -> return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -371,14 +342,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUsersByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetUsersByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetUsersByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetUsersByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetUsersByUserId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -403,14 +371,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutUsersByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutUsersByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PutUsersByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutUsersByUserId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -435,14 +400,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteUsersByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return DeleteUsersByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -465,14 +427,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/change-password" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -494,14 +455,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/favorites" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -523,14 +482,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/customization" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -550,14 +508,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/permissions" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -570,14 +526,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/notifications" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsNotifications.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsNotifications.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -594,14 +548,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsNotificationsByNotificationId.OK
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsNotificationsByNotificationId.OK
+            | HttpStatusCode.BadRequest ->
                 return PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -618,13 +571,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return DeleteAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -636,14 +589,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/accounts" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccounts.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAccounts.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetAccounts.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccounts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetAccounts.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAccounts.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetAccounts.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccounts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -654,14 +604,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent account ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/accounts" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAccounts.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAccounts.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAccounts.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAccounts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAccounts.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAccounts.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAccounts.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAccounts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -672,14 +619,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync httpClient "/accountsbulk" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAccountsbulk.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAccountsbulk.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAccountsbulk.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAccountsbulk.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAccountsbulk.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAccountsbulk.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -692,14 +636,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -712,14 +653,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -736,14 +674,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -760,14 +696,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}/branding" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -780,14 +715,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/branding/verify" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -800,14 +734,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/roles" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -824,13 +756,14 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
+            match status with
+            | HttpStatusCode.OK ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.InternalServerError(Serializer.deserialize content)
         }
 
@@ -844,14 +777,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/notifications" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -868,13 +800,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsNotificationsByAccountIdAndNotificationId.OK
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsNotificationsByAccountIdAndNotificationId.OK
+            | HttpStatusCode.BadRequest ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     PutAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(
                         Serializer.deserialize content
@@ -895,15 +827,15 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
+            | HttpStatusCode.BadRequest ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(
                         Serializer.deserialize content
@@ -922,14 +854,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/products" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -948,14 +879,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/products/alerts" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsProductsAlerts.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PutAccountsProductsAlerts.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PutAccountsProductsAlerts.Unauthorized
-            else
-                return PutAccountsProductsAlerts.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsProductsAlerts.OK
+            | HttpStatusCode.BadRequest -> return PutAccountsProductsAlerts.BadRequest
+            | HttpStatusCode.Unauthorized -> return PutAccountsProductsAlerts.Unauthorized
+            | _ -> return PutAccountsProductsAlerts.InternalServerError
         }
 
     ///<summary>
@@ -972,14 +900,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}/topup-direct" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1066,13 +993,14 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
+            match status with
+            | HttpStatusCode.OK ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     GetAccountsSecuritySettingsAvailableGapsByAccountId.InternalServerError(
                         Serializer.deserialize content
@@ -1102,13 +1030,14 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
+            match status with
+            | HttpStatusCode.OK ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     GetAccountsSecuritySettingsAvailableIpsByAccountId.InternalServerError(
                         Serializer.deserialize content
@@ -1136,14 +1065,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/mail" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostMail.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostMail.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostMail.Unauthorized(Serializer.deserialize content)
-            else
-                return PostMail.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostMail.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostMail.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostMail.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostMail.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1319,18 +1245,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/products" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetProducts.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetProducts.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return GetProducts.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return GetProducts.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return GetProducts.InternalServerError
-            else
-                return GetProducts.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return GetProducts.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetProducts.BadRequest
+            | HttpStatusCode.Unauthorized -> return GetProducts.Unauthorized
+            | HttpStatusCode.Forbidden -> return GetProducts.Forbidden
+            | HttpStatusCode.InternalServerError -> return GetProducts.InternalServerError
+            | _ -> return GetProducts.ServiceUnavailable
         }
 
     ///<summary>
@@ -1349,14 +1270,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/products" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostProducts.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostProducts.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostProducts.Unauthorized(Serializer.deserialize content)
-            else
-                return PostProducts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostProducts.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostProducts.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostProducts.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostProducts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1370,18 +1288,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetProductsByProductId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetProductsByProductId.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return GetProductsByProductId.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return GetProductsByProductId.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return GetProductsByProductId.InternalServerError
-            else
-                return GetProductsByProductId.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return GetProductsByProductId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetProductsByProductId.BadRequest
+            | HttpStatusCode.Unauthorized -> return GetProductsByProductId.Unauthorized
+            | HttpStatusCode.Forbidden -> return GetProductsByProductId.Forbidden
+            | HttpStatusCode.InternalServerError -> return GetProductsByProductId.InternalServerError
+            | _ -> return GetProductsByProductId.ServiceUnavailable
         }
 
     ///<summary>
@@ -1401,14 +1314,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PatchProductsByProductId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PatchProductsByProductId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
-            else
-                return PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1422,14 +1333,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteProductsByProductId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return DeleteProductsByProductId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
+            | _ -> return DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1446,14 +1355,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/schema/product" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSchemaProduct.OK
-            else if status = HttpStatusCode.BadRequest then
-                return GetSchemaProduct.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
-            else
-                return GetSchemaProduct.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetSchemaProduct.OK
+            | HttpStatusCode.BadRequest -> return GetSchemaProduct.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetSchemaProduct.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1473,18 +1379,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/products/{productId}/transfer" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostProductsTransferByProductId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostProductsTransferByProductId.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PostProductsTransferByProductId.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return PostProductsTransferByProductId.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return PostProductsTransferByProductId.InternalServerError
-            else
-                return PostProductsTransferByProductId.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return PostProductsTransferByProductId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostProductsTransferByProductId.BadRequest
+            | HttpStatusCode.Unauthorized -> return PostProductsTransferByProductId.Unauthorized
+            | HttpStatusCode.Forbidden -> return PostProductsTransferByProductId.Forbidden
+            | HttpStatusCode.InternalServerError -> return PostProductsTransferByProductId.InternalServerError
+            | _ -> return PostProductsTransferByProductId.ServiceUnavailable
         }
 
     ///<summary>
@@ -1530,16 +1431,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/cdr" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetCdr.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetCdr.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetCdr.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return GetCdr.NotFound(Serializer.deserialize content)
-            else
-                return GetCdr.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetCdr.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetCdr.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetCdr.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return GetCdr.NotFound(Serializer.deserialize content)
+            | _ -> return GetCdr.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1575,14 +1472,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/assets" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssets.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAssets.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetAssets.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAssets.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1593,14 +1487,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/assets" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssets.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssets.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAssets.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAssets.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1611,14 +1502,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/assetsbulk" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsbulk.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsbulk.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsbulk.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsbulk.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAssetsbulk.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssetsbulk.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1629,14 +1517,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1647,14 +1532,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1665,14 +1547,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteAssetsByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return DeleteAssetsByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1689,14 +1568,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/groupname" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1713,14 +1590,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/transfer" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1737,14 +1612,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/subscribe" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1761,14 +1634,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/unsubscribe" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1785,14 +1656,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/resubscribe" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1809,14 +1678,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/suspend" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1833,14 +1699,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/unsuspend" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1855,14 +1719,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/alerts" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsAlertsByIccid.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsAlertsByIccid.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PutAssetsAlertsByIccid.Unauthorized
-            else
-                return PutAssetsAlertsByIccid.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsAlertsByIccid.OK
+            | HttpStatusCode.BadRequest -> return PutAssetsAlertsByIccid.BadRequest
+            | HttpStatusCode.Unauthorized -> return PutAssetsAlertsByIccid.Unauthorized
+            | _ -> return PutAssetsAlertsByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1875,14 +1736,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/purge" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsPurgeByIccid.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsPurgeByIccid.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsPurgeByIccid.Unauthorized
-            else
-                return PostAssetsPurgeByIccid.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsPurgeByIccid.OK
+            | HttpStatusCode.BadRequest -> return PostAssetsPurgeByIccid.BadRequest
+            | HttpStatusCode.Unauthorized -> return PostAssetsPurgeByIccid.Unauthorized
+            | _ -> return PostAssetsPurgeByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1895,14 +1753,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/sms" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsSmsByIccid.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsSmsByIccid.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsSmsByIccid.Unauthorized
-            else
-                return PostAssetsSmsByIccid.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsSmsByIccid.OK
+            | HttpStatusCode.BadRequest -> return PostAssetsSmsByIccid.BadRequest
+            | HttpStatusCode.Unauthorized -> return PostAssetsSmsByIccid.Unauthorized
+            | _ -> return PostAssetsSmsByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1915,14 +1770,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/limit" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsLimitByIccid.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsLimitByIccid.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsLimitByIccid.Unauthorized
-            else
-                return PostAssetsLimitByIccid.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsLimitByIccid.OK
+            | HttpStatusCode.BadRequest -> return PostAssetsLimitByIccid.BadRequest
+            | HttpStatusCode.Unauthorized -> return PostAssetsLimitByIccid.Unauthorized
+            | _ -> return PostAssetsLimitByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1963,14 +1815,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/tags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsTagsByIccid.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsTagsByIccid.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsTagsByIccid.Unauthorized
-            else
-                return PostAssetsTagsByIccid.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsTagsByIccid.OK
+            | HttpStatusCode.BadRequest -> return PostAssetsTagsByIccid.BadRequest
+            | HttpStatusCode.Unauthorized -> return PostAssetsTagsByIccid.Unauthorized
+            | _ -> return PostAssetsTagsByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1983,14 +1832,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/diagnostic" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetAssetsDiagnosticByIccid.Unauthorized
-            else if status = HttpStatusCode.InternalServerError then
-                return GetAssetsDiagnosticByIccid.InternalServerError
-            else
-                return GetAssetsDiagnosticByIccid.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetAssetsDiagnosticByIccid.Unauthorized
+            | HttpStatusCode.InternalServerError -> return GetAssetsDiagnosticByIccid.InternalServerError
+            | _ -> return GetAssetsDiagnosticByIccid.ServiceUnavailable
         }
 
     ///<summary>
@@ -2003,16 +1849,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/location" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
-            else
-                return GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
+            | _ -> return GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2025,16 +1868,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/sessions" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
-            else
-                return GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
+            | _ -> return GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2062,12 +1902,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetReportsCustom.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetReportsCustom.Unauthorized(Serializer.deserialize content)
-            else
-                return GetReportsCustom.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetReportsCustom.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetReportsCustom.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2078,16 +1916,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent report ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostReportsCustom.OK
-            else if status = HttpStatusCode.Unauthorized then
-                return PostReportsCustom.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return PostReportsCustom.Forbidden(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return PostReportsCustom.NotFound(Serializer.deserialize content)
-            else
-                return PostReportsCustom.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostReportsCustom.OK
+            | HttpStatusCode.Unauthorized -> return PostReportsCustom.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return PostReportsCustom.Forbidden(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return PostReportsCustom.NotFound(Serializer.deserialize content)
+            | _ -> return PostReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2098,12 +1932,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return DeleteReportsCustom.NoContent
-            else if status = HttpStatusCode.Unauthorized then
-                return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return DeleteReportsCustom.NoContent
+            | HttpStatusCode.Unauthorized -> return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2116,14 +1948,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetReportsCustomByReportId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetReportsCustomByReportId.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
-            else
-                return GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
+            | _ -> return GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2136,14 +1966,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return DeleteReportsCustomByReportId.NoContent
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.NoContent -> return DeleteReportsCustomByReportId.NoContent
+            | HttpStatusCode.Unauthorized ->
                 return DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
-            else
-                return DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
+            | _ -> return DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2209,14 +2037,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/events" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetEvents.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetEvents.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetEvents.Unauthorized(Serializer.deserialize content)
-            else
-                return GetEvents.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetEvents.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetEvents.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetEvents.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetEvents.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2276,14 +2101,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/subscribe" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2296,14 +2118,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/transfer" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2316,14 +2135,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/return" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2336,14 +2152,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/suspend" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2356,14 +2169,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/unsuspend" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2380,14 +2190,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/resubscribe" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2398,14 +2206,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/bulk/assets" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssets.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssets.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssets.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssets.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2416,14 +2221,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/bulk/assets" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PutBulkAssets.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutBulkAssets.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutBulkAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PutBulkAssets.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutBulkAssets.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutBulkAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2436,14 +2238,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/groupname" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2456,14 +2255,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/limit" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2478,14 +2274,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/alerts" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2496,14 +2289,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/bulk/assets/sms" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2516,14 +2306,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/purge" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2570,14 +2357,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/reallocate-ip" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2650,14 +2435,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/payments/topupPaypal" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
-            else
-                return PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2677,14 +2459,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/payments/confirmTopupPaypal" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
-            else
-                return PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2786,18 +2567,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/security/alerts" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSecurityAlerts.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetSecurityAlerts.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return GetSecurityAlerts.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return GetSecurityAlerts.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return GetSecurityAlerts.InternalServerError
-            else
-                return GetSecurityAlerts.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return GetSecurityAlerts.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetSecurityAlerts.BadRequest
+            | HttpStatusCode.Unauthorized -> return GetSecurityAlerts.Unauthorized
+            | HttpStatusCode.Forbidden -> return GetSecurityAlerts.Forbidden
+            | HttpStatusCode.InternalServerError -> return GetSecurityAlerts.InternalServerError
+            | _ -> return GetSecurityAlerts.ServiceUnavailable
         }
 
     ///<summary>
@@ -2823,18 +2599,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetSecurityAlertsByAlertId.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return GetSecurityAlertsByAlertId.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return GetSecurityAlertsByAlertId.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return GetSecurityAlertsByAlertId.InternalServerError
-            else
-                return GetSecurityAlertsByAlertId.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetSecurityAlertsByAlertId.BadRequest
+            | HttpStatusCode.Unauthorized -> return GetSecurityAlertsByAlertId.Unauthorized
+            | HttpStatusCode.Forbidden -> return GetSecurityAlertsByAlertId.Forbidden
+            | HttpStatusCode.InternalServerError -> return GetSecurityAlertsByAlertId.InternalServerError
+            | _ -> return GetSecurityAlertsByAlertId.ServiceUnavailable
         }
 
     ///<summary>
@@ -2863,18 +2634,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutSecurityAlertsByAlertId.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PutSecurityAlertsByAlertId.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return PutSecurityAlertsByAlertId.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return PutSecurityAlertsByAlertId.InternalServerError
-            else
-                return PutSecurityAlertsByAlertId.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutSecurityAlertsByAlertId.BadRequest
+            | HttpStatusCode.Unauthorized -> return PutSecurityAlertsByAlertId.Unauthorized
+            | HttpStatusCode.Forbidden -> return PutSecurityAlertsByAlertId.Forbidden
+            | HttpStatusCode.InternalServerError -> return PutSecurityAlertsByAlertId.InternalServerError
+            | _ -> return PutSecurityAlertsByAlertId.ServiceUnavailable
         }
 
     ///<summary>
@@ -2900,18 +2666,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return DeleteSecurityAlertsByAlertId.NoContent
-            else if status = HttpStatusCode.BadRequest then
-                return DeleteSecurityAlertsByAlertId.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return DeleteSecurityAlertsByAlertId.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteSecurityAlertsByAlertId.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return DeleteSecurityAlertsByAlertId.InternalServerError
-            else
-                return DeleteSecurityAlertsByAlertId.ServiceUnavailable
+            match status with
+            | HttpStatusCode.NoContent -> return DeleteSecurityAlertsByAlertId.NoContent
+            | HttpStatusCode.BadRequest -> return DeleteSecurityAlertsByAlertId.BadRequest
+            | HttpStatusCode.Unauthorized -> return DeleteSecurityAlertsByAlertId.Unauthorized
+            | HttpStatusCode.Forbidden -> return DeleteSecurityAlertsByAlertId.Forbidden
+            | HttpStatusCode.InternalServerError -> return DeleteSecurityAlertsByAlertId.InternalServerError
+            | _ -> return DeleteSecurityAlertsByAlertId.ServiceUnavailable
         }
 
     ///<summary>
@@ -2946,14 +2707,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/security/topthreaten" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2988,14 +2747,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/security/byalarmtype" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3020,14 +2777,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/esims" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostEsims.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostEsims.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostEsims.Unauthorized(Serializer.deserialize content)
-            else
-                return PostEsims.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostEsims.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostEsims.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostEsims.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostEsims.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3070,14 +2824,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/esims/{eid}/transfer" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostEsimsTransferByEid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostEsimsTransferByEid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3090,14 +2841,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/esims/{eid}/return" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostEsimsReturnByEid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostEsimsReturnByEid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3421,14 +3169,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/1" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph1.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph1.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph1.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph1.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph1.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph1.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph1.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph1.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3458,14 +3203,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/2" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph2.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph2.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph2.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph2.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph2.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph2.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph2.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph2.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3495,14 +3237,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/3" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph3.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph3.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph3.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph3.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph3.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph3.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph3.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph3.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3532,14 +3271,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/4" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph4.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph4.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph4.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph4.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph4.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph4.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph4.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph4.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3569,14 +3305,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/5" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph5.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph5.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph5.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph5.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph5.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph5.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph5.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph5.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3606,14 +3339,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/6" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph6.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph6.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph6.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph6.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph6.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph6.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph6.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph6.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3643,14 +3373,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/7" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph7.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph7.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph7.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph7.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph7.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph7.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph7.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph7.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3680,14 +3407,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/8" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph8.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph8.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph8.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph8.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph8.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph8.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph8.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph8.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3717,14 +3441,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/9" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph9.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph9.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph9.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph9.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph9.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph9.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph9.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph9.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3738,14 +3459,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/10" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph10.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph10.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph10.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph10.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph10.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph10.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph10.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph10.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3775,14 +3493,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/11" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph11.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph11.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph11.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph11.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph11.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph11.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph11.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph11.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3812,14 +3527,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/12" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph12.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph12.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph12.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph12.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph12.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph12.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph12.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph12.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3850,14 +3562,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/statusesperday" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraphStatusesperday.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraphStatusesperday.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3887,14 +3596,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3907,14 +3614,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3927,14 +3632,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3951,14 +3655,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3975,14 +3678,13 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return DeleteAssetsQuickDialByIccidAndLocation.NoContent
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.NoContent -> return DeleteAssetsQuickDialByIccidAndLocation.NoContent
+            | HttpStatusCode.BadRequest ->
                 return DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+            | _ -> return DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3995,14 +3697,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/dial" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsDialByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsDialByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>

--- a/examples/Podiosuite/Client.fs
+++ b/examples/Podiosuite/Client.fs
@@ -16,10 +16,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/auth/token" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAuthToken.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAuthToken.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAuthToken.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAuthToken.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthToken.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthToken.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAuthToken.InternalServerError(Serializer.deserialize content)
         }
 
@@ -37,10 +37,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/recover-password" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAuthRecoverPassword.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAuthRecoverPassword.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
         }
 
@@ -64,11 +64,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/reset/{mailtoken}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
         }
 
@@ -89,10 +88,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/revoke-token" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAuthRevokeToken.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAuthRevokeToken.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
         }
 
@@ -113,10 +112,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/change-password" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAuthChangePassword.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAuthChangePassword.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
         }
 
@@ -131,10 +130,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/users" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostUsers.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostUsers.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostUsers.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostUsers.OK(Serializer.deserialize content)
+            | 400 -> return PostUsers.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostUsers.Unauthorized(Serializer.deserialize content)
             | _ -> return PostUsers.InternalServerError(Serializer.deserialize content)
         }
 
@@ -201,10 +200,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUsers.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetUsers.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetUsers.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetUsers.OK(Serializer.deserialize content)
+            | 400 -> return GetUsers.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetUsers.Unauthorized(Serializer.deserialize content)
             | _ -> return GetUsers.InternalServerError(Serializer.deserialize content)
         }
 
@@ -274,10 +273,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/usersbulk" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostUsersbulk.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostUsersbulk.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostUsersbulk.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostUsersbulk.OK(Serializer.deserialize content)
+            | 400 -> return PostUsersbulk.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostUsersbulk.Unauthorized(Serializer.deserialize content)
             | _ -> return PostUsersbulk.InternalServerError(Serializer.deserialize content)
         }
 
@@ -295,10 +294,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/me" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUsersMe.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetUsersMe.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetUsersMe.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetUsersMe.OK(Serializer.deserialize content)
+            | 400 -> return GetUsersMe.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetUsersMe.Unauthorized(Serializer.deserialize content)
             | _ -> return GetUsersMe.InternalServerError(Serializer.deserialize content)
         }
 
@@ -313,10 +312,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/users/me/accept-tc" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostUsersMeAcceptTc.Created
-            | HttpStatusCode.BadRequest -> return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PostUsersMeAcceptTc.Created
+            | 400 -> return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
             | _ -> return PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
         }
 
@@ -342,10 +341,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUsersByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetUsersByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetUsersByUserId.OK(Serializer.deserialize content)
+            | 400 -> return GetUsersByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -371,10 +370,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutUsersByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutUsersByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutUsersByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -400,10 +399,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteUsersByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteUsersByUserId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -427,12 +426,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/change-password" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -455,11 +452,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/favorites" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -482,12 +478,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/customization" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -508,11 +502,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/permissions" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -526,11 +519,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/notifications" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsNotifications.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsNotifications.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
         }
 
@@ -548,12 +540,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsNotificationsByNotificationId.OK
-            | HttpStatusCode.BadRequest ->
-                return PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAccountsNotificationsByNotificationId.OK
+            | 400 -> return PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -571,12 +561,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
             | _ ->
                 return DeleteAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
         }
@@ -589,10 +577,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/accounts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccounts.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAccounts.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetAccounts.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccounts.OK(Serializer.deserialize content)
+            | 400 -> return GetAccounts.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccounts.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccounts.InternalServerError(Serializer.deserialize content)
         }
 
@@ -604,10 +592,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent account ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/accounts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAccounts.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAccounts.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAccounts.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAccounts.OK(Serializer.deserialize content)
+            | 400 -> return PostAccounts.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAccounts.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAccounts.InternalServerError(Serializer.deserialize content)
         }
 
@@ -619,10 +607,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync httpClient "/accountsbulk" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAccountsbulk.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAccountsbulk.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAccountsbulk.OK(Serializer.deserialize content)
+            | 400 -> return PostAccountsbulk.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAccountsbulk.InternalServerError(Serializer.deserialize content)
         }
 
@@ -636,10 +624,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -653,10 +641,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAccountsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -674,11 +662,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -696,12 +683,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}/branding" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -715,12 +700,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/branding/verify" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -734,11 +717,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/roles" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -756,13 +738,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK ->
-                return GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
             | _ ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.InternalServerError(Serializer.deserialize content)
         }
@@ -777,12 +756,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/notifications" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -800,11 +777,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsNotificationsByAccountIdAndNotificationId.OK
-            | HttpStatusCode.BadRequest ->
+            match int status with
+            | 200 -> return PutAccountsNotificationsByAccountIdAndNotificationId.OK
+            | 400 ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
+            | 401 ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
             | _ ->
                 return
@@ -827,12 +804,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
-            | HttpStatusCode.BadRequest ->
+            match int status with
+            | 200 -> return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
+            | 400 ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
+            | 401 ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
             | _ ->
@@ -854,12 +831,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/products" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -879,10 +854,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/products/alerts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsProductsAlerts.OK
-            | HttpStatusCode.BadRequest -> return PutAccountsProductsAlerts.BadRequest
-            | HttpStatusCode.Unauthorized -> return PutAccountsProductsAlerts.Unauthorized
+            match int status with
+            | 200 -> return PutAccountsProductsAlerts.OK
+            | 400 -> return PutAccountsProductsAlerts.BadRequest
+            | 401 -> return PutAccountsProductsAlerts.Unauthorized
             | _ -> return PutAccountsProductsAlerts.InternalServerError
         }
 
@@ -900,12 +875,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}/topup-direct" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -993,12 +966,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK ->
-                return GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
+            match int status with
+            | 200 -> return GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
+            | 400 ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
+            | 401 ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ ->
                 return
@@ -1030,12 +1002,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK ->
-                return GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
+            match int status with
+            | 200 -> return GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
+            | 400 ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
+            | 401 ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ ->
                 return
@@ -1065,10 +1036,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/mail" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostMail.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostMail.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostMail.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostMail.OK(Serializer.deserialize content)
+            | 400 -> return PostMail.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostMail.Unauthorized(Serializer.deserialize content)
             | _ -> return PostMail.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1245,12 +1216,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/products" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetProducts.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetProducts.BadRequest
-            | HttpStatusCode.Unauthorized -> return GetProducts.Unauthorized
-            | HttpStatusCode.Forbidden -> return GetProducts.Forbidden
-            | HttpStatusCode.InternalServerError -> return GetProducts.InternalServerError
+            match int status with
+            | 200 -> return GetProducts.OK(Serializer.deserialize content)
+            | 400 -> return GetProducts.BadRequest
+            | 401 -> return GetProducts.Unauthorized
+            | 403 -> return GetProducts.Forbidden
+            | 500 -> return GetProducts.InternalServerError
             | _ -> return GetProducts.ServiceUnavailable
         }
 
@@ -1270,10 +1241,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/products" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostProducts.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostProducts.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostProducts.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostProducts.OK(Serializer.deserialize content)
+            | 400 -> return PostProducts.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostProducts.Unauthorized(Serializer.deserialize content)
             | _ -> return PostProducts.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1288,12 +1259,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetProductsByProductId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetProductsByProductId.BadRequest
-            | HttpStatusCode.Unauthorized -> return GetProductsByProductId.Unauthorized
-            | HttpStatusCode.Forbidden -> return GetProductsByProductId.Forbidden
-            | HttpStatusCode.InternalServerError -> return GetProductsByProductId.InternalServerError
+            match int status with
+            | 200 -> return GetProductsByProductId.OK(Serializer.deserialize content)
+            | 400 -> return GetProductsByProductId.BadRequest
+            | 401 -> return GetProductsByProductId.Unauthorized
+            | 403 -> return GetProductsByProductId.Forbidden
+            | 500 -> return GetProductsByProductId.InternalServerError
             | _ -> return GetProductsByProductId.ServiceUnavailable
         }
 
@@ -1314,11 +1285,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PatchProductsByProductId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PatchProductsByProductId.OK(Serializer.deserialize content)
+            | 400 -> return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
             | _ -> return PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1333,11 +1303,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteProductsByProductId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteProductsByProductId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1355,10 +1324,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/schema/product" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSchemaProduct.OK
-            | HttpStatusCode.BadRequest -> return GetSchemaProduct.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetSchemaProduct.OK
+            | 400 -> return GetSchemaProduct.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
             | _ -> return GetSchemaProduct.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1379,12 +1348,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/products/{productId}/transfer" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostProductsTransferByProductId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostProductsTransferByProductId.BadRequest
-            | HttpStatusCode.Unauthorized -> return PostProductsTransferByProductId.Unauthorized
-            | HttpStatusCode.Forbidden -> return PostProductsTransferByProductId.Forbidden
-            | HttpStatusCode.InternalServerError -> return PostProductsTransferByProductId.InternalServerError
+            match int status with
+            | 200 -> return PostProductsTransferByProductId.OK(Serializer.deserialize content)
+            | 400 -> return PostProductsTransferByProductId.BadRequest
+            | 401 -> return PostProductsTransferByProductId.Unauthorized
+            | 403 -> return PostProductsTransferByProductId.Forbidden
+            | 500 -> return PostProductsTransferByProductId.InternalServerError
             | _ -> return PostProductsTransferByProductId.ServiceUnavailable
         }
 
@@ -1431,11 +1400,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/cdr" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetCdr.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetCdr.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetCdr.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return GetCdr.NotFound(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetCdr.OK(Serializer.deserialize content)
+            | 400 -> return GetCdr.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetCdr.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetCdr.NotFound(Serializer.deserialize content)
             | _ -> return GetCdr.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1472,10 +1441,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/assets" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssets.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAssets.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetAssets.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssets.OK(Serializer.deserialize content)
+            | 400 -> return GetAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssets.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAssets.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1487,10 +1456,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/assets" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssets.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAssets.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAssets.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAssets.OK(Serializer.deserialize content)
+            | 400 -> return PostAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssets.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAssets.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1502,10 +1471,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/assetsbulk" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsbulk.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAssetsbulk.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAssetsbulk.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsbulk.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAssetsbulk.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1517,10 +1486,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssetsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1532,10 +1501,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1547,10 +1516,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteAssetsByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteAssetsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1568,11 +1537,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/groupname" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1590,11 +1558,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/transfer" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1612,11 +1579,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/subscribe" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1634,11 +1600,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/unsubscribe" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1656,11 +1621,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/resubscribe" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1678,10 +1642,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/suspend" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1699,11 +1663,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/unsuspend" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1719,10 +1682,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/alerts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsAlertsByIccid.OK
-            | HttpStatusCode.BadRequest -> return PutAssetsAlertsByIccid.BadRequest
-            | HttpStatusCode.Unauthorized -> return PutAssetsAlertsByIccid.Unauthorized
+            match int status with
+            | 200 -> return PutAssetsAlertsByIccid.OK
+            | 400 -> return PutAssetsAlertsByIccid.BadRequest
+            | 401 -> return PutAssetsAlertsByIccid.Unauthorized
             | _ -> return PutAssetsAlertsByIccid.InternalServerError
         }
 
@@ -1736,10 +1699,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/purge" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsPurgeByIccid.OK
-            | HttpStatusCode.BadRequest -> return PostAssetsPurgeByIccid.BadRequest
-            | HttpStatusCode.Unauthorized -> return PostAssetsPurgeByIccid.Unauthorized
+            match int status with
+            | 200 -> return PostAssetsPurgeByIccid.OK
+            | 400 -> return PostAssetsPurgeByIccid.BadRequest
+            | 401 -> return PostAssetsPurgeByIccid.Unauthorized
             | _ -> return PostAssetsPurgeByIccid.InternalServerError
         }
 
@@ -1753,10 +1716,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/sms" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsSmsByIccid.OK
-            | HttpStatusCode.BadRequest -> return PostAssetsSmsByIccid.BadRequest
-            | HttpStatusCode.Unauthorized -> return PostAssetsSmsByIccid.Unauthorized
+            match int status with
+            | 200 -> return PostAssetsSmsByIccid.OK
+            | 400 -> return PostAssetsSmsByIccid.BadRequest
+            | 401 -> return PostAssetsSmsByIccid.Unauthorized
             | _ -> return PostAssetsSmsByIccid.InternalServerError
         }
 
@@ -1770,10 +1733,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/limit" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsLimitByIccid.OK
-            | HttpStatusCode.BadRequest -> return PostAssetsLimitByIccid.BadRequest
-            | HttpStatusCode.Unauthorized -> return PostAssetsLimitByIccid.Unauthorized
+            match int status with
+            | 200 -> return PostAssetsLimitByIccid.OK
+            | 400 -> return PostAssetsLimitByIccid.BadRequest
+            | 401 -> return PostAssetsLimitByIccid.Unauthorized
             | _ -> return PostAssetsLimitByIccid.InternalServerError
         }
 
@@ -1815,10 +1778,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/tags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsTagsByIccid.OK
-            | HttpStatusCode.BadRequest -> return PostAssetsTagsByIccid.BadRequest
-            | HttpStatusCode.Unauthorized -> return PostAssetsTagsByIccid.Unauthorized
+            match int status with
+            | 200 -> return PostAssetsTagsByIccid.OK
+            | 400 -> return PostAssetsTagsByIccid.BadRequest
+            | 401 -> return PostAssetsTagsByIccid.Unauthorized
             | _ -> return PostAssetsTagsByIccid.InternalServerError
         }
 
@@ -1832,10 +1795,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/diagnostic" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetAssetsDiagnosticByIccid.Unauthorized
-            | HttpStatusCode.InternalServerError -> return GetAssetsDiagnosticByIccid.InternalServerError
+            match int status with
+            | 200 -> return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
+            | 401 -> return GetAssetsDiagnosticByIccid.Unauthorized
+            | 500 -> return GetAssetsDiagnosticByIccid.InternalServerError
             | _ -> return GetAssetsDiagnosticByIccid.ServiceUnavailable
         }
 
@@ -1849,12 +1812,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/location" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
             | _ -> return GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1868,12 +1830,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/sessions" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
             | _ -> return GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1902,9 +1863,9 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetReportsCustom.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetReportsCustom.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetReportsCustom.OK(Serializer.deserialize content)
+            | 401 -> return GetReportsCustom.Unauthorized(Serializer.deserialize content)
             | _ -> return GetReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1916,11 +1877,11 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent report ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostReportsCustom.OK
-            | HttpStatusCode.Unauthorized -> return PostReportsCustom.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return PostReportsCustom.Forbidden(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return PostReportsCustom.NotFound(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostReportsCustom.OK
+            | 401 -> return PostReportsCustom.Unauthorized(Serializer.deserialize content)
+            | 403 -> return PostReportsCustom.Forbidden(Serializer.deserialize content)
+            | 404 -> return PostReportsCustom.NotFound(Serializer.deserialize content)
             | _ -> return PostReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1932,9 +1893,9 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return DeleteReportsCustom.NoContent
-            | HttpStatusCode.Unauthorized -> return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 204 -> return DeleteReportsCustom.NoContent
+            | 401 -> return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1948,11 +1909,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetReportsCustomByReportId.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetReportsCustomByReportId.OK(Serializer.deserialize content)
+            | 401 -> return GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
             | _ -> return GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1966,11 +1926,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return DeleteReportsCustomByReportId.NoContent
-            | HttpStatusCode.Unauthorized ->
-                return DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
+            match int status with
+            | 204 -> return DeleteReportsCustomByReportId.NoContent
+            | 401 -> return DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
+            | 404 -> return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
             | _ -> return DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2037,10 +1996,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/events" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetEvents.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetEvents.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetEvents.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetEvents.OK(Serializer.deserialize content)
+            | 400 -> return GetEvents.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetEvents.Unauthorized(Serializer.deserialize content)
             | _ -> return GetEvents.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2101,10 +2060,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/subscribe" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2118,10 +2077,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/transfer" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2135,10 +2094,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/return" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2152,10 +2111,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/suspend" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
             | _ -> return PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2169,10 +2128,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/unsuspend" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
             | _ -> return PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2190,11 +2149,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/resubscribe" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2206,10 +2164,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/bulk/assets" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssets.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssets.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssets.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssets.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssets.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssets.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2221,10 +2179,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/bulk/assets" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PutBulkAssets.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutBulkAssets.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutBulkAssets.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PutBulkAssets.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssets.Unauthorized(Serializer.deserialize content)
             | _ -> return PutBulkAssets.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2238,10 +2196,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/groupname" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
             | _ -> return PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2255,10 +2213,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/limit" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2274,10 +2232,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/alerts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
             | _ -> return PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2289,10 +2247,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/bulk/assets/sms" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2306,10 +2264,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/purge" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2357,11 +2315,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/reallocate-ip" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2435,10 +2392,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/payments/topupPaypal" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
+            | 400 -> return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
             | _ -> return PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2459,12 +2416,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/payments/confirmTopupPaypal" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
+            | 400 -> return PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
             | _ -> return PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2567,12 +2522,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/security/alerts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSecurityAlerts.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetSecurityAlerts.BadRequest
-            | HttpStatusCode.Unauthorized -> return GetSecurityAlerts.Unauthorized
-            | HttpStatusCode.Forbidden -> return GetSecurityAlerts.Forbidden
-            | HttpStatusCode.InternalServerError -> return GetSecurityAlerts.InternalServerError
+            match int status with
+            | 200 -> return GetSecurityAlerts.OK(Serializer.deserialize content)
+            | 400 -> return GetSecurityAlerts.BadRequest
+            | 401 -> return GetSecurityAlerts.Unauthorized
+            | 403 -> return GetSecurityAlerts.Forbidden
+            | 500 -> return GetSecurityAlerts.InternalServerError
             | _ -> return GetSecurityAlerts.ServiceUnavailable
         }
 
@@ -2599,12 +2554,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetSecurityAlertsByAlertId.BadRequest
-            | HttpStatusCode.Unauthorized -> return GetSecurityAlertsByAlertId.Unauthorized
-            | HttpStatusCode.Forbidden -> return GetSecurityAlertsByAlertId.Forbidden
-            | HttpStatusCode.InternalServerError -> return GetSecurityAlertsByAlertId.InternalServerError
+            match int status with
+            | 200 -> return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+            | 400 -> return GetSecurityAlertsByAlertId.BadRequest
+            | 401 -> return GetSecurityAlertsByAlertId.Unauthorized
+            | 403 -> return GetSecurityAlertsByAlertId.Forbidden
+            | 500 -> return GetSecurityAlertsByAlertId.InternalServerError
             | _ -> return GetSecurityAlertsByAlertId.ServiceUnavailable
         }
 
@@ -2634,12 +2589,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutSecurityAlertsByAlertId.BadRequest
-            | HttpStatusCode.Unauthorized -> return PutSecurityAlertsByAlertId.Unauthorized
-            | HttpStatusCode.Forbidden -> return PutSecurityAlertsByAlertId.Forbidden
-            | HttpStatusCode.InternalServerError -> return PutSecurityAlertsByAlertId.InternalServerError
+            match int status with
+            | 200 -> return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+            | 400 -> return PutSecurityAlertsByAlertId.BadRequest
+            | 401 -> return PutSecurityAlertsByAlertId.Unauthorized
+            | 403 -> return PutSecurityAlertsByAlertId.Forbidden
+            | 500 -> return PutSecurityAlertsByAlertId.InternalServerError
             | _ -> return PutSecurityAlertsByAlertId.ServiceUnavailable
         }
 
@@ -2666,12 +2621,12 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return DeleteSecurityAlertsByAlertId.NoContent
-            | HttpStatusCode.BadRequest -> return DeleteSecurityAlertsByAlertId.BadRequest
-            | HttpStatusCode.Unauthorized -> return DeleteSecurityAlertsByAlertId.Unauthorized
-            | HttpStatusCode.Forbidden -> return DeleteSecurityAlertsByAlertId.Forbidden
-            | HttpStatusCode.InternalServerError -> return DeleteSecurityAlertsByAlertId.InternalServerError
+            match int status with
+            | 204 -> return DeleteSecurityAlertsByAlertId.NoContent
+            | 400 -> return DeleteSecurityAlertsByAlertId.BadRequest
+            | 401 -> return DeleteSecurityAlertsByAlertId.Unauthorized
+            | 403 -> return DeleteSecurityAlertsByAlertId.Forbidden
+            | 500 -> return DeleteSecurityAlertsByAlertId.InternalServerError
             | _ -> return DeleteSecurityAlertsByAlertId.ServiceUnavailable
         }
 
@@ -2707,11 +2662,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/security/topthreaten" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
+            | 400 -> return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2747,11 +2701,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/security/byalarmtype" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
+            | 400 -> return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2777,10 +2730,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/esims" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostEsims.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostEsims.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostEsims.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostEsims.OK(Serializer.deserialize content)
+            | 400 -> return PostEsims.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostEsims.Unauthorized(Serializer.deserialize content)
             | _ -> return PostEsims.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2824,10 +2777,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/esims/{eid}/transfer" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostEsimsTransferByEid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostEsimsTransferByEid.OK(Serializer.deserialize content)
+            | 400 -> return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
             | _ -> return PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2841,10 +2794,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/esims/{eid}/return" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostEsimsReturnByEid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostEsimsReturnByEid.OK(Serializer.deserialize content)
+            | 400 -> return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
             | _ -> return PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3169,10 +3122,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/1" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph1.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph1.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph1.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph1.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph1.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph1.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph1.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3203,10 +3156,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/2" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph2.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph2.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph2.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph2.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph2.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph2.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph2.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3237,10 +3190,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/3" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph3.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph3.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph3.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph3.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph3.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph3.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph3.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3271,10 +3224,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/4" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph4.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph4.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph4.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph4.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph4.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph4.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph4.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3305,10 +3258,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/5" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph5.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph5.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph5.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph5.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph5.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph5.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph5.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3339,10 +3292,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/6" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph6.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph6.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph6.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph6.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph6.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph6.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph6.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3373,10 +3326,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/7" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph7.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph7.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph7.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph7.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph7.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph7.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph7.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3407,10 +3360,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/8" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph8.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph8.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph8.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph8.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph8.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph8.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph8.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3441,10 +3394,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/9" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph9.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph9.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph9.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph9.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph9.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph9.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph9.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3459,10 +3412,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/10" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph10.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph10.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph10.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph10.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph10.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph10.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph10.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3493,10 +3446,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/11" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph11.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph11.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph11.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph11.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph11.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph11.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph11.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3527,10 +3480,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/12" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph12.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph12.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph12.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph12.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph12.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph12.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph12.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3562,10 +3515,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/statusesperday" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraphStatusesperday.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraphStatusesperday.OK(Serializer.deserialize content)
+            | 400 -> return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3596,11 +3549,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3614,11 +3566,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3632,12 +3583,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3655,12 +3604,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3678,12 +3625,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return DeleteAssetsQuickDialByIccidAndLocation.NoContent
-            | HttpStatusCode.BadRequest ->
-                return DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 204 -> return DeleteAssetsQuickDialByIccidAndLocation.NoContent
+            | 400 -> return DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3697,10 +3642,10 @@ type PodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/dial" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsDialByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAssetsDialByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 

--- a/examples/Slicebox/Client.fs
+++ b/examples/Slicebox/Client.fs
@@ -116,10 +116,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/anonymization/keys/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAnonymizationKeysById.OK(Serializer.deserialize content)
-            else
-                return GetAnonymizationKeysById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetAnonymizationKeysById.OK(Serializer.deserialize content)
+            | _ -> return GetAnonymizationKeysById.NotFound
         }
 
     ///<summary>
@@ -134,10 +133,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/anonymization/keys/{id}/keyvalues" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
-            else
-                return GetAnonymizationKeysKeyvaluesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
+            | _ -> return GetAnonymizationKeysKeyvaluesById.NotFound
         }
 
     ///<summary>
@@ -244,10 +242,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/boxes/incoming/{id}/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
-            else
-                return GetBoxesIncomingImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetBoxesIncomingImagesById.NotFound
         }
 
     ///<summary>
@@ -295,10 +292,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/boxes/outgoing/{id}/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
-            else
-                return GetBoxesOutgoingImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetBoxesOutgoingImagesById.NotFound
         }
 
     ///<summary>
@@ -332,10 +328,9 @@ type SliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/boxes/{id}/send" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostBoxesSendById.Created
-            else
-                return PostBoxesSendById.NotFound
+            match status with
+            | HttpStatusCode.Created -> return PostBoxesSendById.Created
+            | _ -> return PostBoxesSendById.NotFound
         }
 
     ///<summary>
@@ -606,10 +601,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostImages.OK(Serializer.deserialize content)
-            else
-                return PostImages.Created(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostImages.OK(Serializer.deserialize content)
+            | _ -> return PostImages.Created(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -649,10 +643,9 @@ type SliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/images/export" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostImagesExport.OK(Serializer.deserialize content)
-            else
-                return PostImagesExport.Created
+            match status with
+            | HttpStatusCode.OK -> return PostImagesExport.OK(Serializer.deserialize content)
+            | _ -> return PostImagesExport.Created
         }
 
     ///<summary>
@@ -705,10 +698,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/images/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImagesById.OK contentBinary
-            else
-                return GetImagesById.NotFound contentBinary
+            match status with
+            | HttpStatusCode.OK -> return GetImagesById.OK contentBinary
+            | _ -> return GetImagesById.NotFound contentBinary
         }
 
     ///<summary>
@@ -731,10 +723,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/images/{id}/anonymize" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutImagesAnonymizeById.OK(Serializer.deserialize content)
-            else
-                return PutImagesAnonymizeById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PutImagesAnonymizeById.OK(Serializer.deserialize content)
+            | _ -> return PutImagesAnonymizeById.NotFound
         }
 
     ///<summary>
@@ -757,10 +748,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/images/{id}/anonymized" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostImagesAnonymizedById.OK
-            else
-                return PostImagesAnonymizedById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PostImagesAnonymizedById.OK
+            | _ -> return PostImagesAnonymizedById.NotFound
         }
 
     ///<summary>
@@ -775,10 +765,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/images/{id}/attributes" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImagesAttributesById.OK(Serializer.deserialize content)
-            else
-                return GetImagesAttributesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetImagesAttributesById.OK(Serializer.deserialize content)
+            | _ -> return GetImagesAttributesById.NotFound
         }
 
     ///<summary>
@@ -793,10 +782,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/images/{id}/imageinformation" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImagesImageinformationById.OK(Serializer.deserialize content)
-            else
-                return GetImagesImageinformationById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetImagesImageinformationById.OK(Serializer.deserialize content)
+            | _ -> return GetImagesImageinformationById.NotFound
         }
 
     ///<summary>
@@ -855,10 +843,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/images/{id}/png" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImagesPngById.OK contentBinary
-            else
-                return GetImagesPngById.NotFound contentBinary
+            match status with
+            | HttpStatusCode.OK -> return GetImagesPngById.OK contentBinary
+            | _ -> return GetImagesPngById.NotFound contentBinary
         }
 
     ///<summary>
@@ -918,10 +905,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/import/sessions/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImportSessionsById.OK(Serializer.deserialize content)
-            else
-                return GetImportSessionsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetImportSessionsById.OK(Serializer.deserialize content)
+            | _ -> return GetImportSessionsById.NotFound
         }
 
     ///<summary>
@@ -936,10 +922,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/import/sessions/{id}/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImportSessionsImagesById.OK(Serializer.deserialize content)
-            else
-                return GetImportSessionsImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetImportSessionsImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetImportSessionsImagesById.NotFound
         }
 
     ///<summary>
@@ -957,12 +942,10 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/import/sessions/{id}/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostImportSessionsImagesById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return PostImportSessionsImagesById.Created(Serializer.deserialize content)
-            else
-                return PostImportSessionsImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PostImportSessionsImagesById.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return PostImportSessionsImagesById.Created(Serializer.deserialize content)
+            | _ -> return PostImportSessionsImagesById.NotFound
         }
 
     ///<summary>
@@ -1092,10 +1075,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/flatseries/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataFlatseriesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataFlatseriesById.NotFound
         }
 
     ///<summary>
@@ -1149,10 +1131,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/images/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataImagesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataImagesById.NotFound
         }
 
     ///<summary>
@@ -1227,10 +1208,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/patients/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataPatientsById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataPatientsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataPatientsById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataPatientsById.NotFound
         }
 
     ///<summary>
@@ -1328,10 +1308,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataSeriesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataSeriesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesById.NotFound
         }
 
     ///<summary>
@@ -1346,10 +1325,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/seriestags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesSeriestagsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesSeriestagsById.NotFound
         }
 
     ///<summary>
@@ -1367,10 +1345,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/metadata/series/{id}/seriestags" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
-            else
-                return PostMetadataSeriesSeriestagsById.NotFound
+            match status with
+            | HttpStatusCode.Created -> return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
+            | _ -> return PostMetadataSeriesSeriestagsById.NotFound
         }
 
     ///<summary>
@@ -1400,10 +1377,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/seriestypes" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesSeriestypesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesSeriestypesById.NotFound
         }
 
     ///<summary>
@@ -1418,10 +1394,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/source" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesSourceById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesSourceById.NotFound
         }
 
     ///<summary>
@@ -1502,10 +1477,9 @@ type SliceboxClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
-            else
-                return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NotFound
+            match status with
+            | HttpStatusCode.NoContent -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
+            | _ -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NotFound
         }
 
     ///<summary>
@@ -1584,10 +1558,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/studies/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataStudiesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataStudiesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataStudiesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataStudiesById.NotFound
         }
 
     ///<summary>
@@ -1619,10 +1592,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/studies/{id}/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataStudiesImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataStudiesImagesById.NotFound
         }
 
     ///<summary>
@@ -1651,10 +1623,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent scp ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scps" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostScps.Created(Serializer.deserialize content)
-            else
-                return PostScps.BadRequest
+            match status with
+            | HttpStatusCode.Created -> return PostScps.Created(Serializer.deserialize content)
+            | _ -> return PostScps.BadRequest
         }
 
     ///<summary>
@@ -1695,10 +1666,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent scu ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scus" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostScus.Created(Serializer.deserialize content)
-            else
-                return PostScus.BadRequest
+            match status with
+            | HttpStatusCode.Created -> return PostScus.Created(Serializer.deserialize content)
+            | _ -> return PostScus.BadRequest
         }
 
     ///<summary>
@@ -1727,10 +1697,9 @@ type SliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scus/{id}/send" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PostScusSendById.NoContent
-            else
-                return PostScusSendById.NotFound
+            match status with
+            | HttpStatusCode.NoContent -> return PostScusSendById.NoContent
+            | _ -> return PostScusSendById.NotFound
         }
 
     ///<summary>
@@ -1982,10 +1951,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/image" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PostTransactionsImageByToken.NoContent
-            else
-                return PostTransactionsImageByToken.Unauthorized
+            match status with
+            | HttpStatusCode.NoContent -> return PostTransactionsImageByToken.NoContent
+            | _ -> return PostTransactionsImageByToken.Unauthorized
         }
 
     ///<summary>
@@ -2011,12 +1979,10 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/transactions/{token}/outgoing" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTransactionsOutgoingByToken.OK contentBinary
-            else if status = HttpStatusCode.Unauthorized then
-                return GetTransactionsOutgoingByToken.Unauthorized contentBinary
-            else
-                return GetTransactionsOutgoingByToken.NotFound contentBinary
+            match status with
+            | HttpStatusCode.OK -> return GetTransactionsOutgoingByToken.OK contentBinary
+            | HttpStatusCode.Unauthorized -> return GetTransactionsOutgoingByToken.Unauthorized contentBinary
+            | _ -> return GetTransactionsOutgoingByToken.NotFound contentBinary
         }
 
     ///<summary>
@@ -2039,10 +2005,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/outgoing/done" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PostTransactionsOutgoingDoneByToken.NoContent
-            else
-                return PostTransactionsOutgoingDoneByToken.Unauthorized
+            match status with
+            | HttpStatusCode.NoContent -> return PostTransactionsOutgoingDoneByToken.NoContent
+            | _ -> return PostTransactionsOutgoingDoneByToken.Unauthorized
         }
 
     ///<summary>
@@ -2065,10 +2030,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/outgoing/failed" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PostTransactionsOutgoingFailedByToken.NoContent
-            else
-                return PostTransactionsOutgoingFailedByToken.Unauthorized
+            match status with
+            | HttpStatusCode.NoContent -> return PostTransactionsOutgoingFailedByToken.NoContent
+            | _ -> return PostTransactionsOutgoingFailedByToken.Unauthorized
         }
 
     ///<summary>
@@ -2083,12 +2047,10 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/transactions/{token}/outgoing/poll" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetTransactionsOutgoingPollByToken.Unauthorized
-            else
-                return GetTransactionsOutgoingPollByToken.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetTransactionsOutgoingPollByToken.Unauthorized
+            | _ -> return GetTransactionsOutgoingPollByToken.NotFound
         }
 
     ///<summary>
@@ -2111,12 +2073,10 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/transactions/{token}/status" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTransactionsStatusByToken.OK
-            else if status = HttpStatusCode.Unauthorized then
-                return GetTransactionsStatusByToken.Unauthorized
-            else
-                return GetTransactionsStatusByToken.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetTransactionsStatusByToken.OK
+            | HttpStatusCode.Unauthorized -> return GetTransactionsStatusByToken.Unauthorized
+            | _ -> return GetTransactionsStatusByToken.NotFound
         }
 
     ///<summary>
@@ -2142,10 +2102,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/transactions/{token}/status" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PutTransactionsStatusByToken.NoContent
-            else
-                return PutTransactionsStatusByToken.NotFound
+            match status with
+            | HttpStatusCode.NoContent -> return PutTransactionsStatusByToken.NoContent
+            | _ -> return PutTransactionsStatusByToken.NotFound
         }
 
     ///<summary>
@@ -2184,10 +2143,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/current" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUsersCurrent.OK(Serializer.deserialize content)
-            else
-                return GetUsersCurrent.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetUsersCurrent.OK(Serializer.deserialize content)
+            | _ -> return GetUsersCurrent.NotFound
         }
 
     ///<summary>
@@ -2198,10 +2156,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent userPass ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/users/login" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostUsersLogin.Created
-            else
-                return PostUsersLogin.Unauthorized
+            match status with
+            | HttpStatusCode.Created -> return PostUsersLogin.Created
+            | _ -> return PostUsersLogin.Unauthorized
         }
 
     ///<summary>

--- a/examples/Slicebox/Client.fs
+++ b/examples/Slicebox/Client.fs
@@ -116,8 +116,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/anonymization/keys/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAnonymizationKeysById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAnonymizationKeysById.OK(Serializer.deserialize content)
             | _ -> return GetAnonymizationKeysById.NotFound
         }
 
@@ -133,8 +133,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/anonymization/keys/{id}/keyvalues" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
             | _ -> return GetAnonymizationKeysKeyvaluesById.NotFound
         }
 
@@ -242,8 +242,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/boxes/incoming/{id}/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
             | _ -> return GetBoxesIncomingImagesById.NotFound
         }
 
@@ -292,8 +292,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/boxes/outgoing/{id}/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
             | _ -> return GetBoxesOutgoingImagesById.NotFound
         }
 
@@ -328,8 +328,8 @@ type SliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/boxes/{id}/send" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostBoxesSendById.Created
+            match int status with
+            | 201 -> return PostBoxesSendById.Created
             | _ -> return PostBoxesSendById.NotFound
         }
 
@@ -601,8 +601,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostImages.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostImages.OK(Serializer.deserialize content)
             | _ -> return PostImages.Created(Serializer.deserialize content)
         }
 
@@ -643,8 +643,8 @@ type SliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/images/export" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostImagesExport.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostImagesExport.OK(Serializer.deserialize content)
             | _ -> return PostImagesExport.Created
         }
 
@@ -698,8 +698,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/images/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImagesById.OK contentBinary
+            match int status with
+            | 200 -> return GetImagesById.OK contentBinary
             | _ -> return GetImagesById.NotFound contentBinary
         }
 
@@ -723,8 +723,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/images/{id}/anonymize" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutImagesAnonymizeById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutImagesAnonymizeById.OK(Serializer.deserialize content)
             | _ -> return PutImagesAnonymizeById.NotFound
         }
 
@@ -748,8 +748,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/images/{id}/anonymized" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostImagesAnonymizedById.OK
+            match int status with
+            | 200 -> return PostImagesAnonymizedById.OK
             | _ -> return PostImagesAnonymizedById.NotFound
         }
 
@@ -765,8 +765,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/images/{id}/attributes" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImagesAttributesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetImagesAttributesById.OK(Serializer.deserialize content)
             | _ -> return GetImagesAttributesById.NotFound
         }
 
@@ -782,8 +782,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/images/{id}/imageinformation" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImagesImageinformationById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetImagesImageinformationById.OK(Serializer.deserialize content)
             | _ -> return GetImagesImageinformationById.NotFound
         }
 
@@ -843,8 +843,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/images/{id}/png" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImagesPngById.OK contentBinary
+            match int status with
+            | 200 -> return GetImagesPngById.OK contentBinary
             | _ -> return GetImagesPngById.NotFound contentBinary
         }
 
@@ -905,8 +905,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/import/sessions/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImportSessionsById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetImportSessionsById.OK(Serializer.deserialize content)
             | _ -> return GetImportSessionsById.NotFound
         }
 
@@ -922,8 +922,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/import/sessions/{id}/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImportSessionsImagesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetImportSessionsImagesById.OK(Serializer.deserialize content)
             | _ -> return GetImportSessionsImagesById.NotFound
         }
 
@@ -942,9 +942,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/import/sessions/{id}/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostImportSessionsImagesById.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return PostImportSessionsImagesById.Created(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostImportSessionsImagesById.OK(Serializer.deserialize content)
+            | 201 -> return PostImportSessionsImagesById.Created(Serializer.deserialize content)
             | _ -> return PostImportSessionsImagesById.NotFound
         }
 
@@ -1075,8 +1075,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/flatseries/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataFlatseriesById.NotFound
         }
 
@@ -1131,8 +1131,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/images/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataImagesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataImagesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataImagesById.NotFound
         }
 
@@ -1208,8 +1208,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/patients/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataPatientsById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataPatientsById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataPatientsById.NotFound
         }
 
@@ -1308,8 +1308,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataSeriesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataSeriesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesById.NotFound
         }
 
@@ -1325,8 +1325,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/seriestags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesSeriestagsById.NotFound
         }
 
@@ -1345,8 +1345,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/metadata/series/{id}/seriestags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
             | _ -> return PostMetadataSeriesSeriestagsById.NotFound
         }
 
@@ -1377,8 +1377,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/seriestypes" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesSeriestypesById.NotFound
         }
 
@@ -1394,8 +1394,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/source" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesSourceById.NotFound
         }
 
@@ -1477,8 +1477,8 @@ type SliceboxClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
+            match int status with
+            | 204 -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
             | _ -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NotFound
         }
 
@@ -1558,8 +1558,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/studies/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataStudiesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataStudiesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataStudiesById.NotFound
         }
 
@@ -1592,8 +1592,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/studies/{id}/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataStudiesImagesById.NotFound
         }
 
@@ -1623,8 +1623,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent scp ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scps" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostScps.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PostScps.Created(Serializer.deserialize content)
             | _ -> return PostScps.BadRequest
         }
 
@@ -1666,8 +1666,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent scu ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scus" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostScus.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PostScus.Created(Serializer.deserialize content)
             | _ -> return PostScus.BadRequest
         }
 
@@ -1697,8 +1697,8 @@ type SliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scus/{id}/send" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PostScusSendById.NoContent
+            match int status with
+            | 204 -> return PostScusSendById.NoContent
             | _ -> return PostScusSendById.NotFound
         }
 
@@ -1951,8 +1951,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/image" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PostTransactionsImageByToken.NoContent
+            match int status with
+            | 204 -> return PostTransactionsImageByToken.NoContent
             | _ -> return PostTransactionsImageByToken.Unauthorized
         }
 
@@ -1979,9 +1979,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/transactions/{token}/outgoing" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTransactionsOutgoingByToken.OK contentBinary
-            | HttpStatusCode.Unauthorized -> return GetTransactionsOutgoingByToken.Unauthorized contentBinary
+            match int status with
+            | 200 -> return GetTransactionsOutgoingByToken.OK contentBinary
+            | 401 -> return GetTransactionsOutgoingByToken.Unauthorized contentBinary
             | _ -> return GetTransactionsOutgoingByToken.NotFound contentBinary
         }
 
@@ -2005,8 +2005,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/outgoing/done" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PostTransactionsOutgoingDoneByToken.NoContent
+            match int status with
+            | 204 -> return PostTransactionsOutgoingDoneByToken.NoContent
             | _ -> return PostTransactionsOutgoingDoneByToken.Unauthorized
         }
 
@@ -2030,8 +2030,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/outgoing/failed" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PostTransactionsOutgoingFailedByToken.NoContent
+            match int status with
+            | 204 -> return PostTransactionsOutgoingFailedByToken.NoContent
             | _ -> return PostTransactionsOutgoingFailedByToken.Unauthorized
         }
 
@@ -2047,9 +2047,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/transactions/{token}/outgoing/poll" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetTransactionsOutgoingPollByToken.Unauthorized
+            match int status with
+            | 200 -> return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
+            | 401 -> return GetTransactionsOutgoingPollByToken.Unauthorized
             | _ -> return GetTransactionsOutgoingPollByToken.NotFound
         }
 
@@ -2073,9 +2073,9 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/transactions/{token}/status" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTransactionsStatusByToken.OK
-            | HttpStatusCode.Unauthorized -> return GetTransactionsStatusByToken.Unauthorized
+            match int status with
+            | 200 -> return GetTransactionsStatusByToken.OK
+            | 401 -> return GetTransactionsStatusByToken.Unauthorized
             | _ -> return GetTransactionsStatusByToken.NotFound
         }
 
@@ -2102,8 +2102,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/transactions/{token}/status" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PutTransactionsStatusByToken.NoContent
+            match int status with
+            | 204 -> return PutTransactionsStatusByToken.NoContent
             | _ -> return PutTransactionsStatusByToken.NotFound
         }
 
@@ -2143,8 +2143,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/current" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUsersCurrent.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetUsersCurrent.OK(Serializer.deserialize content)
             | _ -> return GetUsersCurrent.NotFound
         }
 
@@ -2156,8 +2156,8 @@ type SliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent userPass ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/users/login" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostUsersLogin.Created
+            match int status with
+            | 201 -> return PostUsersLogin.Created
             | _ -> return PostUsersLogin.Unauthorized
         }
 

--- a/examples/Swashbuckle/Client.fs
+++ b/examples/Swashbuckle/Client.fs
@@ -13,8 +13,8 @@ type SwashbuckleClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Time" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTime.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetTime.BadRequest(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetTime.OK(Serializer.deserialize content)
+            | 400 -> return GetTime.BadRequest(Serializer.deserialize content)
             | _ -> return GetTime.Forbidden(Serializer.deserialize content)
         }

--- a/examples/Swashbuckle/Client.fs
+++ b/examples/Swashbuckle/Client.fs
@@ -13,10 +13,8 @@ type SwashbuckleClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Time" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTime.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetTime.BadRequest(Serializer.deserialize content)
-            else
-                return GetTime.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetTime.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetTime.BadRequest(Serializer.deserialize content)
+            | _ -> return GetTime.Forbidden(Serializer.deserialize content)
         }

--- a/examples/SyncGhibli/Client.fs
+++ b/examples/SyncGhibli/Client.fs
@@ -104,9 +104,9 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/films" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetFilms.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetFilms.BadRequest
+        match int status with
+        | 200 -> GetFilms.OK(Serializer.deserialize content)
+        | 400 -> GetFilms.BadRequest
         | _ -> GetFilms.NotFound
 
     ///<summary>
@@ -124,9 +124,9 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/films/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetFilmsById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetFilmsById.BadRequest
+        match int status with
+        | 200 -> GetFilmsById.OK(Serializer.deserialize content)
+        | 400 -> GetFilmsById.BadRequest
         | _ -> GetFilmsById.NotFound
 
     ///<summary>
@@ -145,9 +145,9 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/people" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetPeople.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetPeople.BadRequest
+        match int status with
+        | 200 -> GetPeople.OK(Serializer.deserialize content)
+        | 400 -> GetPeople.BadRequest
         | _ -> GetPeople.NotFound
 
     ///<summary>
@@ -165,9 +165,9 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/people/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetPeopleById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetPeopleById.BadRequest
+        match int status with
+        | 200 -> GetPeopleById.OK(Serializer.deserialize content)
+        | 400 -> GetPeopleById.BadRequest
         | _ -> GetPeopleById.NotFound
 
     ///<summary>
@@ -186,9 +186,9 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/locations" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetLocations.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetLocations.BadRequest
+        match int status with
+        | 200 -> GetLocations.OK(Serializer.deserialize content)
+        | 400 -> GetLocations.BadRequest
         | _ -> GetLocations.NotFound
 
     ///<summary>
@@ -206,9 +206,9 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/locations/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetLocationsById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetLocationsById.BadRequest
+        match int status with
+        | 200 -> GetLocationsById.OK(Serializer.deserialize content)
+        | 400 -> GetLocationsById.BadRequest
         | _ -> GetLocationsById.NotFound
 
     ///<summary>
@@ -227,9 +227,9 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/species" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSpecies.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetSpecies.BadRequest
+        match int status with
+        | 200 -> GetSpecies.OK(Serializer.deserialize content)
+        | 400 -> GetSpecies.BadRequest
         | _ -> GetSpecies.NotFound
 
     ///<summary>
@@ -247,9 +247,9 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/species/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSpeciesById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetSpeciesById.BadRequest
+        match int status with
+        | 200 -> GetSpeciesById.OK(Serializer.deserialize content)
+        | 400 -> GetSpeciesById.BadRequest
         | _ -> GetSpeciesById.NotFound
 
     ///<summary>
@@ -268,9 +268,9 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/vehicles" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetVehicles.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetVehicles.BadRequest
+        match int status with
+        | 200 -> GetVehicles.OK(Serializer.deserialize content)
+        | 400 -> GetVehicles.BadRequest
         | _ -> GetVehicles.NotFound
 
     ///<summary>
@@ -288,7 +288,7 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/vehicles/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetVehiclesById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetVehiclesById.BadRequest
+        match int status with
+        | 200 -> GetVehiclesById.OK(Serializer.deserialize content)
+        | 400 -> GetVehiclesById.BadRequest
         | _ -> GetVehiclesById.NotFound

--- a/examples/SyncGhibli/Client.fs
+++ b/examples/SyncGhibli/Client.fs
@@ -104,12 +104,10 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/films" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetFilms.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetFilms.BadRequest
-        else
-            GetFilms.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetFilms.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetFilms.BadRequest
+        | _ -> GetFilms.NotFound
 
     ///<summary>
     ///Returns a film based on a single ID
@@ -126,12 +124,10 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/films/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetFilmsById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetFilmsById.BadRequest
-        else
-            GetFilmsById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetFilmsById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetFilmsById.BadRequest
+        | _ -> GetFilmsById.NotFound
 
     ///<summary>
     ///The People endpoint returns information about all of the Studio Ghibli people. This broadly includes all Ghibli characters, human and non-.
@@ -149,12 +145,10 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/people" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetPeople.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetPeople.BadRequest
-        else
-            GetPeople.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetPeople.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetPeople.BadRequest
+        | _ -> GetPeople.NotFound
 
     ///<summary>
     ///Returns a person based on a single ID
@@ -171,12 +165,10 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/people/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetPeopleById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetPeopleById.BadRequest
-        else
-            GetPeopleById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetPeopleById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetPeopleById.BadRequest
+        | _ -> GetPeopleById.NotFound
 
     ///<summary>
     ///The Locations endpoint returns information about all of the Studio Ghibli locations. This broadly includes lands, countries, and places.
@@ -194,12 +186,10 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/locations" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetLocations.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetLocations.BadRequest
-        else
-            GetLocations.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetLocations.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetLocations.BadRequest
+        | _ -> GetLocations.NotFound
 
     ///<summary>
     ///Returns an individual location.
@@ -216,12 +206,10 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/locations/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetLocationsById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetLocationsById.BadRequest
-        else
-            GetLocationsById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetLocationsById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetLocationsById.BadRequest
+        | _ -> GetLocationsById.NotFound
 
     ///<summary>
     ///The Species endpoint returns information about all of the Studio Ghibli species. This includes humans, animals, and spirits et al.
@@ -239,12 +227,10 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/species" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSpecies.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetSpecies.BadRequest
-        else
-            GetSpecies.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetSpecies.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetSpecies.BadRequest
+        | _ -> GetSpecies.NotFound
 
     ///<summary>
     ///Returns an individual species
@@ -261,12 +247,10 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/species/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSpeciesById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetSpeciesById.BadRequest
-        else
-            GetSpeciesById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetSpeciesById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetSpeciesById.BadRequest
+        | _ -> GetSpeciesById.NotFound
 
     ///<summary>
     ///The Vehicles endpoint returns information about all of the Studio Ghibli vechiles. This includes cars, ships, and planes.
@@ -284,12 +268,10 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/vehicles" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetVehicles.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetVehicles.BadRequest
-        else
-            GetVehicles.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetVehicles.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetVehicles.BadRequest
+        | _ -> GetVehicles.NotFound
 
     ///<summary>
     ///An individual vehicle
@@ -306,9 +288,7 @@ type SyncGhibliClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/vehicles/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetVehiclesById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetVehiclesById.BadRequest
-        else
-            GetVehiclesById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetVehiclesById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetVehiclesById.BadRequest
+        | _ -> GetVehiclesById.NotFound

--- a/examples/SyncNSwag/Client.fs
+++ b/examples/SyncNSwag/Client.fs
@@ -36,12 +36,10 @@ type SyncNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Brandings/upload" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            UploadBrandingImage.OK
-        else if status = HttpStatusCode.BadRequest then
-            UploadBrandingImage.BadRequest(Serializer.deserialize content)
-        else
-            UploadBrandingImage.Unauthorized(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> UploadBrandingImage.OK
+        | HttpStatusCode.BadRequest -> UploadBrandingImage.BadRequest(Serializer.deserialize content)
+        | _ -> UploadBrandingImage.Unauthorized(Serializer.deserialize content)
 
     ///<summary>
     ///Retrieves the data sources for a supplier (data measuring company) for the specified period.
@@ -72,10 +70,9 @@ type SyncNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/api/Datahub/datasources" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetDataSources.OK(Serializer.deserialize content)
-        else
-            GetDataSources.Unauthorized content
+        match status with
+        | HttpStatusCode.OK -> GetDataSources.OK(Serializer.deserialize content)
+        | _ -> GetDataSources.Unauthorized content
 
     ///<summary>
     ///Expects the request body to be JSON formatted as follows:
@@ -104,10 +101,9 @@ type SyncNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Datahub/import" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            ImportData.OK(Serializer.deserialize content)
-        else
-            ImportData.Unauthorized content
+        match status with
+        | HttpStatusCode.OK -> ImportData.OK(Serializer.deserialize content)
+        | _ -> ImportData.Unauthorized content
 
     member this.UploadFile(nodeId: int, ?path: string, ?cancellationToken: CancellationToken) =
         let requestParts =
@@ -118,12 +114,10 @@ type SyncNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Documents/upload" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            UploadFile.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            UploadFile.BadRequest(Serializer.deserialize content)
-        else
-            UploadFile.Unauthorized(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> UploadFile.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> UploadFile.BadRequest(Serializer.deserialize content)
+        | _ -> UploadFile.Unauthorized(Serializer.deserialize content)
 
     member this.DownloadFile(nodeId: int, ?path: string, ?cancellationToken: CancellationToken) =
         let requestParts =
@@ -134,12 +128,12 @@ type SyncNSwagClient(httpClient: HttpClient) =
         let (status, contentBinary) =
             OpenApiHttp.postBinary httpClient "/api/Documents/download" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DownloadFile.OK contentBinary
-        else if status = HttpStatusCode.BadRequest then
+        match status with
+        | HttpStatusCode.OK -> DownloadFile.OK contentBinary
+        | HttpStatusCode.BadRequest ->
             let content = Encoding.UTF8.GetString contentBinary
             DownloadFile.BadRequest(Serializer.deserialize content)
-        else
+        | _ ->
             let content = Encoding.UTF8.GetString contentBinary
             DownloadFile.Unauthorized(Serializer.deserialize content)
 

--- a/examples/SyncNSwag/Client.fs
+++ b/examples/SyncNSwag/Client.fs
@@ -36,9 +36,9 @@ type SyncNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Brandings/upload" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> UploadBrandingImage.OK
-        | HttpStatusCode.BadRequest -> UploadBrandingImage.BadRequest(Serializer.deserialize content)
+        match int status with
+        | 200 -> UploadBrandingImage.OK
+        | 400 -> UploadBrandingImage.BadRequest(Serializer.deserialize content)
         | _ -> UploadBrandingImage.Unauthorized(Serializer.deserialize content)
 
     ///<summary>
@@ -70,8 +70,8 @@ type SyncNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/api/Datahub/datasources" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetDataSources.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetDataSources.OK(Serializer.deserialize content)
         | _ -> GetDataSources.Unauthorized content
 
     ///<summary>
@@ -101,8 +101,8 @@ type SyncNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Datahub/import" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> ImportData.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> ImportData.OK(Serializer.deserialize content)
         | _ -> ImportData.Unauthorized content
 
     member this.UploadFile(nodeId: int, ?path: string, ?cancellationToken: CancellationToken) =
@@ -114,9 +114,9 @@ type SyncNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Documents/upload" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> UploadFile.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> UploadFile.BadRequest(Serializer.deserialize content)
+        match int status with
+        | 200 -> UploadFile.OK(Serializer.deserialize content)
+        | 400 -> UploadFile.BadRequest(Serializer.deserialize content)
         | _ -> UploadFile.Unauthorized(Serializer.deserialize content)
 
     member this.DownloadFile(nodeId: int, ?path: string, ?cancellationToken: CancellationToken) =
@@ -128,9 +128,9 @@ type SyncNSwagClient(httpClient: HttpClient) =
         let (status, contentBinary) =
             OpenApiHttp.postBinary httpClient "/api/Documents/download" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DownloadFile.OK contentBinary
-        | HttpStatusCode.BadRequest ->
+        match int status with
+        | 200 -> DownloadFile.OK contentBinary
+        | 400 ->
             let content = Encoding.UTF8.GetString contentBinary
             DownloadFile.BadRequest(Serializer.deserialize content)
         | _ ->

--- a/examples/SyncPetStore/Client.fs
+++ b/examples/SyncPetStore/Client.fs
@@ -24,10 +24,10 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/pet" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> UpdatePet.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> UpdatePet.BadRequest
-        | HttpStatusCode.NotFound -> UpdatePet.NotFound
+        match int status with
+        | 200 -> UpdatePet.OK(Serializer.deserialize content)
+        | 400 -> UpdatePet.BadRequest
+        | 404 -> UpdatePet.NotFound
         | _ -> UpdatePet.MethodNotAllowed
 
     ///<summary>
@@ -39,8 +39,8 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/pet" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> AddPet.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> AddPet.OK(Serializer.deserialize content)
         | _ -> AddPet.MethodNotAllowed
 
     ///<summary>
@@ -56,8 +56,8 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/pet/findByStatus" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> FindPetsByStatus.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> FindPetsByStatus.OK(Serializer.deserialize content)
         | _ -> FindPetsByStatus.BadRequest
 
     ///<summary>
@@ -73,8 +73,8 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/pet/findByTags" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> FindPetsByTags.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> FindPetsByTags.OK(Serializer.deserialize content)
         | _ -> FindPetsByTags.BadRequest
 
     ///<summary>
@@ -88,9 +88,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/pet/{petId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetPetById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetPetById.BadRequest
+        match int status with
+        | 200 -> GetPetById.OK(Serializer.deserialize content)
+        | 400 -> GetPetById.BadRequest
         | _ -> GetPetById.NotFound
 
     ///<summary>
@@ -111,8 +111,8 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/pet/{petId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.MethodNotAllowed -> UpdatePetWithForm.MethodNotAllowed
+        match int status with
+        | 405 -> UpdatePetWithForm.MethodNotAllowed
         | _ -> UpdatePetWithForm.DefaultResponse
 
     ///<summary>
@@ -130,8 +130,8 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/pet/{petId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.BadRequest -> DeletePet.BadRequest
+        match int status with
+        | 400 -> DeletePet.BadRequest
         | _ -> DeletePet.DefaultResponse
 
     ///<summary>
@@ -180,8 +180,8 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/store/order" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PlaceOrder.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> PlaceOrder.OK(Serializer.deserialize content)
         | _ -> PlaceOrder.MethodNotAllowed
 
     ///<summary>
@@ -196,9 +196,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetOrderById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetOrderById.BadRequest
+        match int status with
+        | 200 -> GetOrderById.OK(Serializer.deserialize content)
+        | 400 -> GetOrderById.BadRequest
         | _ -> GetOrderById.NotFound
 
     ///<summary>
@@ -213,9 +213,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.BadRequest -> DeleteOrder.BadRequest
-        | HttpStatusCode.NotFound -> DeleteOrder.NotFound
+        match int status with
+        | 400 -> DeleteOrder.BadRequest
+        | 404 -> DeleteOrder.NotFound
         | _ -> DeleteOrder.DefaultResponse
 
     ///<summary>
@@ -238,8 +238,8 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/user/createWithList" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> CreateUsersWithListInput.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> CreateUsersWithListInput.OK(Serializer.deserialize content)
         | _ -> CreateUsersWithListInput.DefaultResponse
 
     ///<summary>
@@ -258,8 +258,8 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/user/login" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> LoginUser.OK content
+        match int status with
+        | 200 -> LoginUser.OK content
         | _ -> LoginUser.BadRequest
 
     ///<summary>
@@ -285,9 +285,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/user/{username}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetUserByName.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetUserByName.BadRequest
+        match int status with
+        | 200 -> GetUserByName.OK(Serializer.deserialize content)
+        | 400 -> GetUserByName.BadRequest
         | _ -> GetUserByName.NotFound
 
     ///<summary>
@@ -318,7 +318,7 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/user/{username}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.BadRequest -> DeleteUser.BadRequest
-        | HttpStatusCode.NotFound -> DeleteUser.NotFound
+        match int status with
+        | 400 -> DeleteUser.BadRequest
+        | 404 -> DeleteUser.NotFound
         | _ -> DeleteUser.DefaultResponse

--- a/examples/SyncPetStore/Client.fs
+++ b/examples/SyncPetStore/Client.fs
@@ -24,14 +24,11 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/pet" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            UpdatePet.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            UpdatePet.BadRequest
-        else if status = HttpStatusCode.NotFound then
-            UpdatePet.NotFound
-        else
-            UpdatePet.MethodNotAllowed
+        match status with
+        | HttpStatusCode.OK -> UpdatePet.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> UpdatePet.BadRequest
+        | HttpStatusCode.NotFound -> UpdatePet.NotFound
+        | _ -> UpdatePet.MethodNotAllowed
 
     ///<summary>
     ///Add a new pet to the store
@@ -42,10 +39,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/pet" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            AddPet.OK(Serializer.deserialize content)
-        else
-            AddPet.MethodNotAllowed
+        match status with
+        | HttpStatusCode.OK -> AddPet.OK(Serializer.deserialize content)
+        | _ -> AddPet.MethodNotAllowed
 
     ///<summary>
     ///Multiple status values can be provided with comma separated strings
@@ -60,10 +56,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/pet/findByStatus" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            FindPetsByStatus.OK(Serializer.deserialize content)
-        else
-            FindPetsByStatus.BadRequest
+        match status with
+        | HttpStatusCode.OK -> FindPetsByStatus.OK(Serializer.deserialize content)
+        | _ -> FindPetsByStatus.BadRequest
 
     ///<summary>
     ///Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
@@ -78,10 +73,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/pet/findByTags" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            FindPetsByTags.OK(Serializer.deserialize content)
-        else
-            FindPetsByTags.BadRequest
+        match status with
+        | HttpStatusCode.OK -> FindPetsByTags.OK(Serializer.deserialize content)
+        | _ -> FindPetsByTags.BadRequest
 
     ///<summary>
     ///Returns a single pet
@@ -94,12 +88,10 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/pet/{petId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetPetById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetPetById.BadRequest
-        else
-            GetPetById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetPetById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetPetById.BadRequest
+        | _ -> GetPetById.NotFound
 
     ///<summary>
     ///Updates a pet in the store with form data
@@ -119,10 +111,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/pet/{petId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.MethodNotAllowed then
-            UpdatePetWithForm.MethodNotAllowed
-        else
-            UpdatePetWithForm.DefaultResponse
+        match status with
+        | HttpStatusCode.MethodNotAllowed -> UpdatePetWithForm.MethodNotAllowed
+        | _ -> UpdatePetWithForm.DefaultResponse
 
     ///<summary>
     ///Deletes a pet
@@ -139,10 +130,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/pet/{petId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.BadRequest then
-            DeletePet.BadRequest
-        else
-            DeletePet.DefaultResponse
+        match status with
+        | HttpStatusCode.BadRequest -> DeletePet.BadRequest
+        | _ -> DeletePet.DefaultResponse
 
     ///<summary>
     ///uploads an image
@@ -190,10 +180,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/store/order" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PlaceOrder.OK(Serializer.deserialize content)
-        else
-            PlaceOrder.MethodNotAllowed
+        match status with
+        | HttpStatusCode.OK -> PlaceOrder.OK(Serializer.deserialize content)
+        | _ -> PlaceOrder.MethodNotAllowed
 
     ///<summary>
     ///For valid response try integer IDs with value &amp;lt;= 5 or &amp;gt; 10. Other values will generate exceptions.
@@ -207,12 +196,10 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetOrderById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetOrderById.BadRequest
-        else
-            GetOrderById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetOrderById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetOrderById.BadRequest
+        | _ -> GetOrderById.NotFound
 
     ///<summary>
     ///For valid response try integer IDs with value &amp;lt; 1000. Anything above 1000 or nonintegers will generate API errors
@@ -226,12 +213,10 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.BadRequest then
-            DeleteOrder.BadRequest
-        else if status = HttpStatusCode.NotFound then
-            DeleteOrder.NotFound
-        else
-            DeleteOrder.DefaultResponse
+        match status with
+        | HttpStatusCode.BadRequest -> DeleteOrder.BadRequest
+        | HttpStatusCode.NotFound -> DeleteOrder.NotFound
+        | _ -> DeleteOrder.DefaultResponse
 
     ///<summary>
     ///This can only be done by the logged in user.
@@ -253,10 +238,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/user/createWithList" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            CreateUsersWithListInput.OK(Serializer.deserialize content)
-        else
-            CreateUsersWithListInput.DefaultResponse
+        match status with
+        | HttpStatusCode.OK -> CreateUsersWithListInput.OK(Serializer.deserialize content)
+        | _ -> CreateUsersWithListInput.DefaultResponse
 
     ///<summary>
     ///Logs user into the system
@@ -274,10 +258,9 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/user/login" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            LoginUser.OK content
-        else
-            LoginUser.BadRequest
+        match status with
+        | HttpStatusCode.OK -> LoginUser.OK content
+        | _ -> LoginUser.BadRequest
 
     ///<summary>
     ///Logs out current logged in user session
@@ -302,12 +285,10 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/user/{username}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetUserByName.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetUserByName.BadRequest
-        else
-            GetUserByName.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetUserByName.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetUserByName.BadRequest
+        | _ -> GetUserByName.NotFound
 
     ///<summary>
     ///This can only be done by the logged in user.
@@ -337,9 +318,7 @@ type SyncPetStoreClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/user/{username}" requestParts cancellationToken
 
-        if status = HttpStatusCode.BadRequest then
-            DeleteUser.BadRequest
-        else if status = HttpStatusCode.NotFound then
-            DeleteUser.NotFound
-        else
-            DeleteUser.DefaultResponse
+        match status with
+        | HttpStatusCode.BadRequest -> DeleteUser.BadRequest
+        | HttpStatusCode.NotFound -> DeleteUser.NotFound
+        | _ -> DeleteUser.DefaultResponse

--- a/examples/SyncPodiosuite/Client.fs
+++ b/examples/SyncPodiosuite/Client.fs
@@ -17,10 +17,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/auth/token" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAuthToken.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAuthToken.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAuthToken.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAuthToken.OK(Serializer.deserialize content)
+        | 400 -> PostAuthToken.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAuthToken.Unauthorized(Serializer.deserialize content)
         | _ -> PostAuthToken.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -36,10 +36,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/auth/recover-password" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAuthRecoverPassword.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAuthRecoverPassword.OK(Serializer.deserialize content)
+        | 400 -> PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
         | _ -> PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -61,10 +61,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/auth/reset/{mailtoken}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAuthResetByMailtoken.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAuthResetByMailtoken.OK(Serializer.deserialize content)
+        | 400 -> PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
         | _ -> PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -83,10 +83,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/auth/revoke-token" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAuthRevokeToken.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAuthRevokeToken.OK(Serializer.deserialize content)
+        | 400 -> PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
         | _ -> PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -105,10 +105,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/auth/change-password" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAuthChangePassword.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAuthChangePassword.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAuthChangePassword.OK(Serializer.deserialize content)
+        | 400 -> PostAuthChangePassword.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
         | _ -> PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -122,10 +122,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/users" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostUsers.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostUsers.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostUsers.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostUsers.OK(Serializer.deserialize content)
+        | 400 -> PostUsers.BadRequest(Serializer.deserialize content)
+        | 401 -> PostUsers.Unauthorized(Serializer.deserialize content)
         | _ -> PostUsers.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -191,10 +191,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/users" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetUsers.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetUsers.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetUsers.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetUsers.OK(Serializer.deserialize content)
+        | 400 -> GetUsers.BadRequest(Serializer.deserialize content)
+        | 401 -> GetUsers.Unauthorized(Serializer.deserialize content)
         | _ -> GetUsers.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -263,10 +263,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/usersbulk" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostUsersbulk.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostUsersbulk.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostUsersbulk.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostUsersbulk.OK(Serializer.deserialize content)
+        | 400 -> PostUsersbulk.BadRequest(Serializer.deserialize content)
+        | 401 -> PostUsersbulk.Unauthorized(Serializer.deserialize content)
         | _ -> PostUsersbulk.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -283,10 +283,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/users/me" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetUsersMe.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetUsersMe.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetUsersMe.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetUsersMe.OK(Serializer.deserialize content)
+        | 400 -> GetUsersMe.BadRequest(Serializer.deserialize content)
+        | 401 -> GetUsersMe.Unauthorized(Serializer.deserialize content)
         | _ -> GetUsersMe.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -299,10 +299,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/users/me/accept-tc" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Created -> PostUsersMeAcceptTc.Created
-        | HttpStatusCode.BadRequest -> PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 201 -> PostUsersMeAcceptTc.Created
+        | 400 -> PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
+        | 401 -> PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
         | _ -> PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -327,10 +327,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/users/{userId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetUsersByUserId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetUsersByUserId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetUsersByUserId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetUsersByUserId.OK(Serializer.deserialize content)
+        | 400 -> GetUsersByUserId.BadRequest(Serializer.deserialize content)
+        | 401 -> GetUsersByUserId.Unauthorized(Serializer.deserialize content)
         | _ -> GetUsersByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -355,10 +355,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/users/{userId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutUsersByUserId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutUsersByUserId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutUsersByUserId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutUsersByUserId.OK(Serializer.deserialize content)
+        | 400 -> PutUsersByUserId.BadRequest(Serializer.deserialize content)
+        | 401 -> PutUsersByUserId.Unauthorized(Serializer.deserialize content)
         | _ -> PutUsersByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -383,10 +383,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/users/{userId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteUsersByUserId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> DeleteUsersByUserId.OK(Serializer.deserialize content)
+        | 400 -> DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
+        | 401 -> DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
         | _ -> DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -408,10 +408,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/users/{userId}/change-password" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
+        | 400 -> PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
+        | 401 -> PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
         | _ -> PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -432,10 +432,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/users/{userId}/favorites" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
+        | 400 -> PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
+        | 401 -> PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
         | _ -> PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -456,10 +456,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/users/{userId}/customization" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
+        | 400 -> PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
+        | 401 -> PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
         | _ -> PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -478,10 +478,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/users/{userId}/permissions" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
+        | 400 -> PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
+        | 401 -> PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
         | _ -> PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -493,10 +493,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/notifications" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAccountsNotifications.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAccountsNotifications.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAccountsNotifications.OK(Serializer.deserialize content)
+        | 400 -> GetAccountsNotifications.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
         | _ -> GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -508,12 +508,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/accounts/notifications/{notificationId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAccountsNotificationsByNotificationId.OK
-        | HttpStatusCode.BadRequest ->
-            PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAccountsNotificationsByNotificationId.OK
+        | 400 -> PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
         | _ -> PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -525,12 +523,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/accounts/notifications/{notificationId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest ->
-            DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
+        | 400 -> DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
+        | 401 -> DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
         | _ -> DeleteAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -542,10 +538,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAccounts.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAccounts.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAccounts.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAccounts.OK(Serializer.deserialize content)
+        | 400 -> GetAccounts.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAccounts.Unauthorized(Serializer.deserialize content)
         | _ -> GetAccounts.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -557,10 +553,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/accounts" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAccounts.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAccounts.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAccounts.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAccounts.OK(Serializer.deserialize content)
+        | 400 -> PostAccounts.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAccounts.Unauthorized(Serializer.deserialize content)
         | _ -> PostAccounts.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -572,10 +568,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/accountsbulk" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAccountsbulk.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAccountsbulk.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAccountsbulk.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAccountsbulk.OK(Serializer.deserialize content)
+        | 400 -> PostAccountsbulk.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAccountsbulk.Unauthorized(Serializer.deserialize content)
         | _ -> PostAccountsbulk.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -587,10 +583,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAccountsByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAccountsByAccountId.OK(Serializer.deserialize content)
+        | 400 -> GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -602,10 +598,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAccountsByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAccountsByAccountId.OK(Serializer.deserialize content)
+        | 400 -> PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -621,10 +617,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteAccountsByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> DeleteAccountsByAccountId.OK(Serializer.deserialize content)
+        | 400 -> DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -640,10 +636,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/accounts/{accountId}/branding" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
+        | 400 -> PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -655,11 +651,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}/branding/verify" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
+        | 400 -> GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -671,10 +666,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}/roles" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
+        | 400 -> GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -686,12 +681,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}/roles/{rolename}/actions" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest ->
-            GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
+        | 400 -> GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
         | _ -> GetAccountsRolesActionsByAccountIdAndRolename.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -703,11 +696,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}/notifications" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
+        | 400 -> GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -723,12 +715,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
                 requestParts
                 cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAccountsNotificationsByAccountIdAndNotificationId.OK
-        | HttpStatusCode.BadRequest ->
-            PutAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            PutAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAccountsNotificationsByAccountIdAndNotificationId.OK
+        | 400 -> PutAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
         | _ -> PutAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -744,12 +734,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
                 requestParts
                 cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
-        | HttpStatusCode.BadRequest ->
-            DeleteAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            DeleteAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
+        | 400 -> DeleteAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
+        | 401 -> DeleteAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
         | _ ->
             DeleteAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(Serializer.deserialize content)
 
@@ -764,10 +752,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}/products" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
+        | 400 -> GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -785,10 +773,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/accounts/products/alerts" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAccountsProductsAlerts.OK
-        | HttpStatusCode.BadRequest -> PutAccountsProductsAlerts.BadRequest
-        | HttpStatusCode.Unauthorized -> PutAccountsProductsAlerts.Unauthorized
+        match int status with
+        | 200 -> PutAccountsProductsAlerts.OK
+        | 400 -> PutAccountsProductsAlerts.BadRequest
+        | 401 -> PutAccountsProductsAlerts.Unauthorized
         | _ -> PutAccountsProductsAlerts.InternalServerError
 
     ///<summary>
@@ -804,10 +792,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/accounts/{accountId}/topup-direct" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
+        | 400 -> PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -883,12 +871,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
                 requestParts
                 cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest ->
-            GetAccountsSecuritySettingsAvailableGapsByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            GetAccountsSecuritySettingsAvailableGapsByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
+        | 400 -> GetAccountsSecuritySettingsAvailableGapsByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAccountsSecuritySettingsAvailableGapsByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> GetAccountsSecuritySettingsAvailableGapsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -913,12 +899,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
                 requestParts
                 cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest ->
-            GetAccountsSecuritySettingsAvailableIpsByAccountId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            GetAccountsSecuritySettingsAvailableIpsByAccountId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
+        | 400 -> GetAccountsSecuritySettingsAvailableIpsByAccountId.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAccountsSecuritySettingsAvailableIpsByAccountId.Unauthorized(Serializer.deserialize content)
         | _ -> GetAccountsSecuritySettingsAvailableIpsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -943,10 +927,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/mail" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostMail.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostMail.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostMail.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostMail.OK(Serializer.deserialize content)
+        | 400 -> PostMail.BadRequest(Serializer.deserialize content)
+        | 401 -> PostMail.Unauthorized(Serializer.deserialize content)
         | _ -> PostMail.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1120,12 +1104,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/products" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetProducts.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetProducts.BadRequest
-        | HttpStatusCode.Unauthorized -> GetProducts.Unauthorized
-        | HttpStatusCode.Forbidden -> GetProducts.Forbidden
-        | HttpStatusCode.InternalServerError -> GetProducts.InternalServerError
+        match int status with
+        | 200 -> GetProducts.OK(Serializer.deserialize content)
+        | 400 -> GetProducts.BadRequest
+        | 401 -> GetProducts.Unauthorized
+        | 403 -> GetProducts.Forbidden
+        | 500 -> GetProducts.InternalServerError
         | _ -> GetProducts.ServiceUnavailable
 
     ///<summary>
@@ -1144,10 +1128,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/products" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostProducts.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostProducts.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostProducts.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostProducts.OK(Serializer.deserialize content)
+        | 400 -> PostProducts.BadRequest(Serializer.deserialize content)
+        | 401 -> PostProducts.Unauthorized(Serializer.deserialize content)
         | _ -> PostProducts.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1160,12 +1144,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/products/{productId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetProductsByProductId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetProductsByProductId.BadRequest
-        | HttpStatusCode.Unauthorized -> GetProductsByProductId.Unauthorized
-        | HttpStatusCode.Forbidden -> GetProductsByProductId.Forbidden
-        | HttpStatusCode.InternalServerError -> GetProductsByProductId.InternalServerError
+        match int status with
+        | 200 -> GetProductsByProductId.OK(Serializer.deserialize content)
+        | 400 -> GetProductsByProductId.BadRequest
+        | 401 -> GetProductsByProductId.Unauthorized
+        | 403 -> GetProductsByProductId.Forbidden
+        | 500 -> GetProductsByProductId.InternalServerError
         | _ -> GetProductsByProductId.ServiceUnavailable
 
     ///<summary>
@@ -1184,10 +1168,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.patch httpClient "/products/{productId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PatchProductsByProductId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PatchProductsByProductId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PatchProductsByProductId.OK(Serializer.deserialize content)
+        | 400 -> PatchProductsByProductId.BadRequest(Serializer.deserialize content)
+        | 401 -> PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
         | _ -> PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1200,10 +1184,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/products/{productId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteProductsByProductId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> DeleteProductsByProductId.OK(Serializer.deserialize content)
+        | 400 -> DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
+        | 401 -> DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
         | _ -> DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1220,10 +1204,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/schema/product" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSchemaProduct.OK
-        | HttpStatusCode.BadRequest -> GetSchemaProduct.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetSchemaProduct.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetSchemaProduct.OK
+        | 400 -> GetSchemaProduct.BadRequest(Serializer.deserialize content)
+        | 401 -> GetSchemaProduct.Unauthorized(Serializer.deserialize content)
         | _ -> GetSchemaProduct.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1242,12 +1226,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/products/{productId}/transfer" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostProductsTransferByProductId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostProductsTransferByProductId.BadRequest
-        | HttpStatusCode.Unauthorized -> PostProductsTransferByProductId.Unauthorized
-        | HttpStatusCode.Forbidden -> PostProductsTransferByProductId.Forbidden
-        | HttpStatusCode.InternalServerError -> PostProductsTransferByProductId.InternalServerError
+        match int status with
+        | 200 -> PostProductsTransferByProductId.OK(Serializer.deserialize content)
+        | 400 -> PostProductsTransferByProductId.BadRequest
+        | 401 -> PostProductsTransferByProductId.Unauthorized
+        | 403 -> PostProductsTransferByProductId.Forbidden
+        | 500 -> PostProductsTransferByProductId.InternalServerError
         | _ -> PostProductsTransferByProductId.ServiceUnavailable
 
     ///<summary>
@@ -1293,11 +1277,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/cdr" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetCdr.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetCdr.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetCdr.Unauthorized(Serializer.deserialize content)
-        | HttpStatusCode.NotFound -> GetCdr.NotFound(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetCdr.OK(Serializer.deserialize content)
+        | 400 -> GetCdr.BadRequest(Serializer.deserialize content)
+        | 401 -> GetCdr.Unauthorized(Serializer.deserialize content)
+        | 404 -> GetCdr.NotFound(Serializer.deserialize content)
         | _ -> GetCdr.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1334,10 +1318,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAssets.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAssets.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAssets.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAssets.OK(Serializer.deserialize content)
+        | 400 -> GetAssets.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAssets.Unauthorized(Serializer.deserialize content)
         | _ -> GetAssets.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1349,10 +1333,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAssets.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAssets.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAssets.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAssets.OK(Serializer.deserialize content)
+        | 400 -> PostAssets.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAssets.Unauthorized(Serializer.deserialize content)
         | _ -> PostAssets.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1364,10 +1348,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assetsbulk" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAssetsbulk.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAssetsbulk.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAssetsbulk.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAssetsbulk.OK(Serializer.deserialize content)
+        | 400 -> PostAssetsbulk.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAssetsbulk.Unauthorized(Serializer.deserialize content)
         | _ -> PostAssetsbulk.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1379,10 +1363,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAssetsByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAssetsByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAssetsByIccid.OK(Serializer.deserialize content)
+        | 400 -> GetAssetsByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1394,10 +1378,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAssetsByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAssetsByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAssetsByIccid.OK(Serializer.deserialize content)
+        | 400 -> PutAssetsByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1409,10 +1393,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/assets/{iccid}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteAssetsByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> DeleteAssetsByIccid.OK(Serializer.deserialize content)
+        | 400 -> DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1428,10 +1412,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/groupname" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
+        | 400 -> PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1447,10 +1431,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/transfer" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAssetsTransferByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAssetsTransferByIccid.OK(Serializer.deserialize content)
+        | 400 -> PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1466,10 +1450,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/subscribe" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
+        | 400 -> PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1485,10 +1469,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/unsubscribe" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
+        | 400 -> PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1504,10 +1488,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/resubscribe" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
+        | 400 -> PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1523,10 +1507,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/suspend" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
+        | 400 -> PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1542,10 +1526,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/unsuspend" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
+        | 400 -> PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1559,10 +1543,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/alerts" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAssetsAlertsByIccid.OK
-        | HttpStatusCode.BadRequest -> PutAssetsAlertsByIccid.BadRequest
-        | HttpStatusCode.Unauthorized -> PutAssetsAlertsByIccid.Unauthorized
+        match int status with
+        | 200 -> PutAssetsAlertsByIccid.OK
+        | 400 -> PutAssetsAlertsByIccid.BadRequest
+        | 401 -> PutAssetsAlertsByIccid.Unauthorized
         | _ -> PutAssetsAlertsByIccid.InternalServerError
 
     ///<summary>
@@ -1574,10 +1558,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/purge" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAssetsPurgeByIccid.OK
-        | HttpStatusCode.BadRequest -> PostAssetsPurgeByIccid.BadRequest
-        | HttpStatusCode.Unauthorized -> PostAssetsPurgeByIccid.Unauthorized
+        match int status with
+        | 200 -> PostAssetsPurgeByIccid.OK
+        | 400 -> PostAssetsPurgeByIccid.BadRequest
+        | 401 -> PostAssetsPurgeByIccid.Unauthorized
         | _ -> PostAssetsPurgeByIccid.InternalServerError
 
     ///<summary>
@@ -1589,10 +1573,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/sms" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAssetsSmsByIccid.OK
-        | HttpStatusCode.BadRequest -> PostAssetsSmsByIccid.BadRequest
-        | HttpStatusCode.Unauthorized -> PostAssetsSmsByIccid.Unauthorized
+        match int status with
+        | 200 -> PostAssetsSmsByIccid.OK
+        | 400 -> PostAssetsSmsByIccid.BadRequest
+        | 401 -> PostAssetsSmsByIccid.Unauthorized
         | _ -> PostAssetsSmsByIccid.InternalServerError
 
     ///<summary>
@@ -1604,10 +1588,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/limit" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAssetsLimitByIccid.OK
-        | HttpStatusCode.BadRequest -> PostAssetsLimitByIccid.BadRequest
-        | HttpStatusCode.Unauthorized -> PostAssetsLimitByIccid.Unauthorized
+        match int status with
+        | 200 -> PostAssetsLimitByIccid.OK
+        | 400 -> PostAssetsLimitByIccid.BadRequest
+        | 401 -> PostAssetsLimitByIccid.Unauthorized
         | _ -> PostAssetsLimitByIccid.InternalServerError
 
     ///<summary>
@@ -1647,10 +1631,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/tags" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAssetsTagsByIccid.OK
-        | HttpStatusCode.BadRequest -> PostAssetsTagsByIccid.BadRequest
-        | HttpStatusCode.Unauthorized -> PostAssetsTagsByIccid.Unauthorized
+        match int status with
+        | 200 -> PostAssetsTagsByIccid.OK
+        | 400 -> PostAssetsTagsByIccid.BadRequest
+        | 401 -> PostAssetsTagsByIccid.Unauthorized
         | _ -> PostAssetsTagsByIccid.InternalServerError
 
     ///<summary>
@@ -1662,10 +1646,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}/diagnostic" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAssetsDiagnosticByIccid.Unauthorized
-        | HttpStatusCode.InternalServerError -> GetAssetsDiagnosticByIccid.InternalServerError
+        match int status with
+        | 200 -> GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
+        | 401 -> GetAssetsDiagnosticByIccid.Unauthorized
+        | 500 -> GetAssetsDiagnosticByIccid.InternalServerError
         | _ -> GetAssetsDiagnosticByIccid.ServiceUnavailable
 
     ///<summary>
@@ -1677,11 +1661,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}/location" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAssetsLocationByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
-        | HttpStatusCode.NotFound -> GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAssetsLocationByIccid.OK(Serializer.deserialize content)
+        | 400 -> GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
+        | 404 -> GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
         | _ -> GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1693,11 +1677,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}/sessions" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
-        | HttpStatusCode.NotFound -> GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
+        | 400 -> GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
+        | 404 -> GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
         | _ -> GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1724,9 +1708,9 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/reports/custom" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetReportsCustom.OK(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetReportsCustom.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetReportsCustom.OK(Serializer.deserialize content)
+        | 401 -> GetReportsCustom.Unauthorized(Serializer.deserialize content)
         | _ -> GetReportsCustom.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1738,11 +1722,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/reports/custom" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostReportsCustom.OK
-        | HttpStatusCode.Unauthorized -> PostReportsCustom.Unauthorized(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> PostReportsCustom.Forbidden(Serializer.deserialize content)
-        | HttpStatusCode.NotFound -> PostReportsCustom.NotFound(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostReportsCustom.OK
+        | 401 -> PostReportsCustom.Unauthorized(Serializer.deserialize content)
+        | 403 -> PostReportsCustom.Forbidden(Serializer.deserialize content)
+        | 404 -> PostReportsCustom.NotFound(Serializer.deserialize content)
         | _ -> PostReportsCustom.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1754,9 +1738,9 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/reports/custom" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.NoContent -> DeleteReportsCustom.NoContent
-        | HttpStatusCode.Unauthorized -> DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 204 -> DeleteReportsCustom.NoContent
+        | 401 -> DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
         | _ -> DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1768,10 +1752,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetReportsCustomByReportId.OK(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-        | HttpStatusCode.NotFound -> GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetReportsCustomByReportId.OK(Serializer.deserialize content)
+        | 401 -> GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
+        | 404 -> GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
         | _ -> GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1783,10 +1767,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.NoContent -> DeleteReportsCustomByReportId.NoContent
-        | HttpStatusCode.Unauthorized -> DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-        | HttpStatusCode.NotFound -> DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
+        match int status with
+        | 204 -> DeleteReportsCustomByReportId.NoContent
+        | 401 -> DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
+        | 404 -> DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
         | _ -> DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1852,10 +1836,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/events" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetEvents.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetEvents.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetEvents.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetEvents.OK(Serializer.deserialize content)
+        | 400 -> GetEvents.BadRequest(Serializer.deserialize content)
+        | 401 -> GetEvents.Unauthorized(Serializer.deserialize content)
         | _ -> GetEvents.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1912,10 +1896,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/subscribe" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
+        | 400 -> PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
+        | 401 -> PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
         | _ -> PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1927,10 +1911,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/transfer" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
+        | 400 -> PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
+        | 401 -> PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
         | _ -> PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1942,10 +1926,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/return" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
+        | 400 -> PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
+        | 401 -> PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
         | _ -> PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1957,10 +1941,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/bulk/assets/suspend" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
+        | 400 -> PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
+        | 401 -> PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
         | _ -> PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1972,10 +1956,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/bulk/assets/unsuspend" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
+        | 400 -> PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
+        | 401 -> PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
         | _ -> PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -1991,10 +1975,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/resubscribe" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
+        | 400 -> PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
+        | 401 -> PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
         | _ -> PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2006,10 +1990,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PostBulkAssets.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostBulkAssets.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostBulkAssets.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PostBulkAssets.Accepted(Serializer.deserialize content)
+        | 400 -> PostBulkAssets.BadRequest(Serializer.deserialize content)
+        | 401 -> PostBulkAssets.Unauthorized(Serializer.deserialize content)
         | _ -> PostBulkAssets.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2021,10 +2005,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/bulk/assets" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PutBulkAssets.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutBulkAssets.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutBulkAssets.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PutBulkAssets.Accepted(Serializer.deserialize content)
+        | 400 -> PutBulkAssets.BadRequest(Serializer.deserialize content)
+        | 401 -> PutBulkAssets.Unauthorized(Serializer.deserialize content)
         | _ -> PutBulkAssets.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2036,10 +2020,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/bulk/assets/groupname" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
+        | 400 -> PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
+        | 401 -> PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
         | _ -> PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2051,10 +2035,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/limit" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
+        | 400 -> PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
+        | 401 -> PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
         | _ -> PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2068,10 +2052,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/bulk/assets/alerts" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
+        | 400 -> PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
+        | 401 -> PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
         | _ -> PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2083,10 +2067,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/sms" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PostBulkAssetsSms.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PostBulkAssetsSms.Accepted(Serializer.deserialize content)
+        | 400 -> PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
+        | 401 -> PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
         | _ -> PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2098,10 +2082,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/purge" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
+        | 400 -> PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
+        | 401 -> PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
         | _ -> PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2143,10 +2127,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/reallocate-ip" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.Accepted -> PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 202 -> PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
+        | 400 -> PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
+        | 401 -> PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
         | _ -> PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2218,10 +2202,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/payments/topupPaypal" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
+        | 400 -> PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
+        | 401 -> PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
         | _ -> PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2240,10 +2224,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/payments/confirmTopupPaypal" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
+        | 400 -> PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
+        | 401 -> PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
         | _ -> PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2345,12 +2329,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/security/alerts" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSecurityAlerts.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetSecurityAlerts.BadRequest
-        | HttpStatusCode.Unauthorized -> GetSecurityAlerts.Unauthorized
-        | HttpStatusCode.Forbidden -> GetSecurityAlerts.Forbidden
-        | HttpStatusCode.InternalServerError -> GetSecurityAlerts.InternalServerError
+        match int status with
+        | 200 -> GetSecurityAlerts.OK(Serializer.deserialize content)
+        | 400 -> GetSecurityAlerts.BadRequest
+        | 401 -> GetSecurityAlerts.Unauthorized
+        | 403 -> GetSecurityAlerts.Forbidden
+        | 500 -> GetSecurityAlerts.InternalServerError
         | _ -> GetSecurityAlerts.ServiceUnavailable
 
     ///<summary>
@@ -2375,12 +2359,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetSecurityAlertsByAlertId.BadRequest
-        | HttpStatusCode.Unauthorized -> GetSecurityAlertsByAlertId.Unauthorized
-        | HttpStatusCode.Forbidden -> GetSecurityAlertsByAlertId.Forbidden
-        | HttpStatusCode.InternalServerError -> GetSecurityAlertsByAlertId.InternalServerError
+        match int status with
+        | 200 -> GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+        | 400 -> GetSecurityAlertsByAlertId.BadRequest
+        | 401 -> GetSecurityAlertsByAlertId.Unauthorized
+        | 403 -> GetSecurityAlertsByAlertId.Forbidden
+        | 500 -> GetSecurityAlertsByAlertId.InternalServerError
         | _ -> GetSecurityAlertsByAlertId.ServiceUnavailable
 
     ///<summary>
@@ -2408,12 +2392,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutSecurityAlertsByAlertId.BadRequest
-        | HttpStatusCode.Unauthorized -> PutSecurityAlertsByAlertId.Unauthorized
-        | HttpStatusCode.Forbidden -> PutSecurityAlertsByAlertId.Forbidden
-        | HttpStatusCode.InternalServerError -> PutSecurityAlertsByAlertId.InternalServerError
+        match int status with
+        | 200 -> PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+        | 400 -> PutSecurityAlertsByAlertId.BadRequest
+        | 401 -> PutSecurityAlertsByAlertId.Unauthorized
+        | 403 -> PutSecurityAlertsByAlertId.Forbidden
+        | 500 -> PutSecurityAlertsByAlertId.InternalServerError
         | _ -> PutSecurityAlertsByAlertId.ServiceUnavailable
 
     ///<summary>
@@ -2438,12 +2422,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.NoContent -> DeleteSecurityAlertsByAlertId.NoContent
-        | HttpStatusCode.BadRequest -> DeleteSecurityAlertsByAlertId.BadRequest
-        | HttpStatusCode.Unauthorized -> DeleteSecurityAlertsByAlertId.Unauthorized
-        | HttpStatusCode.Forbidden -> DeleteSecurityAlertsByAlertId.Forbidden
-        | HttpStatusCode.InternalServerError -> DeleteSecurityAlertsByAlertId.InternalServerError
+        match int status with
+        | 204 -> DeleteSecurityAlertsByAlertId.NoContent
+        | 400 -> DeleteSecurityAlertsByAlertId.BadRequest
+        | 401 -> DeleteSecurityAlertsByAlertId.Unauthorized
+        | 403 -> DeleteSecurityAlertsByAlertId.Forbidden
+        | 500 -> DeleteSecurityAlertsByAlertId.InternalServerError
         | _ -> DeleteSecurityAlertsByAlertId.ServiceUnavailable
 
     ///<summary>
@@ -2477,10 +2461,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/security/topthreaten" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
+        | 400 -> GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2514,10 +2498,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/security/byalarmtype" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
+        | 400 -> GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2544,10 +2528,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/esims" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostEsims.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostEsims.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostEsims.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostEsims.OK(Serializer.deserialize content)
+        | 400 -> PostEsims.BadRequest(Serializer.deserialize content)
+        | 401 -> PostEsims.Unauthorized(Serializer.deserialize content)
         | _ -> PostEsims.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2592,10 +2576,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/esims/{eid}/transfer" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostEsimsTransferByEid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostEsimsTransferByEid.OK(Serializer.deserialize content)
+        | 400 -> PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
+        | 401 -> PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
         | _ -> PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2607,10 +2591,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/esims/{eid}/return" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostEsimsReturnByEid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostEsimsReturnByEid.OK(Serializer.deserialize content)
+        | 400 -> PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
+        | 401 -> PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
         | _ -> PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2908,10 +2892,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/1" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph1.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph1.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph1.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph1.OK(Serializer.deserialize content)
+        | 400 -> GetGraph1.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph1.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph1.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2941,10 +2925,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/2" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph2.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph2.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph2.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph2.OK(Serializer.deserialize content)
+        | 400 -> GetGraph2.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph2.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph2.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -2974,10 +2958,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/3" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph3.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph3.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph3.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph3.OK(Serializer.deserialize content)
+        | 400 -> GetGraph3.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph3.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph3.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3007,10 +2991,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/4" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph4.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph4.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph4.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph4.OK(Serializer.deserialize content)
+        | 400 -> GetGraph4.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph4.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph4.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3040,10 +3024,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/5" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph5.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph5.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph5.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph5.OK(Serializer.deserialize content)
+        | 400 -> GetGraph5.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph5.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph5.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3073,10 +3057,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/6" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph6.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph6.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph6.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph6.OK(Serializer.deserialize content)
+        | 400 -> GetGraph6.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph6.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph6.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3106,10 +3090,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/7" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph7.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph7.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph7.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph7.OK(Serializer.deserialize content)
+        | 400 -> GetGraph7.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph7.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph7.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3139,10 +3123,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/8" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph8.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph8.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph8.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph8.OK(Serializer.deserialize content)
+        | 400 -> GetGraph8.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph8.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph8.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3172,10 +3156,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/9" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph9.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph9.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph9.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph9.OK(Serializer.deserialize content)
+        | 400 -> GetGraph9.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph9.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph9.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3189,10 +3173,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/10" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph10.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph10.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph10.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph10.OK(Serializer.deserialize content)
+        | 400 -> GetGraph10.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph10.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph10.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3222,10 +3206,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/11" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph11.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph11.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph11.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph11.OK(Serializer.deserialize content)
+        | 400 -> GetGraph11.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph11.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph11.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3255,10 +3239,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/12" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraph12.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraph12.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraph12.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraph12.OK(Serializer.deserialize content)
+        | 400 -> GetGraph12.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraph12.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraph12.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3288,10 +3272,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/statusesperday" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetGraphStatusesperday.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetGraphStatusesperday.OK(Serializer.deserialize content)
+        | 400 -> GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
+        | 401 -> GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
         | _ -> GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3320,10 +3304,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+        | 400 -> PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3335,10 +3319,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+        | 400 -> GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3350,11 +3334,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+        | 400 -> GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+        | 401 -> GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
         | _ -> GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3370,11 +3353,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+        | 400 -> PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+        | 401 -> PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
         | _ -> PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3386,12 +3368,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.NoContent -> DeleteAssetsQuickDialByIccidAndLocation.NoContent
-        | HttpStatusCode.BadRequest ->
-            DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized ->
-            DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 204 -> DeleteAssetsQuickDialByIccidAndLocation.NoContent
+        | 400 -> DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+        | 401 -> DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
         | _ -> DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -3403,10 +3383,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/dial" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostAssetsDialByIccid.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
-        | HttpStatusCode.Unauthorized -> PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
+        match int status with
+        | 200 -> PostAssetsDialByIccid.OK(Serializer.deserialize content)
+        | 400 -> PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
+        | 401 -> PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
         | _ -> PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>

--- a/examples/SyncPodiosuite/Client.fs
+++ b/examples/SyncPodiosuite/Client.fs
@@ -17,14 +17,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/auth/token" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAuthToken.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAuthToken.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAuthToken.Unauthorized(Serializer.deserialize content)
-        else
-            PostAuthToken.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAuthToken.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAuthToken.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAuthToken.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAuthToken.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Takes username or email as values and sends an email to the user with instructions to reset the password, including a tokenized URL that directs the user to the password reset form.
@@ -39,14 +36,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/auth/recover-password" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAuthRecoverPassword.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
-        else
-            PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAuthRecoverPassword.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Takes token session sent in email and resets the password for the active user.
@@ -67,14 +61,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/auth/reset/{mailtoken}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAuthResetByMailtoken.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
-        else
-            PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAuthResetByMailtoken.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Revokes the active session for the user by disabling the token. This disables the different sessions opened on differents computers and browsers.&amp;lt;br /&amp;gt; The user will login again to use the App, and a new token will be generate.
@@ -92,14 +83,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/auth/revoke-token" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAuthRevokeToken.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
-        else
-            PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAuthRevokeToken.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Changes the user’s password and resets the session token.
@@ -117,14 +105,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/auth/change-password" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAuthChangePassword.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAuthChangePassword.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
-        else
-            PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAuthChangePassword.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAuthChangePassword.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Creates a new user taking token and new user data. Returns the new user data. An email is sent to the new user with instructions to log in.
@@ -137,14 +122,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/users" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostUsers.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostUsers.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostUsers.Unauthorized(Serializer.deserialize content)
-        else
-            PostUsers.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostUsers.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostUsers.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostUsers.Unauthorized(Serializer.deserialize content)
+        | _ -> PostUsers.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Takes token and account ID as mandatory parameters and returns an array of users. If nothing is found returns an empty array.
@@ -209,14 +191,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/users" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetUsers.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetUsers.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetUsers.Unauthorized(Serializer.deserialize content)
-        else
-            GetUsers.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetUsers.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetUsers.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetUsers.Unauthorized(Serializer.deserialize content)
+        | _ -> GetUsers.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Takes token, account ID and and bulk search parameters to returns a list of users belonging to a specific account.
@@ -284,14 +263,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/usersbulk" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostUsersbulk.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostUsersbulk.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostUsersbulk.Unauthorized(Serializer.deserialize content)
-        else
-            PostUsersbulk.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostUsersbulk.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostUsersbulk.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostUsersbulk.Unauthorized(Serializer.deserialize content)
+        | _ -> PostUsersbulk.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Takes token and returns user data.
@@ -307,14 +283,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/users/me" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetUsersMe.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetUsersMe.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetUsersMe.Unauthorized(Serializer.deserialize content)
-        else
-            GetUsersMe.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetUsersMe.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetUsersMe.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetUsersMe.Unauthorized(Serializer.deserialize content)
+        | _ -> GetUsersMe.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///User accept terms and conditions.
@@ -326,14 +299,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/users/me/accept-tc" requestParts cancellationToken
 
-        if status = HttpStatusCode.Created then
-            PostUsersMeAcceptTc.Created
-        else if status = HttpStatusCode.BadRequest then
-            PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
-        else
-            PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Created -> PostUsersMeAcceptTc.Created
+        | HttpStatusCode.BadRequest -> PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
+        | _ -> PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Gets a user by ID, using token, userID and accountID as parameters, and returns a JSON with the users data.
@@ -357,14 +327,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/users/{userId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetUsersByUserId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetUsersByUserId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetUsersByUserId.Unauthorized(Serializer.deserialize content)
-        else
-            GetUsersByUserId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetUsersByUserId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetUsersByUserId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetUsersByUserId.Unauthorized(Serializer.deserialize content)
+        | _ -> GetUsersByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Modify a user using the parameters available.
@@ -388,14 +355,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/users/{userId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutUsersByUserId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutUsersByUserId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutUsersByUserId.Unauthorized(Serializer.deserialize content)
-        else
-            PutUsersByUserId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutUsersByUserId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutUsersByUserId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutUsersByUserId.Unauthorized(Serializer.deserialize content)
+        | _ -> PutUsersByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Takes token and user ID, then removes user.
@@ -419,14 +383,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/users/{userId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteUsersByUserId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
-        else
-            DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> DeleteUsersByUserId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
+        | _ -> DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Change a user password using the parameters available.
@@ -447,14 +408,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/users/{userId}/change-password" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
-        else
-            PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
+        | _ -> PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Modify the user options for favorites using the parameters available.
@@ -474,14 +432,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/users/{userId}/favorites" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
-        else
-            PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
+        | _ -> PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Modify the user customization options. Modify the setup of the columns as displayed in tables in the user interface and the sort order.
@@ -501,14 +456,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/users/{userId}/customization" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
-        else
-            PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
+        | _ -> PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Gell all users actions for an account.
@@ -526,14 +478,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/users/{userId}/permissions" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
-        else
-            PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
+        | _ -> PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get all notifications of an account.
@@ -544,14 +493,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/notifications" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAccountsNotifications.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAccountsNotifications.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
-        else
-            GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetAccountsNotifications.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAccountsNotifications.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
+        | _ -> GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Set the notification which id has been given as readed.
@@ -562,14 +508,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/accounts/notifications/{notificationId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAccountsNotificationsByNotificationId.OK
-        else if status = HttpStatusCode.BadRequest then
+        match status with
+        | HttpStatusCode.OK -> PutAccountsNotificationsByNotificationId.OK
+        | HttpStatusCode.BadRequest ->
             PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        | HttpStatusCode.Unauthorized ->
             PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
-        else
-            PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
+        | _ -> PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Delete a notification
@@ -580,14 +525,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/accounts/notifications/{notificationId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
+        match status with
+        | HttpStatusCode.OK -> DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest ->
             DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        | HttpStatusCode.Unauthorized ->
             DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
-        else
-            DeleteAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
+        | _ -> DeleteAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get all accounts and subaccounts.
@@ -598,14 +542,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAccounts.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAccounts.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAccounts.Unauthorized(Serializer.deserialize content)
-        else
-            GetAccounts.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetAccounts.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAccounts.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAccounts.Unauthorized(Serializer.deserialize content)
+        | _ -> GetAccounts.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Create a new child account in the system.
@@ -616,14 +557,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/accounts" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAccounts.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAccounts.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAccounts.Unauthorized(Serializer.deserialize content)
-        else
-            PostAccounts.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAccounts.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAccounts.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAccounts.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAccounts.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get all accounts and subaccounts.
@@ -634,14 +572,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/accountsbulk" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAccountsbulk.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAccountsbulk.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAccountsbulk.Unauthorized(Serializer.deserialize content)
-        else
-            PostAccountsbulk.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAccountsbulk.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAccountsbulk.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAccountsbulk.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAccountsbulk.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Retrieve one account matching the id provided.
@@ -652,14 +587,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAccountsByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetAccountsByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+        | _ -> GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Modify an existing account with the new data setted into the parameters.
@@ -670,14 +602,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAccountsByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutAccountsByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+        | _ -> PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Remove an existing account from the database.
@@ -692,14 +621,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteAccountsByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> DeleteAccountsByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+        | _ -> DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Modify the branding information of an account.
@@ -714,14 +640,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/accounts/{accountId}/branding" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
+        | _ -> PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get Account Branding status.
@@ -732,14 +655,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}/branding/verify" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        match status with
+        | HttpStatusCode.OK -> GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized ->
             GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
+        | _ -> GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Retrieve all existing roles.
@@ -750,14 +671,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}/roles" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
+        | _ -> GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get all actions belonging a role.
@@ -768,14 +686,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}/roles/{rolename}/actions" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
+        match status with
+        | HttpStatusCode.OK -> GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest ->
             GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        | HttpStatusCode.Unauthorized ->
             GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
-        else
-            GetAccountsRolesActionsByAccountIdAndRolename.InternalServerError(Serializer.deserialize content)
+        | _ -> GetAccountsRolesActionsByAccountIdAndRolename.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get all notifications of an account.
@@ -786,14 +703,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}/notifications" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        match status with
+        | HttpStatusCode.OK -> GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized ->
             GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
+        | _ -> GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///The notification with the id provided will be check as readed.
@@ -808,14 +723,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
                 requestParts
                 cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAccountsNotificationsByAccountIdAndNotificationId.OK
-        else if status = HttpStatusCode.BadRequest then
+        match status with
+        | HttpStatusCode.OK -> PutAccountsNotificationsByAccountIdAndNotificationId.OK
+        | HttpStatusCode.BadRequest ->
             PutAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        | HttpStatusCode.Unauthorized ->
             PutAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
-        else
-            PutAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(Serializer.deserialize content)
+        | _ -> PutAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Delete a notification
@@ -830,13 +744,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
                 requestParts
                 cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
-        else if status = HttpStatusCode.BadRequest then
+        match status with
+        | HttpStatusCode.OK -> DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
+        | HttpStatusCode.BadRequest ->
             DeleteAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        | HttpStatusCode.Unauthorized ->
             DeleteAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
-        else
+        | _ ->
             DeleteAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
@@ -850,14 +764,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/accounts/{accountId}/products" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
+        | _ -> GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///- A maximum of 3 alerts per SIM can be set in order to notify the user when the consumption of a  promotion  reaches or exceeds a certain limit, Alerts can also be used to notify the user of usage over their predefined bundle amount.
@@ -874,14 +785,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/accounts/products/alerts" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAccountsProductsAlerts.OK
-        else if status = HttpStatusCode.BadRequest then
-            PutAccountsProductsAlerts.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            PutAccountsProductsAlerts.Unauthorized
-        else
-            PutAccountsProductsAlerts.InternalServerError
+        match status with
+        | HttpStatusCode.OK -> PutAccountsProductsAlerts.OK
+        | HttpStatusCode.BadRequest -> PutAccountsProductsAlerts.BadRequest
+        | HttpStatusCode.Unauthorized -> PutAccountsProductsAlerts.Unauthorized
+        | _ -> PutAccountsProductsAlerts.InternalServerError
 
     ///<summary>
     ///Amount in which the balance increases.
@@ -896,14 +804,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/accounts/{accountId}/topup-direct" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
+        | _ -> PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Add a Security Service Setting inside an account
@@ -978,14 +883,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
                 requestParts
                 cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
+        match status with
+        | HttpStatusCode.OK -> GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest ->
             GetAccountsSecuritySettingsAvailableGapsByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        | HttpStatusCode.Unauthorized ->
             GetAccountsSecuritySettingsAvailableGapsByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            GetAccountsSecuritySettingsAvailableGapsByAccountId.InternalServerError(Serializer.deserialize content)
+        | _ -> GetAccountsSecuritySettingsAvailableGapsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Retrieve available ips for particular pool.
@@ -1009,14 +913,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
                 requestParts
                 cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
+        match status with
+        | HttpStatusCode.OK -> GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest ->
             GetAccountsSecuritySettingsAvailableIpsByAccountId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        | HttpStatusCode.Unauthorized ->
             GetAccountsSecuritySettingsAvailableIpsByAccountId.Unauthorized(Serializer.deserialize content)
-        else
-            GetAccountsSecuritySettingsAvailableIpsByAccountId.InternalServerError(Serializer.deserialize content)
+        | _ -> GetAccountsSecuritySettingsAvailableIpsByAccountId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Endpoint to asure the App is up and working. If is not, nginx will return a 502 Bad Gateway exception.
@@ -1040,14 +943,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/mail" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostMail.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostMail.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostMail.Unauthorized(Serializer.deserialize content)
-        else
-            PostMail.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostMail.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostMail.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostMail.Unauthorized(Serializer.deserialize content)
+        | _ -> PostMail.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///General endpoint to send files
@@ -1220,18 +1120,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/products" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetProducts.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetProducts.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            GetProducts.Unauthorized
-        else if status = HttpStatusCode.Forbidden then
-            GetProducts.Forbidden
-        else if status = HttpStatusCode.InternalServerError then
-            GetProducts.InternalServerError
-        else
-            GetProducts.ServiceUnavailable
+        match status with
+        | HttpStatusCode.OK -> GetProducts.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetProducts.BadRequest
+        | HttpStatusCode.Unauthorized -> GetProducts.Unauthorized
+        | HttpStatusCode.Forbidden -> GetProducts.Forbidden
+        | HttpStatusCode.InternalServerError -> GetProducts.InternalServerError
+        | _ -> GetProducts.ServiceUnavailable
 
     ///<summary>
     ///Creates a new product taking a token, an accountId and the new product data. Returns the new product data.
@@ -1249,14 +1144,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/products" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostProducts.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostProducts.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostProducts.Unauthorized(Serializer.deserialize content)
-        else
-            PostProducts.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostProducts.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostProducts.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostProducts.Unauthorized(Serializer.deserialize content)
+        | _ -> PostProducts.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get a product of an account
@@ -1268,18 +1160,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/products/{productId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetProductsByProductId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetProductsByProductId.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            GetProductsByProductId.Unauthorized
-        else if status = HttpStatusCode.Forbidden then
-            GetProductsByProductId.Forbidden
-        else if status = HttpStatusCode.InternalServerError then
-            GetProductsByProductId.InternalServerError
-        else
-            GetProductsByProductId.ServiceUnavailable
+        match status with
+        | HttpStatusCode.OK -> GetProductsByProductId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetProductsByProductId.BadRequest
+        | HttpStatusCode.Unauthorized -> GetProductsByProductId.Unauthorized
+        | HttpStatusCode.Forbidden -> GetProductsByProductId.Forbidden
+        | HttpStatusCode.InternalServerError -> GetProductsByProductId.InternalServerError
+        | _ -> GetProductsByProductId.ServiceUnavailable
 
     ///<summary>
     ///Updates a product taking a token, an accountId and the updated product data. Returns the updated product data.
@@ -1297,14 +1184,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.patch httpClient "/products/{productId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PatchProductsByProductId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PatchProductsByProductId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
-        else
-            PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PatchProductsByProductId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PatchProductsByProductId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
+        | _ -> PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Delete product by ID
@@ -1316,14 +1200,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/products/{productId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteProductsByProductId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
-        else
-            DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> DeleteProductsByProductId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
+        | _ -> DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get all the availables schemas for creating a product.
@@ -1339,14 +1220,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/schema/product" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSchemaProduct.OK
-        else if status = HttpStatusCode.BadRequest then
-            GetSchemaProduct.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetSchemaProduct.Unauthorized(Serializer.deserialize content)
-        else
-            GetSchemaProduct.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetSchemaProduct.OK
+        | HttpStatusCode.BadRequest -> GetSchemaProduct.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetSchemaProduct.Unauthorized(Serializer.deserialize content)
+        | _ -> GetSchemaProduct.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Transfer products from an account to another
@@ -1364,18 +1242,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/products/{productId}/transfer" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostProductsTransferByProductId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostProductsTransferByProductId.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            PostProductsTransferByProductId.Unauthorized
-        else if status = HttpStatusCode.Forbidden then
-            PostProductsTransferByProductId.Forbidden
-        else if status = HttpStatusCode.InternalServerError then
-            PostProductsTransferByProductId.InternalServerError
-        else
-            PostProductsTransferByProductId.ServiceUnavailable
+        match status with
+        | HttpStatusCode.OK -> PostProductsTransferByProductId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostProductsTransferByProductId.BadRequest
+        | HttpStatusCode.Unauthorized -> PostProductsTransferByProductId.Unauthorized
+        | HttpStatusCode.Forbidden -> PostProductsTransferByProductId.Forbidden
+        | HttpStatusCode.InternalServerError -> PostProductsTransferByProductId.InternalServerError
+        | _ -> PostProductsTransferByProductId.ServiceUnavailable
 
     ///<summary>
     ///Get cdrs on application. If param type is not set to sms, always returns data cdrs
@@ -1420,16 +1293,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/cdr" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetCdr.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetCdr.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetCdr.Unauthorized(Serializer.deserialize content)
-        else if status = HttpStatusCode.NotFound then
-            GetCdr.NotFound(Serializer.deserialize content)
-        else
-            GetCdr.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetCdr.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetCdr.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetCdr.Unauthorized(Serializer.deserialize content)
+        | HttpStatusCode.NotFound -> GetCdr.NotFound(Serializer.deserialize content)
+        | _ -> GetCdr.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get all cdrs on application. If type is not set to `sms` it returns data cdrs.
@@ -1465,14 +1334,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAssets.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAssets.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAssets.Unauthorized(Serializer.deserialize content)
-        else
-            GetAssets.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetAssets.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAssets.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAssets.Unauthorized(Serializer.deserialize content)
+        | _ -> GetAssets.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Create a new Asset
@@ -1483,14 +1349,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAssets.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAssets.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAssets.Unauthorized(Serializer.deserialize content)
-        else
-            PostAssets.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAssets.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAssets.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAssets.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAssets.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Assets card Info (bulk)
@@ -1501,14 +1364,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assetsbulk" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAssetsbulk.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAssetsbulk.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAssetsbulk.Unauthorized(Serializer.deserialize content)
-        else
-            PostAssetsbulk.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAssetsbulk.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAssetsbulk.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAssetsbulk.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAssetsbulk.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Assets get Info
@@ -1519,14 +1379,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAssetsByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAssetsByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetAssetsByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAssetsByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Change the name of the asset for the specified accountId
@@ -1537,14 +1394,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAssetsByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAssetsByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutAssetsByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAssetsByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Remove an Asset
@@ -1555,14 +1409,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/assets/{iccid}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteAssetsByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> DeleteAssetsByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Update group name
@@ -1577,14 +1428,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/groupname" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Transfer an Asset from an account to another
@@ -1599,14 +1447,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/transfer" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAssetsTransferByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAssetsTransferByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Activate an asset and subscribe the asset to the assigned product.
@@ -1621,14 +1466,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/subscribe" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Unsubscribe the asset to the assigned product
@@ -1643,14 +1485,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/unsubscribe" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Remove subscription and create a new subscribe the asset to the assigned product.
@@ -1665,14 +1504,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/resubscribe" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Suspend an assets
@@ -1687,14 +1523,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/suspend" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Reactive an assets. The assets should be suspended
@@ -1709,14 +1542,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/unsuspend" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///- You can set data alerts (alerts array) and sms alerts (smsAlerts array). You can set both or one of them.
@@ -1729,14 +1559,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/alerts" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAssetsAlertsByIccid.OK
-        else if status = HttpStatusCode.BadRequest then
-            PutAssetsAlertsByIccid.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            PutAssetsAlertsByIccid.Unauthorized
-        else
-            PutAssetsAlertsByIccid.InternalServerError
+        match status with
+        | HttpStatusCode.OK -> PutAssetsAlertsByIccid.OK
+        | HttpStatusCode.BadRequest -> PutAssetsAlertsByIccid.BadRequest
+        | HttpStatusCode.Unauthorized -> PutAssetsAlertsByIccid.Unauthorized
+        | _ -> PutAssetsAlertsByIccid.InternalServerError
 
     ///<summary>
     ///Forces an update location on the SIM. Useful to remotely reset the network connection on a SIM (refresh connection).
@@ -1747,14 +1574,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/purge" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAssetsPurgeByIccid.OK
-        else if status = HttpStatusCode.BadRequest then
-            PostAssetsPurgeByIccid.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            PostAssetsPurgeByIccid.Unauthorized
-        else
-            PostAssetsPurgeByIccid.InternalServerError
+        match status with
+        | HttpStatusCode.OK -> PostAssetsPurgeByIccid.OK
+        | HttpStatusCode.BadRequest -> PostAssetsPurgeByIccid.BadRequest
+        | HttpStatusCode.Unauthorized -> PostAssetsPurgeByIccid.Unauthorized
+        | _ -> PostAssetsPurgeByIccid.InternalServerError
 
     ///<summary>
     ///Sends a message to the SIM limited to 160 characters. A single SMS can hold up to 160 characters using "Stardard" coding, some special characters are allowed but they consume double space. Using characters out of the standard set requires UCS-2 coding and the message size is limited to 70 characters.&amp;lt;br&amp;gt;&amp;lt;br&amp;gt;Use data coding scheme 240 for a Flash SMS, and 0 for a Standard SMS. A Flash SMS is displayed on the screen immediately upon arrival but is not saved or stored on the device. A Standard SMS is displayed and saved to the device
@@ -1765,14 +1589,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/sms" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAssetsSmsByIccid.OK
-        else if status = HttpStatusCode.BadRequest then
-            PostAssetsSmsByIccid.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            PostAssetsSmsByIccid.Unauthorized
-        else
-            PostAssetsSmsByIccid.InternalServerError
+        match status with
+        | HttpStatusCode.OK -> PostAssetsSmsByIccid.OK
+        | HttpStatusCode.BadRequest -> PostAssetsSmsByIccid.BadRequest
+        | HttpStatusCode.Unauthorized -> PostAssetsSmsByIccid.Unauthorized
+        | _ -> PostAssetsSmsByIccid.InternalServerError
 
     ///<summary>
     ///Set limits for a simcard. You can set the limit for data (limit or datalimit) or sms (smslimit). Is mandatory to set one of them at least, but you can set both.&amp;lt;br&amp;gt;Datalimit must be set on bytes.
@@ -1783,14 +1604,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/limit" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAssetsLimitByIccid.OK
-        else if status = HttpStatusCode.BadRequest then
-            PostAssetsLimitByIccid.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            PostAssetsLimitByIccid.Unauthorized
-        else
-            PostAssetsLimitByIccid.InternalServerError
+        match status with
+        | HttpStatusCode.OK -> PostAssetsLimitByIccid.OK
+        | HttpStatusCode.BadRequest -> PostAssetsLimitByIccid.BadRequest
+        | HttpStatusCode.Unauthorized -> PostAssetsLimitByIccid.Unauthorized
+        | _ -> PostAssetsLimitByIccid.InternalServerError
 
     ///<summary>
     ///Set tags for a simcard. Each tag have an index  related with the order of the custom field.,  You need to add in each query as many values as tags have the simcard.   Example if you create three custom Fields  in this order  CF1, CF2 and CF3, you will need to add in the body 3 sections with the values that you need
@@ -1829,14 +1647,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/tags" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAssetsTagsByIccid.OK
-        else if status = HttpStatusCode.BadRequest then
-            PostAssetsTagsByIccid.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            PostAssetsTagsByIccid.Unauthorized
-        else
-            PostAssetsTagsByIccid.InternalServerError
+        match status with
+        | HttpStatusCode.OK -> PostAssetsTagsByIccid.OK
+        | HttpStatusCode.BadRequest -> PostAssetsTagsByIccid.BadRequest
+        | HttpStatusCode.Unauthorized -> PostAssetsTagsByIccid.Unauthorized
+        | _ -> PostAssetsTagsByIccid.InternalServerError
 
     ///<summary>
     ///Checks the simcard status over the network, if the sim is correctly provisioned in the system, last connection, last data transmision, if it is online etc...
@@ -1847,14 +1662,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}/diagnostic" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAssetsDiagnosticByIccid.Unauthorized
-        else if status = HttpStatusCode.InternalServerError then
-            GetAssetsDiagnosticByIccid.InternalServerError
-        else
-            GetAssetsDiagnosticByIccid.ServiceUnavailable
+        match status with
+        | HttpStatusCode.OK -> GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAssetsDiagnosticByIccid.Unauthorized
+        | HttpStatusCode.InternalServerError -> GetAssetsDiagnosticByIccid.InternalServerError
+        | _ -> GetAssetsDiagnosticByIccid.ServiceUnavailable
 
     ///<summary>
     ///Return assets location.
@@ -1865,16 +1677,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}/location" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAssetsLocationByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
-        else if status = HttpStatusCode.NotFound then
-            GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
-        else
-            GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetAssetsLocationByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
+        | HttpStatusCode.NotFound -> GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
+        | _ -> GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Return asset sessions.
@@ -1885,16 +1693,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}/sessions" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
-        else if status = HttpStatusCode.NotFound then
-            GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
-        else
-            GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
+        | HttpStatusCode.NotFound -> GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
+        | _ -> GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Reassign a new IP to a single asset or a bulk of assets. You can choose to update the IP and assign a new Fixed IP from a security service or a dynamic IP.
@@ -1920,12 +1724,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/reports/custom" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetReportsCustom.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetReportsCustom.Unauthorized(Serializer.deserialize content)
-        else
-            GetReportsCustom.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetReportsCustom.OK(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetReportsCustom.Unauthorized(Serializer.deserialize content)
+        | _ -> GetReportsCustom.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Create a new custom report. &amp;lt;/br&amp;gt; Date filtering supports dates as `YYYY-MM-DDTHH:mm:SSZ`, for example `"2020-04-01T00:59:59Z"` &amp;lt;/br&amp;gt; The fileds requires are; accountId, dateFrom, dateTo
@@ -1936,16 +1738,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/reports/custom" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostReportsCustom.OK
-        else if status = HttpStatusCode.Unauthorized then
-            PostReportsCustom.Unauthorized(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            PostReportsCustom.Forbidden(Serializer.deserialize content)
-        else if status = HttpStatusCode.NotFound then
-            PostReportsCustom.NotFound(Serializer.deserialize content)
-        else
-            PostReportsCustom.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostReportsCustom.OK
+        | HttpStatusCode.Unauthorized -> PostReportsCustom.Unauthorized(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> PostReportsCustom.Forbidden(Serializer.deserialize content)
+        | HttpStatusCode.NotFound -> PostReportsCustom.NotFound(Serializer.deserialize content)
+        | _ -> PostReportsCustom.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Delete all reports from an account
@@ -1956,12 +1754,10 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/reports/custom" requestParts cancellationToken
 
-        if status = HttpStatusCode.NoContent then
-            DeleteReportsCustom.NoContent
-        else if status = HttpStatusCode.Unauthorized then
-            DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
-        else
-            DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.NoContent -> DeleteReportsCustom.NoContent
+        | HttpStatusCode.Unauthorized -> DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
+        | _ -> DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get one reports from an account
@@ -1972,14 +1768,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetReportsCustomByReportId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-        else if status = HttpStatusCode.NotFound then
-            GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
-        else
-            GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetReportsCustomByReportId.OK(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
+        | HttpStatusCode.NotFound -> GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
+        | _ -> GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Delete one report from an account
@@ -1990,14 +1783,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.NoContent then
-            DeleteReportsCustomByReportId.NoContent
-        else if status = HttpStatusCode.Unauthorized then
-            DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-        else if status = HttpStatusCode.NotFound then
-            DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
-        else
-            DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.NoContent -> DeleteReportsCustomByReportId.NoContent
+        | HttpStatusCode.Unauthorized -> DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
+        | HttpStatusCode.NotFound -> DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
+        | _ -> DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Assets card Info (bulk)
@@ -2062,14 +1852,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/events" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetEvents.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetEvents.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetEvents.Unauthorized(Serializer.deserialize content)
-        else
-            GetEvents.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetEvents.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetEvents.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetEvents.Unauthorized(Serializer.deserialize content)
+        | _ -> GetEvents.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get all zones schemes
@@ -2125,14 +1912,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/subscribe" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
-        else
-            PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
+        | _ -> PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Transfer a Asset from a account to another in bulk
@@ -2143,14 +1927,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/transfer" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
-        else
-            PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
+        | _ -> PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Return a Asset from a account to parent account in bulk
@@ -2161,14 +1942,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/return" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
-        else
-            PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
+        | _ -> PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Suspend assets in a massive way by using different filters
@@ -2179,14 +1957,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/bulk/assets/suspend" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
-        else
-            PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
+        | _ -> PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///This endpoint change in a massive way the suspend status of the assets which match with the filter setted.
@@ -2197,14 +1972,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/bulk/assets/unsuspend" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
-        else
-            PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
+        | _ -> PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Resubscribe a bulk of assets to the assigned product.
@@ -2219,14 +1991,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/resubscribe" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
-        else
-            PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
+        | _ -> PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Create Assets in bulk mode
@@ -2237,14 +2006,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PostBulkAssets.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostBulkAssets.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostBulkAssets.Unauthorized(Serializer.deserialize content)
-        else
-            PostBulkAssets.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PostBulkAssets.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostBulkAssets.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostBulkAssets.Unauthorized(Serializer.deserialize content)
+        | _ -> PostBulkAssets.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Update Assets in bulk mode
@@ -2255,14 +2021,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/bulk/assets" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PutBulkAssets.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutBulkAssets.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutBulkAssets.Unauthorized(Serializer.deserialize content)
-        else
-            PutBulkAssets.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PutBulkAssets.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutBulkAssets.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutBulkAssets.Unauthorized(Serializer.deserialize content)
+        | _ -> PutBulkAssets.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Update group name of Assets in bulk mode
@@ -2273,14 +2036,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/bulk/assets/groupname" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
-        else
-            PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
+        | _ -> PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///You can set the limit for data (limit or datalimit) or sms (smslimit). Is mandatory to set one of them at least, but you can set both.&amp;lt;br&amp;gt;Datalimit must be set on bytes.
@@ -2291,14 +2051,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/limit" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
-        else
-            PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
+        | _ -> PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///- A maximum of 3 alerts per SIM can be set in order to notify the user when the consumption of a  promotion  reaches or exceeds a certain limit, Alerts can also be used to notify the user of usage over their predefined bundle amount.
@@ -2311,14 +2068,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/bulk/assets/alerts" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
-        else
-            PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
+        | _ -> PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Sends a message to the SIM limited to 160 characters. A single SMS can hold up to 160 characters using "Stardard" coding, some special characters are allowed but they consume double space. Using characters out of the standard set requires UCS-2 coding and the message size is limited to 70 characters.&amp;lt;br&amp;gt;&amp;lt;br&amp;gt;Use data coding scheme 240 for a Flash SMS, and 0 for a Standard SMS. A Flash SMS is displayed on the screen immediately upon arrival but is not saved or stored on the device. A Standard SMS is displayed and saved to the device
@@ -2329,14 +2083,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/sms" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PostBulkAssetsSms.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
-        else
-            PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PostBulkAssetsSms.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
+        | _ -> PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Forces an update location on the SIM. Useful to remotely reset the network connection on a SIM (refresh connection).
@@ -2347,14 +2098,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/purge" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
-        else
-            PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
+        | _ -> PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Download template for bulk update.
@@ -2395,14 +2143,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/bulk/assets/reallocate-ip" requestParts cancellationToken
 
-        if status = HttpStatusCode.Accepted then
-            PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
-        else
-            PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.Accepted -> PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
+        | _ -> PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Retrieve the URL and params for the redirection.
@@ -2473,14 +2218,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/payments/topupPaypal" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
-        else
-            PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
+        | _ -> PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Confirms a Paypal transaction
@@ -2498,14 +2240,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/payments/confirmTopupPaypal" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
-        else
-            PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
+        | _ -> PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Retrieves security alerts for an account
@@ -2606,18 +2345,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/security/alerts" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSecurityAlerts.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetSecurityAlerts.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            GetSecurityAlerts.Unauthorized
-        else if status = HttpStatusCode.Forbidden then
-            GetSecurityAlerts.Forbidden
-        else if status = HttpStatusCode.InternalServerError then
-            GetSecurityAlerts.InternalServerError
-        else
-            GetSecurityAlerts.ServiceUnavailable
+        match status with
+        | HttpStatusCode.OK -> GetSecurityAlerts.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetSecurityAlerts.BadRequest
+        | HttpStatusCode.Unauthorized -> GetSecurityAlerts.Unauthorized
+        | HttpStatusCode.Forbidden -> GetSecurityAlerts.Forbidden
+        | HttpStatusCode.InternalServerError -> GetSecurityAlerts.InternalServerError
+        | _ -> GetSecurityAlerts.ServiceUnavailable
 
     ///<summary>
     ///Fetches security alerts for an account
@@ -2641,18 +2375,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetSecurityAlertsByAlertId.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            GetSecurityAlertsByAlertId.Unauthorized
-        else if status = HttpStatusCode.Forbidden then
-            GetSecurityAlertsByAlertId.Forbidden
-        else if status = HttpStatusCode.InternalServerError then
-            GetSecurityAlertsByAlertId.InternalServerError
-        else
-            GetSecurityAlertsByAlertId.ServiceUnavailable
+        match status with
+        | HttpStatusCode.OK -> GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetSecurityAlertsByAlertId.BadRequest
+        | HttpStatusCode.Unauthorized -> GetSecurityAlertsByAlertId.Unauthorized
+        | HttpStatusCode.Forbidden -> GetSecurityAlertsByAlertId.Forbidden
+        | HttpStatusCode.InternalServerError -> GetSecurityAlertsByAlertId.InternalServerError
+        | _ -> GetSecurityAlertsByAlertId.ServiceUnavailable
 
     ///<summary>
     ///Edits security alerts for an account
@@ -2679,18 +2408,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutSecurityAlertsByAlertId.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            PutSecurityAlertsByAlertId.Unauthorized
-        else if status = HttpStatusCode.Forbidden then
-            PutSecurityAlertsByAlertId.Forbidden
-        else if status = HttpStatusCode.InternalServerError then
-            PutSecurityAlertsByAlertId.InternalServerError
-        else
-            PutSecurityAlertsByAlertId.ServiceUnavailable
+        match status with
+        | HttpStatusCode.OK -> PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutSecurityAlertsByAlertId.BadRequest
+        | HttpStatusCode.Unauthorized -> PutSecurityAlertsByAlertId.Unauthorized
+        | HttpStatusCode.Forbidden -> PutSecurityAlertsByAlertId.Forbidden
+        | HttpStatusCode.InternalServerError -> PutSecurityAlertsByAlertId.InternalServerError
+        | _ -> PutSecurityAlertsByAlertId.ServiceUnavailable
 
     ///<summary>
     ///Deletes security alerts for an account
@@ -2714,18 +2438,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-        if status = HttpStatusCode.NoContent then
-            DeleteSecurityAlertsByAlertId.NoContent
-        else if status = HttpStatusCode.BadRequest then
-            DeleteSecurityAlertsByAlertId.BadRequest
-        else if status = HttpStatusCode.Unauthorized then
-            DeleteSecurityAlertsByAlertId.Unauthorized
-        else if status = HttpStatusCode.Forbidden then
-            DeleteSecurityAlertsByAlertId.Forbidden
-        else if status = HttpStatusCode.InternalServerError then
-            DeleteSecurityAlertsByAlertId.InternalServerError
-        else
-            DeleteSecurityAlertsByAlertId.ServiceUnavailable
+        match status with
+        | HttpStatusCode.NoContent -> DeleteSecurityAlertsByAlertId.NoContent
+        | HttpStatusCode.BadRequest -> DeleteSecurityAlertsByAlertId.BadRequest
+        | HttpStatusCode.Unauthorized -> DeleteSecurityAlertsByAlertId.Unauthorized
+        | HttpStatusCode.Forbidden -> DeleteSecurityAlertsByAlertId.Forbidden
+        | HttpStatusCode.InternalServerError -> DeleteSecurityAlertsByAlertId.InternalServerError
+        | _ -> DeleteSecurityAlertsByAlertId.ServiceUnavailable
 
     ///<summary>
     ///Get Top 10 subscribers threatened. Type Table
@@ -2758,14 +2477,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/security/topthreaten" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get Counter of alert grouped by type of security alert. Type Pie
@@ -2798,14 +2514,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/security/byalarmtype" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Retrive the information stored about eSIMs for an account and below.
@@ -2831,14 +2544,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/esims" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostEsims.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostEsims.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostEsims.Unauthorized(Serializer.deserialize content)
-        else
-            PostEsims.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostEsims.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostEsims.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostEsims.Unauthorized(Serializer.deserialize content)
+        | _ -> PostEsims.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Retrive the information stored about eSIMs for an account and below.
@@ -2882,14 +2592,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/esims/{eid}/transfer" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostEsimsTransferByEid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
-        else
-            PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostEsimsTransferByEid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
+        | _ -> PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Return a ESim from a account to parent account
@@ -2900,14 +2607,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/esims/{eid}/return" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostEsimsReturnByEid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
-        else
-            PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostEsimsReturnByEid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
+        | _ -> PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Activate the enabled profile and subscribe it to the assigned product.
@@ -3204,14 +2908,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/1" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph1.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph1.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph1.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph1.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph1.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph1.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph1.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph1.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get amount of cdrs by an account.Type Line
@@ -3240,14 +2941,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/2" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph2.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph2.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph2.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph2.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph2.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph2.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph2.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph2.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get amount of cdrs aggregated by the mcc in an account. Type Pie
@@ -3276,14 +2974,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/3" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph3.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph3.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph3.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph3.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph3.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph3.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph3.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph3.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get amount of cdrs aggregated by the mcc and the mnc in an account. Type Pie
@@ -3312,14 +3007,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/4" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph4.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph4.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph4.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph4.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph4.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph4.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph4.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph4.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get CDRs aggregated by Products in an account. Type Line
@@ -3348,14 +3040,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/5" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph5.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph5.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph5.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph5.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph5.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph5.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph5.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph5.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get bytes consumed and aggregated by ICCID in an account. Type Table
@@ -3384,14 +3073,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/6" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph6.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph6.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph6.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph6.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph6.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph6.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph6.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph6.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get CDRs aggregated by ICCID in an account. Type Table
@@ -3420,14 +3106,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/7" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph7.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph7.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph7.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph7.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph7.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph7.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph7.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph7.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get bytes consumed and aggregated by account for the current month and the previous month. Type Line
@@ -3456,14 +3139,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/8" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph8.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph8.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph8.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph8.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph8.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph8.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph8.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph8.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get CDRs aggregated by account for the current month and the previous month. Type Line
@@ -3492,14 +3172,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/9" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph9.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph9.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph9.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph9.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph9.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph9.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph9.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph9.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get stats of products by account for the current month. The period is from the first day of the current month to today. Type Table
@@ -3512,14 +3189,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/10" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph10.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph10.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph10.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph10.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph10.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph10.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph10.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph10.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get status of simcards by account. Type Pie
@@ -3548,14 +3222,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/11" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph11.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph11.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph11.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph11.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph11.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph11.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph11.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph11.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get cost consumed by an account. Type Line
@@ -3584,14 +3255,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/12" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraph12.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraph12.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraph12.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraph12.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraph12.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraph12.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraph12.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraph12.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get the simcard status per day by an account. Type Line
@@ -3620,14 +3288,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/graph/statusesperday" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetGraphStatusesperday.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
-        else
-            GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetGraphStatusesperday.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
+        | _ -> GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get components that are not fully operational and are being used in this account
@@ -3655,14 +3320,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Get a list of all quick dial entries for the SIM
@@ -3673,14 +3335,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Show an individual quick dial entry in the SIM
@@ -3691,14 +3350,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        match status with
+        | HttpStatusCode.OK -> GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized ->
             GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-        else
-            GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+        | _ -> GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Update a short dial entry
@@ -3713,14 +3370,12 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        match status with
+        | HttpStatusCode.OK -> PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized ->
             PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-        else
-            PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+        | _ -> PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Remove a short dial entry. Use "all" as location param if all locations for an user need to be removed.
@@ -3731,14 +3386,13 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-        if status = HttpStatusCode.NoContent then
-            DeleteAssetsQuickDialByIccidAndLocation.NoContent
-        else if status = HttpStatusCode.BadRequest then
+        match status with
+        | HttpStatusCode.NoContent -> DeleteAssetsQuickDialByIccidAndLocation.NoContent
+        | HttpStatusCode.BadRequest ->
             DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
+        | HttpStatusCode.Unauthorized ->
             DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-        else
-            DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+        | _ -> DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Forces to make a MT voice call to a SIM. This function is used to make the client perform a task when it gets a call.
@@ -3749,14 +3403,11 @@ type SyncPodiosuiteClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/assets/{iccid}/dial" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostAssetsDialByIccid.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
-        else if status = HttpStatusCode.Unauthorized then
-            PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
-        else
-            PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> PostAssetsDialByIccid.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
+        | HttpStatusCode.Unauthorized -> PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
+        | _ -> PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
 
     ///<summary>
     ///Retrive the information stored about all steering lists for an account.

--- a/examples/SyncSwashbuckle/Client.fs
+++ b/examples/SyncSwashbuckle/Client.fs
@@ -14,9 +14,7 @@ type SyncSwashbuckleClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/Time" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetTime.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetTime.BadRequest(Serializer.deserialize content)
-        else
-            GetTime.Forbidden(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> GetTime.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetTime.BadRequest(Serializer.deserialize content)
+        | _ -> GetTime.Forbidden(Serializer.deserialize content)

--- a/examples/SyncSwashbuckle/Client.fs
+++ b/examples/SyncSwashbuckle/Client.fs
@@ -14,7 +14,7 @@ type SyncSwashbuckleClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/Time" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetTime.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetTime.BadRequest(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetTime.OK(Serializer.deserialize content)
+        | 400 -> GetTime.BadRequest(Serializer.deserialize content)
         | _ -> GetTime.Forbidden(Serializer.deserialize content)

--- a/examples/SyncWatchful/Client.fs
+++ b/examples/SyncWatchful/Client.fs
@@ -27,8 +27,8 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/audits" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAudits.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetAudits.OK(Serializer.deserialize content)
         | _ -> GetAudits.Forbidden
 
     ///<summary>
@@ -53,9 +53,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/audits/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteAuditById.OK content
-        | HttpStatusCode.Forbidden -> DeleteAuditById.Forbidden
+        match int status with
+        | 200 -> DeleteAuditById.OK content
+        | 403 -> DeleteAuditById.Forbidden
         | _ -> DeleteAuditById.NotFound
 
     ///<summary>
@@ -73,9 +73,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/audits/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetAuditById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetAuditById.BadRequest
+        match int status with
+        | 200 -> GetAuditById.OK(Serializer.deserialize content)
+        | 400 -> GetAuditById.BadRequest
         | _ -> GetAuditById.Forbidden
 
     ///<summary>
@@ -127,9 +127,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/extensions" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetExtensions.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> GetExtensions.Forbidden
+        match int status with
+        | 200 -> GetExtensions.OK(Serializer.deserialize content)
+        | 403 -> GetExtensions.Forbidden
         | _ -> GetExtensions.NotFound
 
     ///<summary>
@@ -154,8 +154,8 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/extensions/{id}/ignore" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> IgnoreExtensionUpdate.OK content
+        match int status with
+        | 200 -> IgnoreExtensionUpdate.OK content
         | _ -> IgnoreExtensionUpdate.NotFound
 
     ///<summary>
@@ -169,8 +169,8 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/extensions/{id}/unignore" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> UnignoreExtensionUpdate.OK content
+        match int status with
+        | 200 -> UnignoreExtensionUpdate.OK content
         | _ -> UnignoreExtensionUpdate.NotFound
 
     ///<summary>
@@ -184,8 +184,8 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/extensions/{id}/update" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> UpdateExtension.OK content
+        match int status with
+        | 200 -> UpdateExtension.OK content
         | _ -> UpdateExtension.NotFound
 
     ///<summary>
@@ -201,8 +201,8 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/feedbacks" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetFeedbacks.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetFeedbacks.OK(Serializer.deserialize content)
         | _ -> GetFeedbacks.Forbidden
 
     ///<summary>
@@ -214,11 +214,11 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/feedbacks" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> CreateFeedbacks.OK(Serializer.deserialize content)
-        | HttpStatusCode.Created -> CreateFeedbacks.Created
-        | HttpStatusCode.BadRequest -> CreateFeedbacks.BadRequest
-        | HttpStatusCode.Forbidden -> CreateFeedbacks.Forbidden
+        match int status with
+        | 200 -> CreateFeedbacks.OK(Serializer.deserialize content)
+        | 201 -> CreateFeedbacks.Created
+        | 400 -> CreateFeedbacks.BadRequest
+        | 403 -> CreateFeedbacks.Forbidden
         | _ -> CreateFeedbacks.NotFound
 
     ///<summary>
@@ -277,8 +277,8 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/logs" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetLogs.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetLogs.OK(Serializer.deserialize content)
         | _ -> GetLogs.Forbidden
 
     ///<summary>
@@ -325,8 +325,8 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/logs/export" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetExportLogs.OK
+        match int status with
+        | 200 -> GetExportLogs.OK
         | _ -> GetExportLogs.Forbidden
 
     ///<summary>
@@ -362,9 +362,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/logs/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteLogById.OK content
-        | HttpStatusCode.Forbidden -> DeleteLogById.Forbidden
+        match int status with
+        | 200 -> DeleteLogById.OK content
+        | 403 -> DeleteLogById.Forbidden
         | _ -> DeleteLogById.NotFound
 
     member this.PostPackages(?cancellationToken: CancellationToken) =
@@ -411,9 +411,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, contentBinary) =
             OpenApiHttp.getBinary httpClient "/reports/sites/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetReportsSitesById.OK contentBinary
-        | HttpStatusCode.Forbidden -> GetReportsSitesById.Forbidden contentBinary
+        match int status with
+        | 200 -> GetReportsSitesById.OK contentBinary
+        | 403 -> GetReportsSitesById.Forbidden contentBinary
         | _ -> GetReportsSitesById.NotFound contentBinary
 
     ///<summary>
@@ -452,9 +452,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, contentBinary) =
             OpenApiHttp.getBinary httpClient "/reports/tags/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetReportsTagsById.OK contentBinary
-        | HttpStatusCode.Forbidden -> GetReportsTagsById.Forbidden contentBinary
+        match int status with
+        | 200 -> GetReportsTagsById.OK contentBinary
+        | 403 -> GetReportsTagsById.Forbidden contentBinary
         | _ -> GetReportsTagsById.NotFound contentBinary
 
     ///<summary>
@@ -530,9 +530,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSites.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> GetSites.Forbidden
+        match int status with
+        | 200 -> GetSites.OK(Serializer.deserialize content)
+        | 403 -> GetSites.Forbidden
         | _ -> GetSites.NotFound
 
     ///<summary>
@@ -544,11 +544,11 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> CreateSite.OK(Serializer.deserialize content)
-        | HttpStatusCode.Created -> CreateSite.Created
-        | HttpStatusCode.BadRequest -> CreateSite.BadRequest
-        | HttpStatusCode.Forbidden -> CreateSite.Forbidden
+        match int status with
+        | 200 -> CreateSite.OK(Serializer.deserialize content)
+        | 201 -> CreateSite.Created
+        | 400 -> CreateSite.BadRequest
+        | 403 -> CreateSite.Forbidden
         | _ -> CreateSite.NotFound
 
     ///<summary>
@@ -573,9 +573,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/sites/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteSitesById.OK content
-        | HttpStatusCode.Forbidden -> DeleteSitesById.Forbidden
+        match int status with
+        | 200 -> DeleteSitesById.OK content
+        | 403 -> DeleteSitesById.Forbidden
         | _ -> DeleteSitesById.NotFound
 
     ///<summary>
@@ -593,9 +593,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSiteById.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> GetSiteById.Forbidden
+        match int status with
+        | 200 -> GetSiteById.OK(Serializer.deserialize content)
+        | 403 -> GetSiteById.Forbidden
         | _ -> GetSiteById.NotFound
 
     ///<summary>
@@ -612,10 +612,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/sites/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PutSitesById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> PutSitesById.BadRequest
-        | HttpStatusCode.Forbidden -> PutSitesById.Forbidden
+        match int status with
+        | 200 -> PutSitesById.OK(Serializer.deserialize content)
+        | 400 -> PutSitesById.BadRequest
+        | 403 -> PutSitesById.Forbidden
         | _ -> PutSitesById.NotFound
 
     ///<summary>
@@ -650,9 +650,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSiteAudits.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> GetSiteAudits.Forbidden
+        match int status with
+        | 200 -> GetSiteAudits.OK(Serializer.deserialize content)
+        | 403 -> GetSiteAudits.Forbidden
         | _ -> GetSiteAudits.NotFound
 
     ///<summary>
@@ -666,11 +666,11 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> CreateAudits.OK(Serializer.deserialize content)
-        | HttpStatusCode.Created -> CreateAudits.Created
-        | HttpStatusCode.BadRequest -> CreateAudits.BadRequest
-        | HttpStatusCode.Forbidden -> CreateAudits.Forbidden
+        match int status with
+        | 200 -> CreateAudits.OK(Serializer.deserialize content)
+        | 201 -> CreateAudits.Created
+        | 400 -> CreateAudits.BadRequest
+        | 403 -> CreateAudits.Forbidden
         | _ -> CreateAudits.NotFound
 
     ///<summary>
@@ -684,9 +684,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/backupnow" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> AddSiteToBackupQueue.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> AddSiteToBackupQueue.Forbidden
+        match int status with
+        | 200 -> AddSiteToBackupQueue.OK(Serializer.deserialize content)
+        | 403 -> AddSiteToBackupQueue.Forbidden
         | _ -> AddSiteToBackupQueue.NotFound
 
     ///<summary>
@@ -700,9 +700,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/backupprofiles" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetBackupProfiles.OK
-        | HttpStatusCode.Forbidden -> GetBackupProfiles.Forbidden
+        match int status with
+        | 200 -> GetBackupProfiles.OK
+        | 403 -> GetBackupProfiles.Forbidden
         | _ -> GetBackupProfiles.NotFound
 
     ///<summary>
@@ -716,9 +716,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/backups" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetListBackups.OK
-        | HttpStatusCode.Forbidden -> GetListBackups.Forbidden
+        match int status with
+        | 200 -> GetListBackups.OK
+        | 403 -> GetListBackups.Forbidden
         | _ -> GetListBackups.NotFound
 
     ///<summary>
@@ -732,9 +732,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/backupstart" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> StartSiteBackup.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> StartSiteBackup.Forbidden
+        match int status with
+        | 200 -> StartSiteBackup.OK(Serializer.deserialize content)
+        | 403 -> StartSiteBackup.Forbidden
         | _ -> StartSiteBackup.NotFound
 
     ///<summary>
@@ -748,9 +748,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/backupstep" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> StepSiteBackup.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> StepSiteBackup.Forbidden
+        match int status with
+        | 200 -> StepSiteBackup.OK(Serializer.deserialize content)
+        | 403 -> StepSiteBackup.Forbidden
         | _ -> StepSiteBackup.NotFound
 
     ///<summary>
@@ -785,9 +785,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSitesExtensionsById.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> GetSitesExtensionsById.Forbidden
+        match int status with
+        | 200 -> GetSitesExtensionsById.OK(Serializer.deserialize content)
+        | 403 -> GetSitesExtensionsById.Forbidden
         | _ -> GetSitesExtensionsById.NotFound
 
     ///<summary>
@@ -804,9 +804,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> InstallExtension.OK
-        | HttpStatusCode.Forbidden -> InstallExtension.Forbidden
+        match int status with
+        | 200 -> InstallExtension.OK
+        | 403 -> InstallExtension.Forbidden
         | _ -> InstallExtension.NotFound
 
     ///<summary>
@@ -857,9 +857,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSitesLogsById.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> GetSitesLogsById.Forbidden
+        match int status with
+        | 200 -> GetSitesLogsById.OK(Serializer.deserialize content)
+        | 403 -> GetSitesLogsById.Forbidden
         | _ -> GetSitesLogsById.NotFound
 
     ///<summary>
@@ -876,11 +876,11 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> CreateLog.OK(Serializer.deserialize content)
-        | HttpStatusCode.Created -> CreateLog.Created
-        | HttpStatusCode.BadRequest -> CreateLog.BadRequest
-        | HttpStatusCode.Forbidden -> CreateLog.Forbidden
+        match int status with
+        | 200 -> CreateLog.OK(Serializer.deserialize content)
+        | 201 -> CreateLog.Created
+        | 400 -> CreateLog.BadRequest
+        | 403 -> CreateLog.Forbidden
         | _ -> CreateLog.NotFound
 
     ///<summary>
@@ -894,9 +894,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteMonitor.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> DeleteMonitor.Forbidden
+        match int status with
+        | 200 -> DeleteMonitor.OK(Serializer.deserialize content)
+        | 403 -> DeleteMonitor.Forbidden
         | _ -> DeleteMonitor.NotFound
 
     ///<summary>
@@ -910,9 +910,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostMonitor.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> PostMonitor.Forbidden
+        match int status with
+        | 200 -> PostMonitor.OK(Serializer.deserialize content)
+        | 403 -> PostMonitor.Forbidden
         | _ -> PostMonitor.NotFound
 
     ///<summary>
@@ -926,9 +926,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/scanner" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> Scanner.OK content
-        | HttpStatusCode.Forbidden -> Scanner.Forbidden
+        match int status with
+        | 200 -> Scanner.OK content
+        | 403 -> Scanner.Forbidden
         | _ -> Scanner.NotFound
 
     ///<summary>
@@ -942,9 +942,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/seo" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> SeoAnalyze.OK content
-        | HttpStatusCode.Forbidden -> SeoAnalyze.Forbidden
+        match int status with
+        | 200 -> SeoAnalyze.OK content
+        | 403 -> SeoAnalyze.Forbidden
         | _ -> SeoAnalyze.NotFound
 
     ///<summary>
@@ -987,9 +987,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSitesTagsById.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> GetSitesTagsById.Forbidden
+        match int status with
+        | 200 -> GetSitesTagsById.OK(Serializer.deserialize content)
+        | 403 -> GetSitesTagsById.Forbidden
         | _ -> GetSitesTagsById.NotFound
 
     ///<summary>
@@ -1006,10 +1006,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> PostTags.OK(Serializer.deserialize content)
-        | HttpStatusCode.Created -> PostTags.Created
-        | HttpStatusCode.Forbidden -> PostTags.Forbidden
+        match int status with
+        | 200 -> PostTags.OK(Serializer.deserialize content)
+        | 201 -> PostTags.Created
+        | 403 -> PostTags.Forbidden
         | _ -> PostTags.NotFound
 
     ///<summary>
@@ -1023,9 +1023,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/updatejoomla" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> UpdateJoomla.OK content
-        | HttpStatusCode.Forbidden -> UpdateJoomla.Forbidden
+        match int status with
+        | 200 -> UpdateJoomla.OK content
+        | 403 -> UpdateJoomla.Forbidden
         | _ -> UpdateJoomla.NotFound
 
     ///<summary>
@@ -1039,9 +1039,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/uptime" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetUptime.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> GetUptime.Forbidden
+        match int status with
+        | 200 -> GetUptime.OK(Serializer.deserialize content)
+        | 403 -> GetUptime.Forbidden
         | _ -> GetUptime.NotFound
 
     ///<summary>
@@ -1055,9 +1055,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/validate" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> ValidateSite.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> ValidateSite.Forbidden
+        match int status with
+        | 200 -> ValidateSite.OK(Serializer.deserialize content)
+        | 403 -> ValidateSite.Forbidden
         | _ -> ValidateSite.NotFound
 
     ///<summary>
@@ -1071,9 +1071,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/validatedebug" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> ValidateDebugSite.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> ValidateDebugSite.Forbidden
+        match int status with
+        | 200 -> ValidateDebugSite.OK(Serializer.deserialize content)
+        | 403 -> ValidateDebugSite.Forbidden
         | _ -> ValidateDebugSite.NotFound
 
     ///<summary>
@@ -1085,8 +1085,8 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/ssousers" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSsoUsers.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetSsoUsers.OK(Serializer.deserialize content)
         | _ -> GetSsoUsers.Forbidden
 
     ///<summary>
@@ -1098,11 +1098,11 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/ssousers" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> CreateSsoUsers.OK(Serializer.deserialize content)
-        | HttpStatusCode.Created -> CreateSsoUsers.Created
-        | HttpStatusCode.BadRequest -> CreateSsoUsers.BadRequest
-        | HttpStatusCode.Forbidden -> CreateSsoUsers.Forbidden
+        match int status with
+        | 200 -> CreateSsoUsers.OK(Serializer.deserialize content)
+        | 201 -> CreateSsoUsers.Created
+        | 400 -> CreateSsoUsers.BadRequest
+        | 403 -> CreateSsoUsers.Forbidden
         | _ -> CreateSsoUsers.NotFound
 
     ///<summary>
@@ -1116,9 +1116,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/ssousers/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteSsoUserById.OK content
-        | HttpStatusCode.Forbidden -> DeleteSsoUserById.Forbidden
+        match int status with
+        | 200 -> DeleteSsoUserById.OK content
+        | 403 -> DeleteSsoUserById.Forbidden
         | _ -> DeleteSsoUserById.NotFound
 
     ///<summary>
@@ -1136,9 +1136,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/ssousers/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSsoUsersById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetSsoUsersById.BadRequest
+        match int status with
+        | 200 -> GetSsoUsersById.OK(Serializer.deserialize content)
+        | 400 -> GetSsoUsersById.BadRequest
         | _ -> GetSsoUsersById.Forbidden
 
     ///<summary>
@@ -1155,11 +1155,11 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/ssousers/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> UpdateSsoUsers.OK(Serializer.deserialize content)
-        | HttpStatusCode.Created -> UpdateSsoUsers.Created
-        | HttpStatusCode.BadRequest -> UpdateSsoUsers.BadRequest
-        | HttpStatusCode.Forbidden -> UpdateSsoUsers.Forbidden
+        match int status with
+        | 200 -> UpdateSsoUsers.OK(Serializer.deserialize content)
+        | 201 -> UpdateSsoUsers.Created
+        | 400 -> UpdateSsoUsers.BadRequest
+        | 403 -> UpdateSsoUsers.Forbidden
         | _ -> UpdateSsoUsers.NotFound
 
     ///<summary>
@@ -1199,8 +1199,8 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/tags" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetTags.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetTags.OK(Serializer.deserialize content)
         | _ -> GetTags.Forbidden
 
     ///<summary>
@@ -1212,11 +1212,11 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/tags" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> CreateTags.OK(Serializer.deserialize content)
-        | HttpStatusCode.Created -> CreateTags.Created
-        | HttpStatusCode.BadRequest -> CreateTags.BadRequest
-        | HttpStatusCode.Forbidden -> CreateTags.Forbidden
+        match int status with
+        | 200 -> CreateTags.OK(Serializer.deserialize content)
+        | 201 -> CreateTags.Created
+        | 400 -> CreateTags.BadRequest
+        | 403 -> CreateTags.Forbidden
         | _ -> CreateTags.NotFound
 
     ///<summary>
@@ -1241,9 +1241,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/tags/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DeleteTagsById.OK content
-        | HttpStatusCode.Forbidden -> DeleteTagsById.Forbidden
+        match int status with
+        | 200 -> DeleteTagsById.OK content
+        | 403 -> DeleteTagsById.Forbidden
         | _ -> DeleteTagsById.NotFound
 
     ///<summary>
@@ -1261,9 +1261,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/tags/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetTagById.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> GetTagById.BadRequest
+        match int status with
+        | 200 -> GetTagById.OK(Serializer.deserialize content)
+        | 400 -> GetTagById.BadRequest
         | _ -> GetTagById.Forbidden
 
     ///<summary>
@@ -1280,10 +1280,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/tags/{id}" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> UpdateTag.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> UpdateTag.BadRequest
-        | HttpStatusCode.Forbidden -> UpdateTag.Forbidden
+        match int status with
+        | 200 -> UpdateTag.OK(Serializer.deserialize content)
+        | 400 -> UpdateTag.BadRequest
+        | 403 -> UpdateTag.Forbidden
         | _ -> UpdateTag.NotFound
 
     ///<summary>
@@ -1354,7 +1354,7 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/tags/{id}/sites" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetSitesByTags.OK(Serializer.deserialize content)
-        | HttpStatusCode.Forbidden -> GetSitesByTags.Forbidden
+        match int status with
+        | 200 -> GetSitesByTags.OK(Serializer.deserialize content)
+        | 403 -> GetSitesByTags.Forbidden
         | _ -> GetSitesByTags.NotFound

--- a/examples/SyncWatchful/Client.fs
+++ b/examples/SyncWatchful/Client.fs
@@ -27,10 +27,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/audits" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAudits.OK(Serializer.deserialize content)
-        else
-            GetAudits.Forbidden
+        match status with
+        | HttpStatusCode.OK -> GetAudits.OK(Serializer.deserialize content)
+        | _ -> GetAudits.Forbidden
 
     ///<summary>
     ///Returns a list of fields
@@ -54,12 +53,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/audits/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteAuditById.OK content
-        else if status = HttpStatusCode.Forbidden then
-            DeleteAuditById.Forbidden
-        else
-            DeleteAuditById.NotFound
+        match status with
+        | HttpStatusCode.OK -> DeleteAuditById.OK content
+        | HttpStatusCode.Forbidden -> DeleteAuditById.Forbidden
+        | _ -> DeleteAuditById.NotFound
 
     ///<summary>
     ///Returns a audit based on ID
@@ -76,12 +73,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/audits/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetAuditById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetAuditById.BadRequest
-        else
-            GetAuditById.Forbidden
+        match status with
+        | HttpStatusCode.OK -> GetAuditById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetAuditById.BadRequest
+        | _ -> GetAuditById.Forbidden
 
     ///<summary>
     ///Returns a list Extensions
@@ -132,12 +127,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/extensions" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetExtensions.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            GetExtensions.Forbidden
-        else
-            GetExtensions.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetExtensions.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> GetExtensions.Forbidden
+        | _ -> GetExtensions.NotFound
 
     ///<summary>
     ///Returns a list of fields
@@ -161,10 +154,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/extensions/{id}/ignore" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            IgnoreExtensionUpdate.OK content
-        else
-            IgnoreExtensionUpdate.NotFound
+        match status with
+        | HttpStatusCode.OK -> IgnoreExtensionUpdate.OK content
+        | _ -> IgnoreExtensionUpdate.NotFound
 
     ///<summary>
     ///Remove 'ignore updates' for a given extension
@@ -177,10 +169,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/extensions/{id}/unignore" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            UnignoreExtensionUpdate.OK content
-        else
-            UnignoreExtensionUpdate.NotFound
+        match status with
+        | HttpStatusCode.OK -> UnignoreExtensionUpdate.OK content
+        | _ -> UnignoreExtensionUpdate.NotFound
 
     ///<summary>
     ///Update the extension on the remote site
@@ -193,10 +184,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/extensions/{id}/update" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            UpdateExtension.OK content
-        else
-            UpdateExtension.NotFound
+        match status with
+        | HttpStatusCode.OK -> UpdateExtension.OK content
+        | _ -> UpdateExtension.NotFound
 
     ///<summary>
     ///Returns a list of feedbacks
@@ -211,10 +201,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/feedbacks" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetFeedbacks.OK(Serializer.deserialize content)
-        else
-            GetFeedbacks.Forbidden
+        match status with
+        | HttpStatusCode.OK -> GetFeedbacks.OK(Serializer.deserialize content)
+        | _ -> GetFeedbacks.Forbidden
 
     ///<summary>
     ///Create a feedback
@@ -225,16 +214,12 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/feedbacks" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            CreateFeedbacks.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Created then
-            CreateFeedbacks.Created
-        else if status = HttpStatusCode.BadRequest then
-            CreateFeedbacks.BadRequest
-        else if status = HttpStatusCode.Forbidden then
-            CreateFeedbacks.Forbidden
-        else
-            CreateFeedbacks.NotFound
+        match status with
+        | HttpStatusCode.OK -> CreateFeedbacks.OK(Serializer.deserialize content)
+        | HttpStatusCode.Created -> CreateFeedbacks.Created
+        | HttpStatusCode.BadRequest -> CreateFeedbacks.BadRequest
+        | HttpStatusCode.Forbidden -> CreateFeedbacks.Forbidden
+        | _ -> CreateFeedbacks.NotFound
 
     ///<summary>
     ///Returns a list of fields
@@ -292,10 +277,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/logs" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetLogs.OK(Serializer.deserialize content)
-        else
-            GetLogs.Forbidden
+        match status with
+        | HttpStatusCode.OK -> GetLogs.OK(Serializer.deserialize content)
+        | _ -> GetLogs.Forbidden
 
     ///<summary>
     ///Returns a file contain the list of logs
@@ -341,10 +325,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/logs/export" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetExportLogs.OK
-        else
-            GetExportLogs.Forbidden
+        match status with
+        | HttpStatusCode.OK -> GetExportLogs.OK
+        | _ -> GetExportLogs.Forbidden
 
     ///<summary>
     ///Returns a list of fields
@@ -379,12 +362,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/logs/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteLogById.OK content
-        else if status = HttpStatusCode.Forbidden then
-            DeleteLogById.Forbidden
-        else
-            DeleteLogById.NotFound
+        match status with
+        | HttpStatusCode.OK -> DeleteLogById.OK content
+        | HttpStatusCode.Forbidden -> DeleteLogById.Forbidden
+        | _ -> DeleteLogById.NotFound
 
     member this.PostPackages(?cancellationToken: CancellationToken) =
         let requestParts = []
@@ -430,12 +411,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, contentBinary) =
             OpenApiHttp.getBinary httpClient "/reports/sites/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetReportsSitesById.OK contentBinary
-        else if status = HttpStatusCode.Forbidden then
-            GetReportsSitesById.Forbidden contentBinary
-        else
-            GetReportsSitesById.NotFound contentBinary
+        match status with
+        | HttpStatusCode.OK -> GetReportsSitesById.OK contentBinary
+        | HttpStatusCode.Forbidden -> GetReportsSitesById.Forbidden contentBinary
+        | _ -> GetReportsSitesById.NotFound contentBinary
 
     ///<summary>
     ///Returns a report based on a site ID
@@ -473,12 +452,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, contentBinary) =
             OpenApiHttp.getBinary httpClient "/reports/tags/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetReportsTagsById.OK contentBinary
-        else if status = HttpStatusCode.Forbidden then
-            GetReportsTagsById.Forbidden contentBinary
-        else
-            GetReportsTagsById.NotFound contentBinary
+        match status with
+        | HttpStatusCode.OK -> GetReportsTagsById.OK contentBinary
+        | HttpStatusCode.Forbidden -> GetReportsTagsById.Forbidden contentBinary
+        | _ -> GetReportsTagsById.NotFound contentBinary
 
     ///<summary>
     ///Returns a list of Sites
@@ -553,12 +530,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSites.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            GetSites.Forbidden
-        else
-            GetSites.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetSites.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> GetSites.Forbidden
+        | _ -> GetSites.NotFound
 
     ///<summary>
     ///Create a site
@@ -569,16 +544,12 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            CreateSite.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Created then
-            CreateSite.Created
-        else if status = HttpStatusCode.BadRequest then
-            CreateSite.BadRequest
-        else if status = HttpStatusCode.Forbidden then
-            CreateSite.Forbidden
-        else
-            CreateSite.NotFound
+        match status with
+        | HttpStatusCode.OK -> CreateSite.OK(Serializer.deserialize content)
+        | HttpStatusCode.Created -> CreateSite.Created
+        | HttpStatusCode.BadRequest -> CreateSite.BadRequest
+        | HttpStatusCode.Forbidden -> CreateSite.Forbidden
+        | _ -> CreateSite.NotFound
 
     ///<summary>
     ///Returns a list of fields
@@ -602,12 +573,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/sites/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteSitesById.OK content
-        else if status = HttpStatusCode.Forbidden then
-            DeleteSitesById.Forbidden
-        else
-            DeleteSitesById.NotFound
+        match status with
+        | HttpStatusCode.OK -> DeleteSitesById.OK content
+        | HttpStatusCode.Forbidden -> DeleteSitesById.Forbidden
+        | _ -> DeleteSitesById.NotFound
 
     ///<summary>
     ///Return a site based on ID
@@ -624,12 +593,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSiteById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            GetSiteById.Forbidden
-        else
-            GetSiteById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetSiteById.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> GetSiteById.Forbidden
+        | _ -> GetSiteById.NotFound
 
     ///<summary>
     ///Update a site
@@ -645,14 +612,11 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/sites/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PutSitesById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            PutSitesById.BadRequest
-        else if status = HttpStatusCode.Forbidden then
-            PutSitesById.Forbidden
-        else
-            PutSitesById.NotFound
+        match status with
+        | HttpStatusCode.OK -> PutSitesById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> PutSitesById.BadRequest
+        | HttpStatusCode.Forbidden -> PutSitesById.Forbidden
+        | _ -> PutSitesById.NotFound
 
     ///<summary>
     ///Return audits for a specific website
@@ -686,12 +650,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSiteAudits.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            GetSiteAudits.Forbidden
-        else
-            GetSiteAudits.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetSiteAudits.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> GetSiteAudits.Forbidden
+        | _ -> GetSiteAudits.NotFound
 
     ///<summary>
     ///Create an audit for the site
@@ -704,16 +666,12 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            CreateAudits.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Created then
-            CreateAudits.Created
-        else if status = HttpStatusCode.BadRequest then
-            CreateAudits.BadRequest
-        else if status = HttpStatusCode.Forbidden then
-            CreateAudits.Forbidden
-        else
-            CreateAudits.NotFound
+        match status with
+        | HttpStatusCode.OK -> CreateAudits.OK(Serializer.deserialize content)
+        | HttpStatusCode.Created -> CreateAudits.Created
+        | HttpStatusCode.BadRequest -> CreateAudits.BadRequest
+        | HttpStatusCode.Forbidden -> CreateAudits.Forbidden
+        | _ -> CreateAudits.NotFound
 
     ///<summary>
     ///Add the site to the backup queue
@@ -726,12 +684,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/backupnow" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            AddSiteToBackupQueue.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            AddSiteToBackupQueue.Forbidden
-        else
-            AddSiteToBackupQueue.NotFound
+        match status with
+        | HttpStatusCode.OK -> AddSiteToBackupQueue.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> AddSiteToBackupQueue.Forbidden
+        | _ -> AddSiteToBackupQueue.NotFound
 
     ///<summary>
     ///Return backup profile
@@ -744,12 +700,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/backupprofiles" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetBackupProfiles.OK
-        else if status = HttpStatusCode.Forbidden then
-            GetBackupProfiles.Forbidden
-        else
-            GetBackupProfiles.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetBackupProfiles.OK
+        | HttpStatusCode.Forbidden -> GetBackupProfiles.Forbidden
+        | _ -> GetBackupProfiles.NotFound
 
     ///<summary>
     ///List of latest backups
@@ -762,12 +716,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/backups" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetListBackups.OK
-        else if status = HttpStatusCode.Forbidden then
-            GetListBackups.Forbidden
-        else
-            GetListBackups.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetListBackups.OK
+        | HttpStatusCode.Forbidden -> GetListBackups.Forbidden
+        | _ -> GetListBackups.NotFound
 
     ///<summary>
     ///Start a remote backup for the site
@@ -780,12 +732,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/backupstart" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            StartSiteBackup.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            StartSiteBackup.Forbidden
-        else
-            StartSiteBackup.NotFound
+        match status with
+        | HttpStatusCode.OK -> StartSiteBackup.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> StartSiteBackup.Forbidden
+        | _ -> StartSiteBackup.NotFound
 
     ///<summary>
     ///Step (continue) a remote backup for the site
@@ -798,12 +748,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/backupstep" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            StepSiteBackup.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            StepSiteBackup.Forbidden
-        else
-            StepSiteBackup.NotFound
+        match status with
+        | HttpStatusCode.OK -> StepSiteBackup.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> StepSiteBackup.Forbidden
+        | _ -> StepSiteBackup.NotFound
 
     ///<summary>
     ///Get extensions for a site
@@ -837,12 +785,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSitesExtensionsById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            GetSitesExtensionsById.Forbidden
-        else
-            GetSitesExtensionsById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetSitesExtensionsById.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> GetSitesExtensionsById.Forbidden
+        | _ -> GetSitesExtensionsById.NotFound
 
     ///<summary>
     ///Install extension
@@ -858,12 +804,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            InstallExtension.OK
-        else if status = HttpStatusCode.Forbidden then
-            InstallExtension.Forbidden
-        else
-            InstallExtension.NotFound
+        match status with
+        | HttpStatusCode.OK -> InstallExtension.OK
+        | HttpStatusCode.Forbidden -> InstallExtension.Forbidden
+        | _ -> InstallExtension.NotFound
 
     ///<summary>
     ///Return logs for a specific website
@@ -913,12 +857,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSitesLogsById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            GetSitesLogsById.Forbidden
-        else
-            GetSitesLogsById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetSitesLogsById.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> GetSitesLogsById.Forbidden
+        | _ -> GetSitesLogsById.NotFound
 
     ///<summary>
     ///Create a custom log for a specific website
@@ -934,16 +876,12 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            CreateLog.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Created then
-            CreateLog.Created
-        else if status = HttpStatusCode.BadRequest then
-            CreateLog.BadRequest
-        else if status = HttpStatusCode.Forbidden then
-            CreateLog.Forbidden
-        else
-            CreateLog.NotFound
+        match status with
+        | HttpStatusCode.OK -> CreateLog.OK(Serializer.deserialize content)
+        | HttpStatusCode.Created -> CreateLog.Created
+        | HttpStatusCode.BadRequest -> CreateLog.BadRequest
+        | HttpStatusCode.Forbidden -> CreateLog.Forbidden
+        | _ -> CreateLog.NotFound
 
     ///<summary>
     ///Return boolean
@@ -956,12 +894,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteMonitor.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            DeleteMonitor.Forbidden
-        else
-            DeleteMonitor.NotFound
+        match status with
+        | HttpStatusCode.OK -> DeleteMonitor.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> DeleteMonitor.Forbidden
+        | _ -> DeleteMonitor.NotFound
 
     ///<summary>
     ///Return boolean
@@ -974,12 +910,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostMonitor.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            PostMonitor.Forbidden
-        else
-            PostMonitor.NotFound
+        match status with
+        | HttpStatusCode.OK -> PostMonitor.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> PostMonitor.Forbidden
+        | _ -> PostMonitor.NotFound
 
     ///<summary>
     ///Scan the site for malware
@@ -992,12 +926,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/scanner" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            Scanner.OK content
-        else if status = HttpStatusCode.Forbidden then
-            Scanner.Forbidden
-        else
-            Scanner.NotFound
+        match status with
+        | HttpStatusCode.OK -> Scanner.OK content
+        | HttpStatusCode.Forbidden -> Scanner.Forbidden
+        | _ -> Scanner.NotFound
 
     ///<summary>
     ///SEO analyze for a page
@@ -1010,12 +942,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/seo" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            SeoAnalyze.OK content
-        else if status = HttpStatusCode.Forbidden then
-            SeoAnalyze.Forbidden
-        else
-            SeoAnalyze.NotFound
+        match status with
+        | HttpStatusCode.OK -> SeoAnalyze.OK content
+        | HttpStatusCode.Forbidden -> SeoAnalyze.Forbidden
+        | _ -> SeoAnalyze.NotFound
 
     ///<summary>
     ///Return tags for a specific website
@@ -1057,12 +987,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSitesTagsById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            GetSitesTagsById.Forbidden
-        else
-            GetSitesTagsById.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetSitesTagsById.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> GetSitesTagsById.Forbidden
+        | _ -> GetSitesTagsById.NotFound
 
     ///<summary>
     ///Add tags for a specific website
@@ -1078,14 +1006,11 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            PostTags.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Created then
-            PostTags.Created
-        else if status = HttpStatusCode.Forbidden then
-            PostTags.Forbidden
-        else
-            PostTags.NotFound
+        match status with
+        | HttpStatusCode.OK -> PostTags.OK(Serializer.deserialize content)
+        | HttpStatusCode.Created -> PostTags.Created
+        | HttpStatusCode.Forbidden -> PostTags.Forbidden
+        | _ -> PostTags.NotFound
 
     ///<summary>
     ///Update Joomla core on the remote site
@@ -1098,12 +1023,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/sites/{id}/updatejoomla" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            UpdateJoomla.OK content
-        else if status = HttpStatusCode.Forbidden then
-            UpdateJoomla.Forbidden
-        else
-            UpdateJoomla.NotFound
+        match status with
+        | HttpStatusCode.OK -> UpdateJoomla.OK content
+        | HttpStatusCode.Forbidden -> UpdateJoomla.Forbidden
+        | _ -> UpdateJoomla.NotFound
 
     ///<summary>
     ///Return uptime data
@@ -1116,12 +1039,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/uptime" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetUptime.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            GetUptime.Forbidden
-        else
-            GetUptime.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetUptime.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> GetUptime.Forbidden
+        | _ -> GetUptime.NotFound
 
     ///<summary>
     ///validate the site
@@ -1134,12 +1055,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/validate" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            ValidateSite.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            ValidateSite.Forbidden
-        else
-            ValidateSite.NotFound
+        match status with
+        | HttpStatusCode.OK -> ValidateSite.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> ValidateSite.Forbidden
+        | _ -> ValidateSite.NotFound
 
     ///<summary>
     ///validate the site, return the debug information
@@ -1152,12 +1071,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/sites/{id}/validatedebug" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            ValidateDebugSite.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            ValidateDebugSite.Forbidden
-        else
-            ValidateDebugSite.NotFound
+        match status with
+        | HttpStatusCode.OK -> ValidateDebugSite.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> ValidateDebugSite.Forbidden
+        | _ -> ValidateDebugSite.NotFound
 
     ///<summary>
     ///Returns a list of SSO Users
@@ -1168,10 +1085,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/ssousers" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSsoUsers.OK(Serializer.deserialize content)
-        else
-            GetSsoUsers.Forbidden
+        match status with
+        | HttpStatusCode.OK -> GetSsoUsers.OK(Serializer.deserialize content)
+        | _ -> GetSsoUsers.Forbidden
 
     ///<summary>
     ///Create a SSO User
@@ -1182,16 +1098,12 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/ssousers" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            CreateSsoUsers.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Created then
-            CreateSsoUsers.Created
-        else if status = HttpStatusCode.BadRequest then
-            CreateSsoUsers.BadRequest
-        else if status = HttpStatusCode.Forbidden then
-            CreateSsoUsers.Forbidden
-        else
-            CreateSsoUsers.NotFound
+        match status with
+        | HttpStatusCode.OK -> CreateSsoUsers.OK(Serializer.deserialize content)
+        | HttpStatusCode.Created -> CreateSsoUsers.Created
+        | HttpStatusCode.BadRequest -> CreateSsoUsers.BadRequest
+        | HttpStatusCode.Forbidden -> CreateSsoUsers.Forbidden
+        | _ -> CreateSsoUsers.NotFound
 
     ///<summary>
     ///Delete a specific SSO User
@@ -1204,12 +1116,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/ssousers/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteSsoUserById.OK content
-        else if status = HttpStatusCode.Forbidden then
-            DeleteSsoUserById.Forbidden
-        else
-            DeleteSsoUserById.NotFound
+        match status with
+        | HttpStatusCode.OK -> DeleteSsoUserById.OK content
+        | HttpStatusCode.Forbidden -> DeleteSsoUserById.Forbidden
+        | _ -> DeleteSsoUserById.NotFound
 
     ///<summary>
     ///Returns a SSO User based on ID
@@ -1226,12 +1136,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/ssousers/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSsoUsersById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetSsoUsersById.BadRequest
-        else
-            GetSsoUsersById.Forbidden
+        match status with
+        | HttpStatusCode.OK -> GetSsoUsersById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetSsoUsersById.BadRequest
+        | _ -> GetSsoUsersById.Forbidden
 
     ///<summary>
     ///Update a SSO User
@@ -1247,16 +1155,12 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/ssousers/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            UpdateSsoUsers.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Created then
-            UpdateSsoUsers.Created
-        else if status = HttpStatusCode.BadRequest then
-            UpdateSsoUsers.BadRequest
-        else if status = HttpStatusCode.Forbidden then
-            UpdateSsoUsers.Forbidden
-        else
-            UpdateSsoUsers.NotFound
+        match status with
+        | HttpStatusCode.OK -> UpdateSsoUsers.OK(Serializer.deserialize content)
+        | HttpStatusCode.Created -> UpdateSsoUsers.Created
+        | HttpStatusCode.BadRequest -> UpdateSsoUsers.BadRequest
+        | HttpStatusCode.Forbidden -> UpdateSsoUsers.Forbidden
+        | _ -> UpdateSsoUsers.NotFound
 
     ///<summary>
     ///Returns a list of tags
@@ -1295,10 +1199,9 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/tags" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetTags.OK(Serializer.deserialize content)
-        else
-            GetTags.Forbidden
+        match status with
+        | HttpStatusCode.OK -> GetTags.OK(Serializer.deserialize content)
+        | _ -> GetTags.Forbidden
 
     ///<summary>
     ///Create a tag
@@ -1309,16 +1212,12 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/tags" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            CreateTags.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Created then
-            CreateTags.Created
-        else if status = HttpStatusCode.BadRequest then
-            CreateTags.BadRequest
-        else if status = HttpStatusCode.Forbidden then
-            CreateTags.Forbidden
-        else
-            CreateTags.NotFound
+        match status with
+        | HttpStatusCode.OK -> CreateTags.OK(Serializer.deserialize content)
+        | HttpStatusCode.Created -> CreateTags.Created
+        | HttpStatusCode.BadRequest -> CreateTags.BadRequest
+        | HttpStatusCode.Forbidden -> CreateTags.Forbidden
+        | _ -> CreateTags.NotFound
 
     ///<summary>
     ///Returns a list of fields
@@ -1342,12 +1241,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.delete httpClient "/tags/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DeleteTagsById.OK content
-        else if status = HttpStatusCode.Forbidden then
-            DeleteTagsById.Forbidden
-        else
-            DeleteTagsById.NotFound
+        match status with
+        | HttpStatusCode.OK -> DeleteTagsById.OK content
+        | HttpStatusCode.Forbidden -> DeleteTagsById.Forbidden
+        | _ -> DeleteTagsById.NotFound
 
     ///<summary>
     ///Returns a tag based on ID
@@ -1364,12 +1261,10 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/tags/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetTagById.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            GetTagById.BadRequest
-        else
-            GetTagById.Forbidden
+        match status with
+        | HttpStatusCode.OK -> GetTagById.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> GetTagById.BadRequest
+        | _ -> GetTagById.Forbidden
 
     ///<summary>
     ///Update a tag
@@ -1385,14 +1280,11 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.put httpClient "/tags/{id}" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            UpdateTag.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            UpdateTag.BadRequest
-        else if status = HttpStatusCode.Forbidden then
-            UpdateTag.Forbidden
-        else
-            UpdateTag.NotFound
+        match status with
+        | HttpStatusCode.OK -> UpdateTag.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> UpdateTag.BadRequest
+        | HttpStatusCode.Forbidden -> UpdateTag.Forbidden
+        | _ -> UpdateTag.NotFound
 
     ///<summary>
     ///Returns a list of sites based with a specific tag id
@@ -1462,9 +1354,7 @@ type SyncWatchfulClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/tags/{id}/sites" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetSitesByTags.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.Forbidden then
-            GetSitesByTags.Forbidden
-        else
-            GetSitesByTags.NotFound
+        match status with
+        | HttpStatusCode.OK -> GetSitesByTags.OK(Serializer.deserialize content)
+        | HttpStatusCode.Forbidden -> GetSitesByTags.Forbidden
+        | _ -> GetSitesByTags.NotFound

--- a/examples/TaskGhibli/Client.fs
+++ b/examples/TaskGhibli/Client.fs
@@ -105,9 +105,9 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/films" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetFilms.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetFilms.BadRequest
+            match int status with
+            | 200 -> return GetFilms.OK(Serializer.deserialize content)
+            | 400 -> return GetFilms.BadRequest
             | _ -> return GetFilms.NotFound
         }
 
@@ -126,9 +126,9 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/films/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetFilmsById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetFilmsById.BadRequest
+            match int status with
+            | 200 -> return GetFilmsById.OK(Serializer.deserialize content)
+            | 400 -> return GetFilmsById.BadRequest
             | _ -> return GetFilmsById.NotFound
         }
 
@@ -148,9 +148,9 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/people" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetPeople.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetPeople.BadRequest
+            match int status with
+            | 200 -> return GetPeople.OK(Serializer.deserialize content)
+            | 400 -> return GetPeople.BadRequest
             | _ -> return GetPeople.NotFound
         }
 
@@ -169,9 +169,9 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/people/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetPeopleById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetPeopleById.BadRequest
+            match int status with
+            | 200 -> return GetPeopleById.OK(Serializer.deserialize content)
+            | 400 -> return GetPeopleById.BadRequest
             | _ -> return GetPeopleById.NotFound
         }
 
@@ -191,9 +191,9 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/locations" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetLocations.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetLocations.BadRequest
+            match int status with
+            | 200 -> return GetLocations.OK(Serializer.deserialize content)
+            | 400 -> return GetLocations.BadRequest
             | _ -> return GetLocations.NotFound
         }
 
@@ -212,9 +212,9 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/locations/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetLocationsById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetLocationsById.BadRequest
+            match int status with
+            | 200 -> return GetLocationsById.OK(Serializer.deserialize content)
+            | 400 -> return GetLocationsById.BadRequest
             | _ -> return GetLocationsById.NotFound
         }
 
@@ -234,9 +234,9 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/species" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSpecies.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetSpecies.BadRequest
+            match int status with
+            | 200 -> return GetSpecies.OK(Serializer.deserialize content)
+            | 400 -> return GetSpecies.BadRequest
             | _ -> return GetSpecies.NotFound
         }
 
@@ -255,9 +255,9 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/species/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSpeciesById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetSpeciesById.BadRequest
+            match int status with
+            | 200 -> return GetSpeciesById.OK(Serializer.deserialize content)
+            | 400 -> return GetSpeciesById.BadRequest
             | _ -> return GetSpeciesById.NotFound
         }
 
@@ -277,9 +277,9 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/vehicles" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetVehicles.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetVehicles.BadRequest
+            match int status with
+            | 200 -> return GetVehicles.OK(Serializer.deserialize content)
+            | 400 -> return GetVehicles.BadRequest
             | _ -> return GetVehicles.NotFound
         }
 
@@ -298,8 +298,8 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/vehicles/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetVehiclesById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetVehiclesById.BadRequest
+            match int status with
+            | 200 -> return GetVehiclesById.OK(Serializer.deserialize content)
+            | 400 -> return GetVehiclesById.BadRequest
             | _ -> return GetVehiclesById.NotFound
         }

--- a/examples/TaskGhibli/Client.fs
+++ b/examples/TaskGhibli/Client.fs
@@ -105,12 +105,10 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/films" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetFilms.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetFilms.BadRequest
-            else
-                return GetFilms.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetFilms.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetFilms.BadRequest
+            | _ -> return GetFilms.NotFound
         }
 
     ///<summary>
@@ -128,12 +126,10 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/films/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetFilmsById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetFilmsById.BadRequest
-            else
-                return GetFilmsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetFilmsById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetFilmsById.BadRequest
+            | _ -> return GetFilmsById.NotFound
         }
 
     ///<summary>
@@ -152,12 +148,10 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/people" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetPeople.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetPeople.BadRequest
-            else
-                return GetPeople.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetPeople.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetPeople.BadRequest
+            | _ -> return GetPeople.NotFound
         }
 
     ///<summary>
@@ -175,12 +169,10 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/people/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetPeopleById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetPeopleById.BadRequest
-            else
-                return GetPeopleById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetPeopleById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetPeopleById.BadRequest
+            | _ -> return GetPeopleById.NotFound
         }
 
     ///<summary>
@@ -199,12 +191,10 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/locations" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetLocations.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetLocations.BadRequest
-            else
-                return GetLocations.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetLocations.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetLocations.BadRequest
+            | _ -> return GetLocations.NotFound
         }
 
     ///<summary>
@@ -222,12 +212,10 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/locations/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetLocationsById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetLocationsById.BadRequest
-            else
-                return GetLocationsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetLocationsById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetLocationsById.BadRequest
+            | _ -> return GetLocationsById.NotFound
         }
 
     ///<summary>
@@ -246,12 +234,10 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/species" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSpecies.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetSpecies.BadRequest
-            else
-                return GetSpecies.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSpecies.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetSpecies.BadRequest
+            | _ -> return GetSpecies.NotFound
         }
 
     ///<summary>
@@ -269,12 +255,10 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/species/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSpeciesById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetSpeciesById.BadRequest
-            else
-                return GetSpeciesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSpeciesById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetSpeciesById.BadRequest
+            | _ -> return GetSpeciesById.NotFound
         }
 
     ///<summary>
@@ -293,12 +277,10 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/vehicles" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetVehicles.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetVehicles.BadRequest
-            else
-                return GetVehicles.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetVehicles.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetVehicles.BadRequest
+            | _ -> return GetVehicles.NotFound
         }
 
     ///<summary>
@@ -316,10 +298,8 @@ type TaskGhibliClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/vehicles/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetVehiclesById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetVehiclesById.BadRequest
-            else
-                return GetVehiclesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetVehiclesById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetVehiclesById.BadRequest
+            | _ -> return GetVehiclesById.NotFound
         }

--- a/examples/TaskNSwag/Client.fs
+++ b/examples/TaskNSwag/Client.fs
@@ -37,12 +37,10 @@ type TaskNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Brandings/upload" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            UploadBrandingImage.OK
-        else if status = HttpStatusCode.BadRequest then
-            UploadBrandingImage.BadRequest(Serializer.deserialize content)
-        else
-            UploadBrandingImage.Unauthorized(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> UploadBrandingImage.OK
+        | HttpStatusCode.BadRequest -> UploadBrandingImage.BadRequest(Serializer.deserialize content)
+        | _ -> UploadBrandingImage.Unauthorized(Serializer.deserialize content)
 
     ///<summary>
     ///Retrieves the data sources for a supplier (data measuring company) for the specified period.
@@ -73,10 +71,9 @@ type TaskNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/api/Datahub/datasources" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            GetDataSources.OK(Serializer.deserialize content)
-        else
-            GetDataSources.Unauthorized content
+        match status with
+        | HttpStatusCode.OK -> GetDataSources.OK(Serializer.deserialize content)
+        | _ -> GetDataSources.Unauthorized content
 
     ///<summary>
     ///Expects the request body to be JSON formatted as follows:
@@ -105,10 +102,9 @@ type TaskNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Datahub/import" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            ImportData.OK(Serializer.deserialize content)
-        else
-            ImportData.Unauthorized content
+        match status with
+        | HttpStatusCode.OK -> ImportData.OK(Serializer.deserialize content)
+        | _ -> ImportData.Unauthorized content
 
     member this.UploadFile(nodeId: int, ?path: string, ?cancellationToken: CancellationToken) =
         let requestParts =
@@ -119,12 +115,10 @@ type TaskNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Documents/upload" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            UploadFile.OK(Serializer.deserialize content)
-        else if status = HttpStatusCode.BadRequest then
-            UploadFile.BadRequest(Serializer.deserialize content)
-        else
-            UploadFile.Unauthorized(Serializer.deserialize content)
+        match status with
+        | HttpStatusCode.OK -> UploadFile.OK(Serializer.deserialize content)
+        | HttpStatusCode.BadRequest -> UploadFile.BadRequest(Serializer.deserialize content)
+        | _ -> UploadFile.Unauthorized(Serializer.deserialize content)
 
     member this.DownloadFile(nodeId: int, ?path: string, ?cancellationToken: CancellationToken) =
         let requestParts =
@@ -135,12 +129,12 @@ type TaskNSwagClient(httpClient: HttpClient) =
         let (status, contentBinary) =
             OpenApiHttp.postBinary httpClient "/api/Documents/download" requestParts cancellationToken
 
-        if status = HttpStatusCode.OK then
-            DownloadFile.OK contentBinary
-        else if status = HttpStatusCode.BadRequest then
+        match status with
+        | HttpStatusCode.OK -> DownloadFile.OK contentBinary
+        | HttpStatusCode.BadRequest ->
             let content = Encoding.UTF8.GetString contentBinary
             DownloadFile.BadRequest(Serializer.deserialize content)
-        else
+        | _ ->
             let content = Encoding.UTF8.GetString contentBinary
             DownloadFile.Unauthorized(Serializer.deserialize content)
 

--- a/examples/TaskNSwag/Client.fs
+++ b/examples/TaskNSwag/Client.fs
@@ -37,9 +37,9 @@ type TaskNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Brandings/upload" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> UploadBrandingImage.OK
-        | HttpStatusCode.BadRequest -> UploadBrandingImage.BadRequest(Serializer.deserialize content)
+        match int status with
+        | 200 -> UploadBrandingImage.OK
+        | 400 -> UploadBrandingImage.BadRequest(Serializer.deserialize content)
         | _ -> UploadBrandingImage.Unauthorized(Serializer.deserialize content)
 
     ///<summary>
@@ -71,8 +71,8 @@ type TaskNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.get httpClient "/api/Datahub/datasources" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> GetDataSources.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> GetDataSources.OK(Serializer.deserialize content)
         | _ -> GetDataSources.Unauthorized content
 
     ///<summary>
@@ -102,8 +102,8 @@ type TaskNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Datahub/import" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> ImportData.OK(Serializer.deserialize content)
+        match int status with
+        | 200 -> ImportData.OK(Serializer.deserialize content)
         | _ -> ImportData.Unauthorized content
 
     member this.UploadFile(nodeId: int, ?path: string, ?cancellationToken: CancellationToken) =
@@ -115,9 +115,9 @@ type TaskNSwagClient(httpClient: HttpClient) =
         let (status, content) =
             OpenApiHttp.post httpClient "/api/Documents/upload" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> UploadFile.OK(Serializer.deserialize content)
-        | HttpStatusCode.BadRequest -> UploadFile.BadRequest(Serializer.deserialize content)
+        match int status with
+        | 200 -> UploadFile.OK(Serializer.deserialize content)
+        | 400 -> UploadFile.BadRequest(Serializer.deserialize content)
         | _ -> UploadFile.Unauthorized(Serializer.deserialize content)
 
     member this.DownloadFile(nodeId: int, ?path: string, ?cancellationToken: CancellationToken) =
@@ -129,9 +129,9 @@ type TaskNSwagClient(httpClient: HttpClient) =
         let (status, contentBinary) =
             OpenApiHttp.postBinary httpClient "/api/Documents/download" requestParts cancellationToken
 
-        match status with
-        | HttpStatusCode.OK -> DownloadFile.OK contentBinary
-        | HttpStatusCode.BadRequest ->
+        match int status with
+        | 200 -> DownloadFile.OK contentBinary
+        | 400 ->
             let content = Encoding.UTF8.GetString contentBinary
             DownloadFile.BadRequest(Serializer.deserialize content)
         | _ ->

--- a/examples/TaskPetStore/Client.fs
+++ b/examples/TaskPetStore/Client.fs
@@ -24,14 +24,11 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/pet" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdatePet.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return UpdatePet.BadRequest
-            else if status = HttpStatusCode.NotFound then
-                return UpdatePet.NotFound
-            else
-                return UpdatePet.MethodNotAllowed
+            match status with
+            | HttpStatusCode.OK -> return UpdatePet.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return UpdatePet.BadRequest
+            | HttpStatusCode.NotFound -> return UpdatePet.NotFound
+            | _ -> return UpdatePet.MethodNotAllowed
         }
 
     ///<summary>
@@ -42,10 +39,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return AddPet.OK(Serializer.deserialize content)
-            else
-                return AddPet.MethodNotAllowed
+            match status with
+            | HttpStatusCode.OK -> return AddPet.OK(Serializer.deserialize content)
+            | _ -> return AddPet.MethodNotAllowed
         }
 
     ///<summary>
@@ -61,10 +57,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByStatus" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FindPetsByStatus.OK(Serializer.deserialize content)
-            else
-                return FindPetsByStatus.BadRequest
+            match status with
+            | HttpStatusCode.OK -> return FindPetsByStatus.OK(Serializer.deserialize content)
+            | _ -> return FindPetsByStatus.BadRequest
         }
 
     ///<summary>
@@ -80,10 +75,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByTags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FindPetsByTags.OK(Serializer.deserialize content)
-            else
-                return FindPetsByTags.BadRequest
+            match status with
+            | HttpStatusCode.OK -> return FindPetsByTags.OK(Serializer.deserialize content)
+            | _ -> return FindPetsByTags.BadRequest
         }
 
     ///<summary>
@@ -96,12 +90,10 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("petId", petId) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetPetById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetPetById.BadRequest
-            else
-                return GetPetById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetPetById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetPetById.BadRequest
+            | _ -> return GetPetById.NotFound
         }
 
     ///<summary>
@@ -122,10 +114,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.MethodNotAllowed then
-                return UpdatePetWithForm.MethodNotAllowed
-            else
-                return UpdatePetWithForm.DefaultResponse
+            match status with
+            | HttpStatusCode.MethodNotAllowed -> return UpdatePetWithForm.MethodNotAllowed
+            | _ -> return UpdatePetWithForm.DefaultResponse
         }
 
     ///<summary>
@@ -143,10 +134,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.BadRequest then
-                return DeletePet.BadRequest
-            else
-                return DeletePet.DefaultResponse
+            match status with
+            | HttpStatusCode.BadRequest -> return DeletePet.BadRequest
+            | _ -> return DeletePet.DefaultResponse
         }
 
     ///<summary>
@@ -195,10 +185,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/store/order" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PlaceOrder.OK(Serializer.deserialize content)
-            else
-                return PlaceOrder.MethodNotAllowed
+            match status with
+            | HttpStatusCode.OK -> return PlaceOrder.OK(Serializer.deserialize content)
+            | _ -> return PlaceOrder.MethodNotAllowed
         }
 
     ///<summary>
@@ -214,12 +203,10 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetOrderById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetOrderById.BadRequest
-            else
-                return GetOrderById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetOrderById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetOrderById.BadRequest
+            | _ -> return GetOrderById.NotFound
         }
 
     ///<summary>
@@ -235,12 +222,10 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.BadRequest then
-                return DeleteOrder.BadRequest
-            else if status = HttpStatusCode.NotFound then
-                return DeleteOrder.NotFound
-            else
-                return DeleteOrder.DefaultResponse
+            match status with
+            | HttpStatusCode.BadRequest -> return DeleteOrder.BadRequest
+            | HttpStatusCode.NotFound -> return DeleteOrder.NotFound
+            | _ -> return DeleteOrder.DefaultResponse
         }
 
     ///<summary>
@@ -263,10 +248,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/user/createWithList" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateUsersWithListInput.OK(Serializer.deserialize content)
-            else
-                return CreateUsersWithListInput.DefaultResponse
+            match status with
+            | HttpStatusCode.OK -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
+            | _ -> return CreateUsersWithListInput.DefaultResponse
         }
 
     ///<summary>
@@ -285,10 +269,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/login" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return LoginUser.OK content
-            else
-                return LoginUser.BadRequest
+            match status with
+            | HttpStatusCode.OK -> return LoginUser.OK content
+            | _ -> return LoginUser.BadRequest
         }
 
     ///<summary>
@@ -313,12 +296,10 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUserByName.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetUserByName.BadRequest
-            else
-                return GetUserByName.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetUserByName.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetUserByName.BadRequest
+            | _ -> return GetUserByName.NotFound
         }
 
     ///<summary>
@@ -350,10 +331,8 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            if status = HttpStatusCode.BadRequest then
-                return DeleteUser.BadRequest
-            else if status = HttpStatusCode.NotFound then
-                return DeleteUser.NotFound
-            else
-                return DeleteUser.DefaultResponse
+            match status with
+            | HttpStatusCode.BadRequest -> return DeleteUser.BadRequest
+            | HttpStatusCode.NotFound -> return DeleteUser.NotFound
+            | _ -> return DeleteUser.DefaultResponse
         }

--- a/examples/TaskPetStore/Client.fs
+++ b/examples/TaskPetStore/Client.fs
@@ -24,10 +24,10 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/pet" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdatePet.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return UpdatePet.BadRequest
-            | HttpStatusCode.NotFound -> return UpdatePet.NotFound
+            match int status with
+            | 200 -> return UpdatePet.OK(Serializer.deserialize content)
+            | 400 -> return UpdatePet.BadRequest
+            | 404 -> return UpdatePet.NotFound
             | _ -> return UpdatePet.MethodNotAllowed
         }
 
@@ -39,8 +39,8 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return AddPet.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return AddPet.OK(Serializer.deserialize content)
             | _ -> return AddPet.MethodNotAllowed
         }
 
@@ -57,8 +57,8 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByStatus" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FindPetsByStatus.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FindPetsByStatus.OK(Serializer.deserialize content)
             | _ -> return FindPetsByStatus.BadRequest
         }
 
@@ -75,8 +75,8 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByTags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FindPetsByTags.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FindPetsByTags.OK(Serializer.deserialize content)
             | _ -> return FindPetsByTags.BadRequest
         }
 
@@ -90,9 +90,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("petId", petId) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetPetById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetPetById.BadRequest
+            match int status with
+            | 200 -> return GetPetById.OK(Serializer.deserialize content)
+            | 400 -> return GetPetById.BadRequest
             | _ -> return GetPetById.NotFound
         }
 
@@ -114,8 +114,8 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.MethodNotAllowed -> return UpdatePetWithForm.MethodNotAllowed
+            match int status with
+            | 405 -> return UpdatePetWithForm.MethodNotAllowed
             | _ -> return UpdatePetWithForm.DefaultResponse
         }
 
@@ -134,8 +134,8 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.BadRequest -> return DeletePet.BadRequest
+            match int status with
+            | 400 -> return DeletePet.BadRequest
             | _ -> return DeletePet.DefaultResponse
         }
 
@@ -185,8 +185,8 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/store/order" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PlaceOrder.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PlaceOrder.OK(Serializer.deserialize content)
             | _ -> return PlaceOrder.MethodNotAllowed
         }
 
@@ -203,9 +203,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetOrderById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetOrderById.BadRequest
+            match int status with
+            | 200 -> return GetOrderById.OK(Serializer.deserialize content)
+            | 400 -> return GetOrderById.BadRequest
             | _ -> return GetOrderById.NotFound
         }
 
@@ -222,9 +222,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.BadRequest -> return DeleteOrder.BadRequest
-            | HttpStatusCode.NotFound -> return DeleteOrder.NotFound
+            match int status with
+            | 400 -> return DeleteOrder.BadRequest
+            | 404 -> return DeleteOrder.NotFound
             | _ -> return DeleteOrder.DefaultResponse
         }
 
@@ -248,8 +248,8 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/user/createWithList" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
             | _ -> return CreateUsersWithListInput.DefaultResponse
         }
 
@@ -269,8 +269,8 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/login" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return LoginUser.OK content
+            match int status with
+            | 200 -> return LoginUser.OK content
             | _ -> return LoginUser.BadRequest
         }
 
@@ -296,9 +296,9 @@ type TaskPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUserByName.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetUserByName.BadRequest
+            match int status with
+            | 200 -> return GetUserByName.OK(Serializer.deserialize content)
+            | 400 -> return GetUserByName.BadRequest
             | _ -> return GetUserByName.NotFound
         }
 
@@ -331,8 +331,8 @@ type TaskPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.BadRequest -> return DeleteUser.BadRequest
-            | HttpStatusCode.NotFound -> return DeleteUser.NotFound
+            match int status with
+            | 400 -> return DeleteUser.BadRequest
+            | 404 -> return DeleteUser.NotFound
             | _ -> return DeleteUser.DefaultResponse
         }

--- a/examples/TaskPodiosuite/Client.fs
+++ b/examples/TaskPodiosuite/Client.fs
@@ -17,10 +17,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/auth/token" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAuthToken.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAuthToken.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAuthToken.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAuthToken.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthToken.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthToken.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAuthToken.InternalServerError(Serializer.deserialize content)
         }
 
@@ -38,10 +38,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/recover-password" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAuthRecoverPassword.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAuthRecoverPassword.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
         }
 
@@ -65,11 +65,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/reset/{mailtoken}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
         }
 
@@ -90,10 +89,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/revoke-token" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAuthRevokeToken.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAuthRevokeToken.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
         }
 
@@ -114,10 +113,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/change-password" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAuthChangePassword.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAuthChangePassword.OK(Serializer.deserialize content)
+            | 400 -> return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
         }
 
@@ -132,10 +131,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/users" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostUsers.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostUsers.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostUsers.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostUsers.OK(Serializer.deserialize content)
+            | 400 -> return PostUsers.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostUsers.Unauthorized(Serializer.deserialize content)
             | _ -> return PostUsers.InternalServerError(Serializer.deserialize content)
         }
 
@@ -202,10 +201,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUsers.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetUsers.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetUsers.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetUsers.OK(Serializer.deserialize content)
+            | 400 -> return GetUsers.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetUsers.Unauthorized(Serializer.deserialize content)
             | _ -> return GetUsers.InternalServerError(Serializer.deserialize content)
         }
 
@@ -275,10 +274,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/usersbulk" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostUsersbulk.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostUsersbulk.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostUsersbulk.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostUsersbulk.OK(Serializer.deserialize content)
+            | 400 -> return PostUsersbulk.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostUsersbulk.Unauthorized(Serializer.deserialize content)
             | _ -> return PostUsersbulk.InternalServerError(Serializer.deserialize content)
         }
 
@@ -296,10 +295,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/me" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUsersMe.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetUsersMe.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetUsersMe.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetUsersMe.OK(Serializer.deserialize content)
+            | 400 -> return GetUsersMe.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetUsersMe.Unauthorized(Serializer.deserialize content)
             | _ -> return GetUsersMe.InternalServerError(Serializer.deserialize content)
         }
 
@@ -314,10 +313,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/users/me/accept-tc" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostUsersMeAcceptTc.Created
-            | HttpStatusCode.BadRequest -> return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PostUsersMeAcceptTc.Created
+            | 400 -> return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
             | _ -> return PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
         }
 
@@ -343,10 +342,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUsersByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetUsersByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetUsersByUserId.OK(Serializer.deserialize content)
+            | 400 -> return GetUsersByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -372,10 +371,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutUsersByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutUsersByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutUsersByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -401,10 +400,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteUsersByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteUsersByUserId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -428,12 +427,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/change-password" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -456,11 +453,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/favorites" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -483,12 +479,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/customization" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -509,11 +503,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/permissions" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
+            | 400 -> return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -527,11 +520,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/notifications" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsNotifications.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsNotifications.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
         }
 
@@ -549,12 +541,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsNotificationsByNotificationId.OK
-            | HttpStatusCode.BadRequest ->
-                return PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAccountsNotificationsByNotificationId.OK
+            | 400 -> return PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -572,12 +562,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
             | _ ->
                 return DeleteAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
         }
@@ -590,10 +578,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/accounts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccounts.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAccounts.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetAccounts.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccounts.OK(Serializer.deserialize content)
+            | 400 -> return GetAccounts.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccounts.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccounts.InternalServerError(Serializer.deserialize content)
         }
 
@@ -605,10 +593,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent account ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/accounts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAccounts.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAccounts.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAccounts.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAccounts.OK(Serializer.deserialize content)
+            | 400 -> return PostAccounts.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAccounts.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAccounts.InternalServerError(Serializer.deserialize content)
         }
 
@@ -620,10 +608,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync httpClient "/accountsbulk" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAccountsbulk.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAccountsbulk.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAccountsbulk.OK(Serializer.deserialize content)
+            | 400 -> return PostAccountsbulk.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAccountsbulk.InternalServerError(Serializer.deserialize content)
         }
 
@@ -637,10 +625,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -654,10 +642,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAccountsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -675,11 +663,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -697,12 +684,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}/branding" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -716,12 +701,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/branding/verify" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -735,11 +718,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/roles" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -757,13 +739,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK ->
-                return GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
             | _ ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.InternalServerError(Serializer.deserialize content)
         }
@@ -778,12 +757,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/notifications" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -801,11 +778,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsNotificationsByAccountIdAndNotificationId.OK
-            | HttpStatusCode.BadRequest ->
+            match int status with
+            | 200 -> return PutAccountsNotificationsByAccountIdAndNotificationId.OK
+            | 400 ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
+            | 401 ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
             | _ ->
                 return
@@ -828,12 +805,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
-            | HttpStatusCode.BadRequest ->
+            match int status with
+            | 200 -> return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
+            | 400 ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
+            | 401 ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
             | _ ->
@@ -855,12 +832,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/products" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -880,10 +855,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/products/alerts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsProductsAlerts.OK
-            | HttpStatusCode.BadRequest -> return PutAccountsProductsAlerts.BadRequest
-            | HttpStatusCode.Unauthorized -> return PutAccountsProductsAlerts.Unauthorized
+            match int status with
+            | 200 -> return PutAccountsProductsAlerts.OK
+            | 400 -> return PutAccountsProductsAlerts.BadRequest
+            | 401 -> return PutAccountsProductsAlerts.Unauthorized
             | _ -> return PutAccountsProductsAlerts.InternalServerError
         }
 
@@ -901,12 +876,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}/topup-direct" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
+            | 400 -> return PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -994,12 +967,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK ->
-                return GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
+            match int status with
+            | 200 -> return GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
+            | 400 ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
+            | 401 ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ ->
                 return
@@ -1031,12 +1003,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK ->
-                return GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
+            match int status with
+            | 200 -> return GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
+            | 400 ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
+            | 401 ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.Unauthorized(Serializer.deserialize content)
             | _ ->
                 return
@@ -1066,10 +1037,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/mail" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostMail.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostMail.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostMail.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostMail.OK(Serializer.deserialize content)
+            | 400 -> return PostMail.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostMail.Unauthorized(Serializer.deserialize content)
             | _ -> return PostMail.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1246,12 +1217,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/products" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetProducts.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetProducts.BadRequest
-            | HttpStatusCode.Unauthorized -> return GetProducts.Unauthorized
-            | HttpStatusCode.Forbidden -> return GetProducts.Forbidden
-            | HttpStatusCode.InternalServerError -> return GetProducts.InternalServerError
+            match int status with
+            | 200 -> return GetProducts.OK(Serializer.deserialize content)
+            | 400 -> return GetProducts.BadRequest
+            | 401 -> return GetProducts.Unauthorized
+            | 403 -> return GetProducts.Forbidden
+            | 500 -> return GetProducts.InternalServerError
             | _ -> return GetProducts.ServiceUnavailable
         }
 
@@ -1271,10 +1242,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/products" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostProducts.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostProducts.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostProducts.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostProducts.OK(Serializer.deserialize content)
+            | 400 -> return PostProducts.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostProducts.Unauthorized(Serializer.deserialize content)
             | _ -> return PostProducts.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1289,12 +1260,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetProductsByProductId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetProductsByProductId.BadRequest
-            | HttpStatusCode.Unauthorized -> return GetProductsByProductId.Unauthorized
-            | HttpStatusCode.Forbidden -> return GetProductsByProductId.Forbidden
-            | HttpStatusCode.InternalServerError -> return GetProductsByProductId.InternalServerError
+            match int status with
+            | 200 -> return GetProductsByProductId.OK(Serializer.deserialize content)
+            | 400 -> return GetProductsByProductId.BadRequest
+            | 401 -> return GetProductsByProductId.Unauthorized
+            | 403 -> return GetProductsByProductId.Forbidden
+            | 500 -> return GetProductsByProductId.InternalServerError
             | _ -> return GetProductsByProductId.ServiceUnavailable
         }
 
@@ -1315,11 +1286,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PatchProductsByProductId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PatchProductsByProductId.OK(Serializer.deserialize content)
+            | 400 -> return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
+            | 401 -> return PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
             | _ -> return PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1334,11 +1304,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteProductsByProductId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteProductsByProductId.OK(Serializer.deserialize content)
+            | 400 -> return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1356,10 +1325,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/schema/product" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSchemaProduct.OK
-            | HttpStatusCode.BadRequest -> return GetSchemaProduct.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetSchemaProduct.OK
+            | 400 -> return GetSchemaProduct.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
             | _ -> return GetSchemaProduct.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1380,12 +1349,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/products/{productId}/transfer" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostProductsTransferByProductId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostProductsTransferByProductId.BadRequest
-            | HttpStatusCode.Unauthorized -> return PostProductsTransferByProductId.Unauthorized
-            | HttpStatusCode.Forbidden -> return PostProductsTransferByProductId.Forbidden
-            | HttpStatusCode.InternalServerError -> return PostProductsTransferByProductId.InternalServerError
+            match int status with
+            | 200 -> return PostProductsTransferByProductId.OK(Serializer.deserialize content)
+            | 400 -> return PostProductsTransferByProductId.BadRequest
+            | 401 -> return PostProductsTransferByProductId.Unauthorized
+            | 403 -> return PostProductsTransferByProductId.Forbidden
+            | 500 -> return PostProductsTransferByProductId.InternalServerError
             | _ -> return PostProductsTransferByProductId.ServiceUnavailable
         }
 
@@ -1432,11 +1401,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/cdr" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetCdr.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetCdr.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetCdr.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return GetCdr.NotFound(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetCdr.OK(Serializer.deserialize content)
+            | 400 -> return GetCdr.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetCdr.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetCdr.NotFound(Serializer.deserialize content)
             | _ -> return GetCdr.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1473,10 +1442,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/assets" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssets.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAssets.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetAssets.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssets.OK(Serializer.deserialize content)
+            | 400 -> return GetAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssets.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAssets.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1488,10 +1457,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/assets" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssets.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAssets.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAssets.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAssets.OK(Serializer.deserialize content)
+            | 400 -> return PostAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssets.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAssets.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1503,10 +1472,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/assetsbulk" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsbulk.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAssetsbulk.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAssetsbulk.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsbulk.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAssetsbulk.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1518,10 +1487,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssetsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1533,10 +1502,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1548,10 +1517,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteAssetsByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteAssetsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1569,11 +1538,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/groupname" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1591,11 +1559,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/transfer" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1613,11 +1580,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/subscribe" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1635,11 +1601,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/unsubscribe" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1657,11 +1622,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/resubscribe" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1679,10 +1643,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/suspend" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1700,11 +1664,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/unsuspend" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1720,10 +1683,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/alerts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsAlertsByIccid.OK
-            | HttpStatusCode.BadRequest -> return PutAssetsAlertsByIccid.BadRequest
-            | HttpStatusCode.Unauthorized -> return PutAssetsAlertsByIccid.Unauthorized
+            match int status with
+            | 200 -> return PutAssetsAlertsByIccid.OK
+            | 400 -> return PutAssetsAlertsByIccid.BadRequest
+            | 401 -> return PutAssetsAlertsByIccid.Unauthorized
             | _ -> return PutAssetsAlertsByIccid.InternalServerError
         }
 
@@ -1737,10 +1700,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/purge" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsPurgeByIccid.OK
-            | HttpStatusCode.BadRequest -> return PostAssetsPurgeByIccid.BadRequest
-            | HttpStatusCode.Unauthorized -> return PostAssetsPurgeByIccid.Unauthorized
+            match int status with
+            | 200 -> return PostAssetsPurgeByIccid.OK
+            | 400 -> return PostAssetsPurgeByIccid.BadRequest
+            | 401 -> return PostAssetsPurgeByIccid.Unauthorized
             | _ -> return PostAssetsPurgeByIccid.InternalServerError
         }
 
@@ -1754,10 +1717,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/sms" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsSmsByIccid.OK
-            | HttpStatusCode.BadRequest -> return PostAssetsSmsByIccid.BadRequest
-            | HttpStatusCode.Unauthorized -> return PostAssetsSmsByIccid.Unauthorized
+            match int status with
+            | 200 -> return PostAssetsSmsByIccid.OK
+            | 400 -> return PostAssetsSmsByIccid.BadRequest
+            | 401 -> return PostAssetsSmsByIccid.Unauthorized
             | _ -> return PostAssetsSmsByIccid.InternalServerError
         }
 
@@ -1771,10 +1734,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/limit" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsLimitByIccid.OK
-            | HttpStatusCode.BadRequest -> return PostAssetsLimitByIccid.BadRequest
-            | HttpStatusCode.Unauthorized -> return PostAssetsLimitByIccid.Unauthorized
+            match int status with
+            | 200 -> return PostAssetsLimitByIccid.OK
+            | 400 -> return PostAssetsLimitByIccid.BadRequest
+            | 401 -> return PostAssetsLimitByIccid.Unauthorized
             | _ -> return PostAssetsLimitByIccid.InternalServerError
         }
 
@@ -1816,10 +1779,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/tags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsTagsByIccid.OK
-            | HttpStatusCode.BadRequest -> return PostAssetsTagsByIccid.BadRequest
-            | HttpStatusCode.Unauthorized -> return PostAssetsTagsByIccid.Unauthorized
+            match int status with
+            | 200 -> return PostAssetsTagsByIccid.OK
+            | 400 -> return PostAssetsTagsByIccid.BadRequest
+            | 401 -> return PostAssetsTagsByIccid.Unauthorized
             | _ -> return PostAssetsTagsByIccid.InternalServerError
         }
 
@@ -1833,10 +1796,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/diagnostic" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetAssetsDiagnosticByIccid.Unauthorized
-            | HttpStatusCode.InternalServerError -> return GetAssetsDiagnosticByIccid.InternalServerError
+            match int status with
+            | 200 -> return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
+            | 401 -> return GetAssetsDiagnosticByIccid.Unauthorized
+            | 500 -> return GetAssetsDiagnosticByIccid.InternalServerError
             | _ -> return GetAssetsDiagnosticByIccid.ServiceUnavailable
         }
 
@@ -1850,12 +1813,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/location" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
             | _ -> return GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1869,12 +1831,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/sessions" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
             | _ -> return GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1903,9 +1864,9 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetReportsCustom.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetReportsCustom.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetReportsCustom.OK(Serializer.deserialize content)
+            | 401 -> return GetReportsCustom.Unauthorized(Serializer.deserialize content)
             | _ -> return GetReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1917,11 +1878,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent report ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostReportsCustom.OK
-            | HttpStatusCode.Unauthorized -> return PostReportsCustom.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return PostReportsCustom.Forbidden(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return PostReportsCustom.NotFound(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostReportsCustom.OK
+            | 401 -> return PostReportsCustom.Unauthorized(Serializer.deserialize content)
+            | 403 -> return PostReportsCustom.Forbidden(Serializer.deserialize content)
+            | 404 -> return PostReportsCustom.NotFound(Serializer.deserialize content)
             | _ -> return PostReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1933,9 +1894,9 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return DeleteReportsCustom.NoContent
-            | HttpStatusCode.Unauthorized -> return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 204 -> return DeleteReportsCustom.NoContent
+            | 401 -> return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1949,11 +1910,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetReportsCustomByReportId.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetReportsCustomByReportId.OK(Serializer.deserialize content)
+            | 401 -> return GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
+            | 404 -> return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
             | _ -> return GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -1967,11 +1927,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return DeleteReportsCustomByReportId.NoContent
-            | HttpStatusCode.Unauthorized ->
-                return DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.NotFound -> return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
+            match int status with
+            | 204 -> return DeleteReportsCustomByReportId.NoContent
+            | 401 -> return DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
+            | 404 -> return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
             | _ -> return DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2038,10 +1997,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/events" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetEvents.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetEvents.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetEvents.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetEvents.OK(Serializer.deserialize content)
+            | 400 -> return GetEvents.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetEvents.Unauthorized(Serializer.deserialize content)
             | _ -> return GetEvents.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2102,10 +2061,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/subscribe" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2119,10 +2078,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/transfer" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2136,10 +2095,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/return" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2153,10 +2112,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/suspend" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
             | _ -> return PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2170,10 +2129,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/unsuspend" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
             | _ -> return PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2191,11 +2150,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/resubscribe" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2207,10 +2165,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/bulk/assets" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssets.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssets.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssets.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssets.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssets.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssets.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2222,10 +2180,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/bulk/assets" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PutBulkAssets.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutBulkAssets.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutBulkAssets.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PutBulkAssets.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssets.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssets.Unauthorized(Serializer.deserialize content)
             | _ -> return PutBulkAssets.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2239,10 +2197,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/groupname" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
             | _ -> return PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2256,10 +2214,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/limit" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2275,10 +2233,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/alerts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
+            | 400 -> return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
             | _ -> return PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2290,10 +2248,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/bulk/assets/sms" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2307,10 +2265,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/purge" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2358,11 +2316,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/reallocate-ip" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Accepted -> return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 202 -> return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
+            | 400 -> return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
             | _ -> return PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2436,10 +2393,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/payments/topupPaypal" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
+            | 400 -> return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
             | _ -> return PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2460,12 +2417,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/payments/confirmTopupPaypal" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
+            | 400 -> return PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
             | _ -> return PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2568,12 +2523,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/security/alerts" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSecurityAlerts.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetSecurityAlerts.BadRequest
-            | HttpStatusCode.Unauthorized -> return GetSecurityAlerts.Unauthorized
-            | HttpStatusCode.Forbidden -> return GetSecurityAlerts.Forbidden
-            | HttpStatusCode.InternalServerError -> return GetSecurityAlerts.InternalServerError
+            match int status with
+            | 200 -> return GetSecurityAlerts.OK(Serializer.deserialize content)
+            | 400 -> return GetSecurityAlerts.BadRequest
+            | 401 -> return GetSecurityAlerts.Unauthorized
+            | 403 -> return GetSecurityAlerts.Forbidden
+            | 500 -> return GetSecurityAlerts.InternalServerError
             | _ -> return GetSecurityAlerts.ServiceUnavailable
         }
 
@@ -2600,12 +2555,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetSecurityAlertsByAlertId.BadRequest
-            | HttpStatusCode.Unauthorized -> return GetSecurityAlertsByAlertId.Unauthorized
-            | HttpStatusCode.Forbidden -> return GetSecurityAlertsByAlertId.Forbidden
-            | HttpStatusCode.InternalServerError -> return GetSecurityAlertsByAlertId.InternalServerError
+            match int status with
+            | 200 -> return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+            | 400 -> return GetSecurityAlertsByAlertId.BadRequest
+            | 401 -> return GetSecurityAlertsByAlertId.Unauthorized
+            | 403 -> return GetSecurityAlertsByAlertId.Forbidden
+            | 500 -> return GetSecurityAlertsByAlertId.InternalServerError
             | _ -> return GetSecurityAlertsByAlertId.ServiceUnavailable
         }
 
@@ -2635,12 +2590,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutSecurityAlertsByAlertId.BadRequest
-            | HttpStatusCode.Unauthorized -> return PutSecurityAlertsByAlertId.Unauthorized
-            | HttpStatusCode.Forbidden -> return PutSecurityAlertsByAlertId.Forbidden
-            | HttpStatusCode.InternalServerError -> return PutSecurityAlertsByAlertId.InternalServerError
+            match int status with
+            | 200 -> return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+            | 400 -> return PutSecurityAlertsByAlertId.BadRequest
+            | 401 -> return PutSecurityAlertsByAlertId.Unauthorized
+            | 403 -> return PutSecurityAlertsByAlertId.Forbidden
+            | 500 -> return PutSecurityAlertsByAlertId.InternalServerError
             | _ -> return PutSecurityAlertsByAlertId.ServiceUnavailable
         }
 
@@ -2667,12 +2622,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return DeleteSecurityAlertsByAlertId.NoContent
-            | HttpStatusCode.BadRequest -> return DeleteSecurityAlertsByAlertId.BadRequest
-            | HttpStatusCode.Unauthorized -> return DeleteSecurityAlertsByAlertId.Unauthorized
-            | HttpStatusCode.Forbidden -> return DeleteSecurityAlertsByAlertId.Forbidden
-            | HttpStatusCode.InternalServerError -> return DeleteSecurityAlertsByAlertId.InternalServerError
+            match int status with
+            | 204 -> return DeleteSecurityAlertsByAlertId.NoContent
+            | 400 -> return DeleteSecurityAlertsByAlertId.BadRequest
+            | 401 -> return DeleteSecurityAlertsByAlertId.Unauthorized
+            | 403 -> return DeleteSecurityAlertsByAlertId.Forbidden
+            | 500 -> return DeleteSecurityAlertsByAlertId.InternalServerError
             | _ -> return DeleteSecurityAlertsByAlertId.ServiceUnavailable
         }
 
@@ -2708,11 +2663,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/security/topthreaten" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
+            | 400 -> return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2748,11 +2702,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/security/byalarmtype" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
+            | 400 -> return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2778,10 +2731,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/esims" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostEsims.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostEsims.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostEsims.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostEsims.OK(Serializer.deserialize content)
+            | 400 -> return PostEsims.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostEsims.Unauthorized(Serializer.deserialize content)
             | _ -> return PostEsims.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2825,10 +2778,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/esims/{eid}/transfer" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostEsimsTransferByEid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostEsimsTransferByEid.OK(Serializer.deserialize content)
+            | 400 -> return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
             | _ -> return PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -2842,10 +2795,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/esims/{eid}/return" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostEsimsReturnByEid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostEsimsReturnByEid.OK(Serializer.deserialize content)
+            | 400 -> return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
             | _ -> return PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3170,10 +3123,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/1" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph1.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph1.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph1.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph1.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph1.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph1.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph1.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3204,10 +3157,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/2" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph2.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph2.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph2.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph2.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph2.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph2.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph2.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3238,10 +3191,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/3" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph3.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph3.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph3.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph3.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph3.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph3.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph3.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3272,10 +3225,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/4" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph4.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph4.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph4.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph4.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph4.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph4.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph4.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3306,10 +3259,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/5" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph5.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph5.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph5.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph5.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph5.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph5.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph5.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3340,10 +3293,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/6" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph6.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph6.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph6.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph6.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph6.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph6.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph6.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3374,10 +3327,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/7" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph7.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph7.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph7.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph7.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph7.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph7.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph7.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3408,10 +3361,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/8" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph8.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph8.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph8.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph8.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph8.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph8.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph8.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3442,10 +3395,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/9" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph9.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph9.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph9.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph9.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph9.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph9.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph9.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3460,10 +3413,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/10" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph10.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph10.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph10.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph10.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph10.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph10.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph10.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3494,10 +3447,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/11" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph11.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph11.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph11.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph11.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph11.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph11.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph11.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3528,10 +3481,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/12" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraph12.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraph12.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraph12.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraph12.OK(Serializer.deserialize content)
+            | 400 -> return GetGraph12.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraph12.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraph12.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3563,10 +3516,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/statusesperday" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetGraphStatusesperday.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetGraphStatusesperday.OK(Serializer.deserialize content)
+            | 400 -> return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
             | _ -> return GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3597,11 +3550,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3615,11 +3567,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3633,12 +3584,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+            | 400 -> return GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+            | 401 -> return GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
             | _ -> return GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3656,12 +3605,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest ->
-                return PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+            | 400 -> return PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+            | 401 -> return PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
             | _ -> return PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3679,12 +3626,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return DeleteAssetsQuickDialByIccidAndLocation.NoContent
-            | HttpStatusCode.BadRequest ->
-                return DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 204 -> return DeleteAssetsQuickDialByIccidAndLocation.NoContent
+            | 400 -> return DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
+            | 401 -> return DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
@@ -3698,10 +3643,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/dial" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostAssetsDialByIccid.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostAssetsDialByIccid.OK(Serializer.deserialize content)
+            | 400 -> return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
+            | 401 -> return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
             | _ -> return PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 

--- a/examples/TaskPodiosuite/Client.fs
+++ b/examples/TaskPodiosuite/Client.fs
@@ -17,14 +17,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/auth/token" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAuthToken.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAuthToken.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAuthToken.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthToken.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAuthToken.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAuthToken.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAuthToken.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthToken.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -41,14 +38,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/recover-password" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAuthRecoverPassword.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAuthRecoverPassword.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAuthRecoverPassword.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAuthRecoverPassword.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthRecoverPassword.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -71,14 +65,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/reset/{mailtoken}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PostAuthResetByMailtoken.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAuthResetByMailtoken.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostAuthResetByMailtoken.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostAuthResetByMailtoken.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -98,14 +90,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/revoke-token" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAuthRevokeToken.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAuthRevokeToken.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAuthRevokeToken.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAuthRevokeToken.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthRevokeToken.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -125,14 +114,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/auth/change-password" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAuthChangePassword.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAuthChangePassword.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAuthChangePassword.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAuthChangePassword.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAuthChangePassword.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -146,14 +132,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/users" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostUsers.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostUsers.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostUsers.Unauthorized(Serializer.deserialize content)
-            else
-                return PostUsers.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostUsers.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostUsers.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostUsers.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostUsers.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -219,14 +202,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUsers.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetUsers.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetUsers.Unauthorized(Serializer.deserialize content)
-            else
-                return GetUsers.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetUsers.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetUsers.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetUsers.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetUsers.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -295,14 +275,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/usersbulk" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostUsersbulk.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostUsersbulk.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostUsersbulk.Unauthorized(Serializer.deserialize content)
-            else
-                return PostUsersbulk.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostUsersbulk.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostUsersbulk.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostUsersbulk.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostUsersbulk.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -319,14 +296,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/me" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUsersMe.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetUsersMe.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetUsersMe.Unauthorized(Serializer.deserialize content)
-            else
-                return GetUsersMe.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetUsersMe.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetUsersMe.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetUsersMe.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetUsersMe.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -340,14 +314,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/users/me/accept-tc" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostUsersMeAcceptTc.Created
-            else if status = HttpStatusCode.BadRequest then
-                return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
-            else
-                return PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return PostUsersMeAcceptTc.Created
+            | HttpStatusCode.BadRequest -> return PostUsersMeAcceptTc.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostUsersMeAcceptTc.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostUsersMeAcceptTc.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -372,14 +343,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUsersByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetUsersByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetUsersByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetUsersByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetUsersByUserId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetUsersByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -404,14 +372,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutUsersByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutUsersByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PutUsersByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutUsersByUserId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutUsersByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -436,14 +401,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/users/{userId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteUsersByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return DeleteUsersByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return DeleteUsersByUserId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return DeleteUsersByUserId.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteUsersByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -466,14 +428,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/change-password" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutUsersChangePasswordByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PutUsersChangePasswordByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutUsersChangePasswordByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutUsersChangePasswordByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -495,14 +456,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/favorites" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutUsersFavoritesByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutUsersFavoritesByUserId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutUsersFavoritesByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutUsersFavoritesByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -524,14 +483,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/customization" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutUsersCustomizationByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PutUsersCustomizationByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutUsersCustomizationByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutUsersCustomizationByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -551,14 +509,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/users/{userId}/permissions" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutUsersPermissionsByUserId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutUsersPermissionsByUserId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutUsersPermissionsByUserId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutUsersPermissionsByUserId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -571,14 +527,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/notifications" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsNotifications.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsNotifications.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAccountsNotifications.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsNotifications.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAccountsNotifications.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -595,14 +549,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsNotificationsByNotificationId.OK
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsNotificationsByNotificationId.OK
+            | HttpStatusCode.BadRequest ->
                 return PutAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -619,13 +572,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return DeleteAccountsNotificationsByNotificationId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return DeleteAccountsNotificationsByNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return DeleteAccountsNotificationsByNotificationId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return DeleteAccountsNotificationsByNotificationId.InternalServerError(Serializer.deserialize content)
         }
 
@@ -637,14 +590,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/accounts" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccounts.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAccounts.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetAccounts.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccounts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetAccounts.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAccounts.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetAccounts.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccounts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -655,14 +605,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent account ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/accounts" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAccounts.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAccounts.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAccounts.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAccounts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAccounts.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAccounts.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAccounts.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAccounts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -673,14 +620,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync httpClient "/accountsbulk" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAccountsbulk.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAccountsbulk.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAccountsbulk.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAccountsbulk.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAccountsbulk.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAccountsbulk.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAccountsbulk.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -693,14 +637,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -713,14 +654,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutAccountsByAccountId.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -737,14 +675,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/accounts/{accountId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return DeleteAccountsByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return DeleteAccountsByAccountId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return DeleteAccountsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return DeleteAccountsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -761,14 +697,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}/branding" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsBrandingByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PutAccountsBrandingByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutAccountsBrandingByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAccountsBrandingByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -781,14 +716,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/branding/verify" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsBrandingVerifyByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsBrandingVerifyByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsBrandingVerifyByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAccountsBrandingVerifyByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -801,14 +735,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/roles" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsRolesByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAccountsRolesByAccountId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsRolesByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAccountsRolesByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -825,13 +757,14 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
+            match status with
+            | HttpStatusCode.OK ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return GetAccountsRolesActionsByAccountIdAndRolename.InternalServerError(Serializer.deserialize content)
         }
 
@@ -845,14 +778,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/notifications" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsNotificationsByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsNotificationsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsNotificationsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAccountsNotificationsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -869,13 +801,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsNotificationsByAccountIdAndNotificationId.OK
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsNotificationsByAccountIdAndNotificationId.OK
+            | HttpStatusCode.BadRequest ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     PutAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(
                         Serializer.deserialize content
@@ -896,15 +828,15 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return DeleteAccountsNotificationsByAccountIdAndNotificationId.OK
+            | HttpStatusCode.BadRequest ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     DeleteAccountsNotificationsByAccountIdAndNotificationId.InternalServerError(
                         Serializer.deserialize content
@@ -923,14 +855,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/accounts/{accountId}/products" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return GetAccountsProductsByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsProductsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsProductsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAccountsProductsByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -949,14 +880,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/products/alerts" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsProductsAlerts.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PutAccountsProductsAlerts.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PutAccountsProductsAlerts.Unauthorized
-            else
-                return PutAccountsProductsAlerts.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsProductsAlerts.OK
+            | HttpStatusCode.BadRequest -> return PutAccountsProductsAlerts.BadRequest
+            | HttpStatusCode.Unauthorized -> return PutAccountsProductsAlerts.Unauthorized
+            | _ -> return PutAccountsProductsAlerts.InternalServerError
         }
 
     ///<summary>
@@ -973,14 +901,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/accounts/{accountId}/topup-direct" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutAccountsTopupDirectByAccountId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PutAccountsTopupDirectByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutAccountsTopupDirectByAccountId.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAccountsTopupDirectByAccountId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1067,13 +994,14 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
+            match status with
+            | HttpStatusCode.OK ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsSecuritySettingsAvailableGapsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     GetAccountsSecuritySettingsAvailableGapsByAccountId.InternalServerError(
                         Serializer.deserialize content
@@ -1103,13 +1031,14 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
+            match status with
+            | HttpStatusCode.OK ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            | HttpStatusCode.BadRequest ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAccountsSecuritySettingsAvailableIpsByAccountId.Unauthorized(Serializer.deserialize content)
-            else
+            | _ ->
                 return
                     GetAccountsSecuritySettingsAvailableIpsByAccountId.InternalServerError(
                         Serializer.deserialize content
@@ -1137,14 +1066,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/mail" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostMail.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostMail.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostMail.Unauthorized(Serializer.deserialize content)
-            else
-                return PostMail.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostMail.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostMail.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostMail.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostMail.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1320,18 +1246,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/products" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetProducts.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetProducts.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return GetProducts.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return GetProducts.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return GetProducts.InternalServerError
-            else
-                return GetProducts.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return GetProducts.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetProducts.BadRequest
+            | HttpStatusCode.Unauthorized -> return GetProducts.Unauthorized
+            | HttpStatusCode.Forbidden -> return GetProducts.Forbidden
+            | HttpStatusCode.InternalServerError -> return GetProducts.InternalServerError
+            | _ -> return GetProducts.ServiceUnavailable
         }
 
     ///<summary>
@@ -1350,14 +1271,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/products" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostProducts.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostProducts.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostProducts.Unauthorized(Serializer.deserialize content)
-            else
-                return PostProducts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostProducts.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostProducts.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostProducts.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostProducts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1371,18 +1289,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetProductsByProductId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetProductsByProductId.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return GetProductsByProductId.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return GetProductsByProductId.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return GetProductsByProductId.InternalServerError
-            else
-                return GetProductsByProductId.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return GetProductsByProductId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetProductsByProductId.BadRequest
+            | HttpStatusCode.Unauthorized -> return GetProductsByProductId.Unauthorized
+            | HttpStatusCode.Forbidden -> return GetProductsByProductId.Forbidden
+            | HttpStatusCode.InternalServerError -> return GetProductsByProductId.InternalServerError
+            | _ -> return GetProductsByProductId.ServiceUnavailable
         }
 
     ///<summary>
@@ -1402,14 +1315,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PatchProductsByProductId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PatchProductsByProductId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PatchProductsByProductId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PatchProductsByProductId.Unauthorized(Serializer.deserialize content)
-            else
-                return PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
+            | _ -> return PatchProductsByProductId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1423,14 +1334,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/products/{productId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteProductsByProductId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return DeleteProductsByProductId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return DeleteProductsByProductId.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return DeleteProductsByProductId.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
+            | _ -> return DeleteProductsByProductId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1447,14 +1356,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/schema/product" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSchemaProduct.OK
-            else if status = HttpStatusCode.BadRequest then
-                return GetSchemaProduct.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
-            else
-                return GetSchemaProduct.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetSchemaProduct.OK
+            | HttpStatusCode.BadRequest -> return GetSchemaProduct.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetSchemaProduct.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetSchemaProduct.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1474,18 +1380,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/products/{productId}/transfer" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostProductsTransferByProductId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostProductsTransferByProductId.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PostProductsTransferByProductId.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return PostProductsTransferByProductId.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return PostProductsTransferByProductId.InternalServerError
-            else
-                return PostProductsTransferByProductId.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return PostProductsTransferByProductId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostProductsTransferByProductId.BadRequest
+            | HttpStatusCode.Unauthorized -> return PostProductsTransferByProductId.Unauthorized
+            | HttpStatusCode.Forbidden -> return PostProductsTransferByProductId.Forbidden
+            | HttpStatusCode.InternalServerError -> return PostProductsTransferByProductId.InternalServerError
+            | _ -> return PostProductsTransferByProductId.ServiceUnavailable
         }
 
     ///<summary>
@@ -1531,16 +1432,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/cdr" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetCdr.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetCdr.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetCdr.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return GetCdr.NotFound(Serializer.deserialize content)
-            else
-                return GetCdr.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetCdr.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetCdr.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetCdr.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return GetCdr.NotFound(Serializer.deserialize content)
+            | _ -> return GetCdr.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1576,14 +1473,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/assets" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssets.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAssets.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetAssets.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAssets.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1594,14 +1488,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/assets" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssets.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssets.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAssets.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAssets.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1612,14 +1503,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/assetsbulk" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsbulk.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsbulk.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsbulk.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsbulk.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAssetsbulk.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAssetsbulk.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssetsbulk.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1630,14 +1518,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1648,14 +1533,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1666,14 +1548,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent asset ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/assets/{iccid}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteAssetsByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return DeleteAssetsByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return DeleteAssetsByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return DeleteAssetsByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteAssetsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1690,14 +1569,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/groupname" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsGroupnameByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsGroupnameByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsGroupnameByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsGroupnameByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1714,14 +1591,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/transfer" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsTransferByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAssetsTransferByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostAssetsTransferByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostAssetsTransferByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1738,14 +1613,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/subscribe" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsSubscribeByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsSubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsSubscribeByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsSubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1762,14 +1635,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/unsubscribe" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsUnsubscribeByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsUnsubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsUnsubscribeByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsUnsubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1786,14 +1657,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/resubscribe" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsResubscribeByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsResubscribeByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsResubscribeByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsResubscribeByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1810,14 +1679,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/suspend" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsSuspendByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsSuspendByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutAssetsSuspendByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutAssetsSuspendByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1834,14 +1700,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/unsuspend" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsUnsuspendByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutAssetsUnsuspendByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsUnsuspendByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsUnsuspendByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1856,14 +1720,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/alerts" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsAlertsByIccid.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PutAssetsAlertsByIccid.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PutAssetsAlertsByIccid.Unauthorized
-            else
-                return PutAssetsAlertsByIccid.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsAlertsByIccid.OK
+            | HttpStatusCode.BadRequest -> return PutAssetsAlertsByIccid.BadRequest
+            | HttpStatusCode.Unauthorized -> return PutAssetsAlertsByIccid.Unauthorized
+            | _ -> return PutAssetsAlertsByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1876,14 +1737,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/purge" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsPurgeByIccid.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsPurgeByIccid.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsPurgeByIccid.Unauthorized
-            else
-                return PostAssetsPurgeByIccid.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsPurgeByIccid.OK
+            | HttpStatusCode.BadRequest -> return PostAssetsPurgeByIccid.BadRequest
+            | HttpStatusCode.Unauthorized -> return PostAssetsPurgeByIccid.Unauthorized
+            | _ -> return PostAssetsPurgeByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1896,14 +1754,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/sms" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsSmsByIccid.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsSmsByIccid.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsSmsByIccid.Unauthorized
-            else
-                return PostAssetsSmsByIccid.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsSmsByIccid.OK
+            | HttpStatusCode.BadRequest -> return PostAssetsSmsByIccid.BadRequest
+            | HttpStatusCode.Unauthorized -> return PostAssetsSmsByIccid.Unauthorized
+            | _ -> return PostAssetsSmsByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1916,14 +1771,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/limit" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsLimitByIccid.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsLimitByIccid.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsLimitByIccid.Unauthorized
-            else
-                return PostAssetsLimitByIccid.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsLimitByIccid.OK
+            | HttpStatusCode.BadRequest -> return PostAssetsLimitByIccid.BadRequest
+            | HttpStatusCode.Unauthorized -> return PostAssetsLimitByIccid.Unauthorized
+            | _ -> return PostAssetsLimitByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1964,14 +1816,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/tags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsTagsByIccid.OK
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsTagsByIccid.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsTagsByIccid.Unauthorized
-            else
-                return PostAssetsTagsByIccid.InternalServerError
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsTagsByIccid.OK
+            | HttpStatusCode.BadRequest -> return PostAssetsTagsByIccid.BadRequest
+            | HttpStatusCode.Unauthorized -> return PostAssetsTagsByIccid.Unauthorized
+            | _ -> return PostAssetsTagsByIccid.InternalServerError
         }
 
     ///<summary>
@@ -1984,14 +1833,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/diagnostic" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetAssetsDiagnosticByIccid.Unauthorized
-            else if status = HttpStatusCode.InternalServerError then
-                return GetAssetsDiagnosticByIccid.InternalServerError
-            else
-                return GetAssetsDiagnosticByIccid.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsDiagnosticByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetAssetsDiagnosticByIccid.Unauthorized
+            | HttpStatusCode.InternalServerError -> return GetAssetsDiagnosticByIccid.InternalServerError
+            | _ -> return GetAssetsDiagnosticByIccid.ServiceUnavailable
         }
 
     ///<summary>
@@ -2004,16 +1850,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/location" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsLocationByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAssetsLocationByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetAssetsLocationByIccid.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
-            else
-                return GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return GetAssetsLocationByIccid.NotFound(Serializer.deserialize content)
+            | _ -> return GetAssetsLocationByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2026,16 +1869,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/sessions" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsSessionsByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAssetsSessionsByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetAssetsSessionsByIccid.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
-            else
-                return GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return GetAssetsSessionsByIccid.NotFound(Serializer.deserialize content)
+            | _ -> return GetAssetsSessionsByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2063,12 +1903,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetReportsCustom.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetReportsCustom.Unauthorized(Serializer.deserialize content)
-            else
-                return GetReportsCustom.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetReportsCustom.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetReportsCustom.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2079,16 +1917,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent report ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostReportsCustom.OK
-            else if status = HttpStatusCode.Unauthorized then
-                return PostReportsCustom.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return PostReportsCustom.Forbidden(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return PostReportsCustom.NotFound(Serializer.deserialize content)
-            else
-                return PostReportsCustom.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostReportsCustom.OK
+            | HttpStatusCode.Unauthorized -> return PostReportsCustom.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return PostReportsCustom.Forbidden(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return PostReportsCustom.NotFound(Serializer.deserialize content)
+            | _ -> return PostReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2099,12 +1933,10 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/reports/custom" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return DeleteReportsCustom.NoContent
-            else if status = HttpStatusCode.Unauthorized then
-                return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return DeleteReportsCustom.NoContent
+            | HttpStatusCode.Unauthorized -> return DeleteReportsCustom.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteReportsCustom.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2117,14 +1949,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetReportsCustomByReportId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetReportsCustomByReportId.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
-            else
-                return GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return GetReportsCustomByReportId.NotFound(Serializer.deserialize content)
+            | _ -> return GetReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2137,14 +1967,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/reports/custom/{reportId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return DeleteReportsCustomByReportId.NoContent
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.NoContent -> return DeleteReportsCustomByReportId.NoContent
+            | HttpStatusCode.Unauthorized ->
                 return DeleteReportsCustomByReportId.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.NotFound then
-                return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
-            else
-                return DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
+            | HttpStatusCode.NotFound -> return DeleteReportsCustomByReportId.NotFound(Serializer.deserialize content)
+            | _ -> return DeleteReportsCustomByReportId.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2210,14 +2038,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/events" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetEvents.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetEvents.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetEvents.Unauthorized(Serializer.deserialize content)
-            else
-                return GetEvents.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetEvents.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetEvents.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetEvents.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetEvents.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2277,14 +2102,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/subscribe" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsSubscribe.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsSubscribe.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsSubscribe.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsSubscribe.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2297,14 +2119,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/transfer" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsTransfer.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsTransfer.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsTransfer.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsTransfer.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2317,14 +2136,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/return" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsReturn.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsReturn.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsReturn.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsReturn.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2337,14 +2153,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/suspend" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PutBulkAssetsSuspend.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutBulkAssetsSuspend.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutBulkAssetsSuspend.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsSuspend.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2357,14 +2170,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/unsuspend" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PutBulkAssetsUnsuspend.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutBulkAssetsUnsuspend.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutBulkAssetsUnsuspend.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsUnsuspend.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2381,14 +2191,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/resubscribe" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsResubscribe.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsResubscribe.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostBulkAssetsResubscribe.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsResubscribe.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2399,14 +2207,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/bulk/assets" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssets.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssets.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssets.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssets.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2417,14 +2222,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/bulk/assets" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PutBulkAssets.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutBulkAssets.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutBulkAssets.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssets.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PutBulkAssets.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutBulkAssets.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutBulkAssets.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssets.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2437,14 +2239,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/groupname" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PutBulkAssetsGroupname.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutBulkAssetsGroupname.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutBulkAssetsGroupname.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsGroupname.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2457,14 +2256,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/limit" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsLimit.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsLimit.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsLimit.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsLimit.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2479,14 +2275,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/bulk/assets/alerts" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
-            else
-                return PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PutBulkAssetsAlerts.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutBulkAssetsAlerts.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PutBulkAssetsAlerts.Unauthorized(Serializer.deserialize content)
+            | _ -> return PutBulkAssetsAlerts.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2497,14 +2290,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/bulk/assets/sms" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsSms.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsSms.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsSms.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsSms.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2517,14 +2307,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/purge" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsPurge.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsPurge.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostBulkAssetsPurge.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsPurge.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2571,14 +2358,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/bulk/assets/reallocate-ip" requestParts cancellationToken
 
-            if status = HttpStatusCode.Accepted then
-                return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.Accepted -> return PostBulkAssetsReallocateIp.Accepted(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostBulkAssetsReallocateIp.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostBulkAssetsReallocateIp.Unauthorized(Serializer.deserialize content)
-            else
-                return PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostBulkAssetsReallocateIp.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2651,14 +2436,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/payments/topupPaypal" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
-            else
-                return PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostPaymentsTopupPaypal.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostPaymentsTopupPaypal.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostPaymentsTopupPaypal.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostPaymentsTopupPaypal.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2678,14 +2460,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/payments/confirmTopupPaypal" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PostPaymentsConfirmTopupPaypal.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PostPaymentsConfirmTopupPaypal.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PostPaymentsConfirmTopupPaypal.Unauthorized(Serializer.deserialize content)
-            else
-                return PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostPaymentsConfirmTopupPaypal.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2787,18 +2568,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/security/alerts" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSecurityAlerts.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetSecurityAlerts.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return GetSecurityAlerts.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return GetSecurityAlerts.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return GetSecurityAlerts.InternalServerError
-            else
-                return GetSecurityAlerts.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return GetSecurityAlerts.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetSecurityAlerts.BadRequest
+            | HttpStatusCode.Unauthorized -> return GetSecurityAlerts.Unauthorized
+            | HttpStatusCode.Forbidden -> return GetSecurityAlerts.Forbidden
+            | HttpStatusCode.InternalServerError -> return GetSecurityAlerts.InternalServerError
+            | _ -> return GetSecurityAlerts.ServiceUnavailable
         }
 
     ///<summary>
@@ -2824,18 +2600,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetSecurityAlertsByAlertId.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return GetSecurityAlertsByAlertId.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return GetSecurityAlertsByAlertId.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return GetSecurityAlertsByAlertId.InternalServerError
-            else
-                return GetSecurityAlertsByAlertId.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return GetSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetSecurityAlertsByAlertId.BadRequest
+            | HttpStatusCode.Unauthorized -> return GetSecurityAlertsByAlertId.Unauthorized
+            | HttpStatusCode.Forbidden -> return GetSecurityAlertsByAlertId.Forbidden
+            | HttpStatusCode.InternalServerError -> return GetSecurityAlertsByAlertId.InternalServerError
+            | _ -> return GetSecurityAlertsByAlertId.ServiceUnavailable
         }
 
     ///<summary>
@@ -2864,18 +2635,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutSecurityAlertsByAlertId.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return PutSecurityAlertsByAlertId.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return PutSecurityAlertsByAlertId.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return PutSecurityAlertsByAlertId.InternalServerError
-            else
-                return PutSecurityAlertsByAlertId.ServiceUnavailable
+            match status with
+            | HttpStatusCode.OK -> return PutSecurityAlertsByAlertId.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutSecurityAlertsByAlertId.BadRequest
+            | HttpStatusCode.Unauthorized -> return PutSecurityAlertsByAlertId.Unauthorized
+            | HttpStatusCode.Forbidden -> return PutSecurityAlertsByAlertId.Forbidden
+            | HttpStatusCode.InternalServerError -> return PutSecurityAlertsByAlertId.InternalServerError
+            | _ -> return PutSecurityAlertsByAlertId.ServiceUnavailable
         }
 
     ///<summary>
@@ -2901,18 +2667,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/security/alerts/{alertId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return DeleteSecurityAlertsByAlertId.NoContent
-            else if status = HttpStatusCode.BadRequest then
-                return DeleteSecurityAlertsByAlertId.BadRequest
-            else if status = HttpStatusCode.Unauthorized then
-                return DeleteSecurityAlertsByAlertId.Unauthorized
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteSecurityAlertsByAlertId.Forbidden
-            else if status = HttpStatusCode.InternalServerError then
-                return DeleteSecurityAlertsByAlertId.InternalServerError
-            else
-                return DeleteSecurityAlertsByAlertId.ServiceUnavailable
+            match status with
+            | HttpStatusCode.NoContent -> return DeleteSecurityAlertsByAlertId.NoContent
+            | HttpStatusCode.BadRequest -> return DeleteSecurityAlertsByAlertId.BadRequest
+            | HttpStatusCode.Unauthorized -> return DeleteSecurityAlertsByAlertId.Unauthorized
+            | HttpStatusCode.Forbidden -> return DeleteSecurityAlertsByAlertId.Forbidden
+            | HttpStatusCode.InternalServerError -> return DeleteSecurityAlertsByAlertId.InternalServerError
+            | _ -> return DeleteSecurityAlertsByAlertId.ServiceUnavailable
         }
 
     ///<summary>
@@ -2947,14 +2708,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/security/topthreaten" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetGraphSecurityTopthreaten.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraphSecurityTopthreaten.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetGraphSecurityTopthreaten.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetGraphSecurityTopthreaten.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -2989,14 +2748,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/security/byalarmtype" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetGraphSecurityByalarmtype.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraphSecurityByalarmtype.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetGraphSecurityByalarmtype.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetGraphSecurityByalarmtype.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3021,14 +2778,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent payload ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/esims" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostEsims.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostEsims.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostEsims.Unauthorized(Serializer.deserialize content)
-            else
-                return PostEsims.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostEsims.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostEsims.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostEsims.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostEsims.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3071,14 +2825,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/esims/{eid}/transfer" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostEsimsTransferByEid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostEsimsTransferByEid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostEsimsTransferByEid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostEsimsTransferByEid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostEsimsTransferByEid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3091,14 +2842,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/esims/{eid}/return" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostEsimsReturnByEid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostEsimsReturnByEid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostEsimsReturnByEid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostEsimsReturnByEid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostEsimsReturnByEid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3422,14 +3170,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/1" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph1.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph1.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph1.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph1.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph1.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph1.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph1.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph1.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3459,14 +3204,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/2" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph2.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph2.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph2.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph2.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph2.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph2.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph2.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph2.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3496,14 +3238,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/3" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph3.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph3.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph3.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph3.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph3.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph3.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph3.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph3.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3533,14 +3272,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/4" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph4.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph4.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph4.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph4.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph4.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph4.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph4.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph4.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3570,14 +3306,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/5" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph5.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph5.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph5.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph5.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph5.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph5.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph5.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph5.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3607,14 +3340,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/6" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph6.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph6.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph6.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph6.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph6.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph6.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph6.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph6.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3644,14 +3374,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/7" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph7.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph7.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph7.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph7.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph7.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph7.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph7.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph7.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3681,14 +3408,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/8" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph8.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph8.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph8.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph8.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph8.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph8.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph8.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph8.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3718,14 +3442,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/9" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph9.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph9.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph9.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph9.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph9.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph9.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph9.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph9.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3739,14 +3460,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/10" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph10.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph10.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph10.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph10.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph10.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph10.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph10.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph10.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3776,14 +3494,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/11" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph11.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph11.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph11.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph11.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph11.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph11.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph11.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph11.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3813,14 +3528,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/graph/12" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraph12.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraph12.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraph12.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraph12.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraph12.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraph12.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraph12.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraph12.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3851,14 +3563,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/graph/statusesperday" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetGraphStatusesperday.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
-            else
-                return GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetGraphStatusesperday.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetGraphStatusesperday.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetGraphStatusesperday.Unauthorized(Serializer.deserialize content)
+            | _ -> return GetGraphStatusesperday.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3888,14 +3597,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return PostAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3908,14 +3615,12 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/quick-dial" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsQuickDialByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAssetsQuickDialByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return GetAssetsQuickDialByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAssetsQuickDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3928,14 +3633,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return GetAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return GetAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return GetAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-            else
-                return GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+            | _ -> return GetAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3952,14 +3656,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/assets/{iccid}/quick-dial/{location}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.OK -> return PutAssetsQuickDialByIccidAndLocation.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest ->
                 return PutAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return PutAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-            else
-                return PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+            | _ -> return PutAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3976,14 +3679,13 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return DeleteAssetsQuickDialByIccidAndLocation.NoContent
-            else if status = HttpStatusCode.BadRequest then
+            match status with
+            | HttpStatusCode.NoContent -> return DeleteAssetsQuickDialByIccidAndLocation.NoContent
+            | HttpStatusCode.BadRequest ->
                 return DeleteAssetsQuickDialByIccidAndLocation.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            | HttpStatusCode.Unauthorized ->
                 return DeleteAssetsQuickDialByIccidAndLocation.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
+            | _ -> return DeleteAssetsQuickDialByIccidAndLocation.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -3996,14 +3698,11 @@ type TaskPodiosuiteClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/assets/{iccid}/dial" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostAssetsDialByIccid.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
-            else
-                return PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostAssetsDialByIccid.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PostAssetsDialByIccid.BadRequest(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return PostAssetsDialByIccid.Unauthorized(Serializer.deserialize content)
+            | _ -> return PostAssetsDialByIccid.InternalServerError(Serializer.deserialize content)
         }
 
     ///<summary>

--- a/examples/TaskSlicebox/Client.fs
+++ b/examples/TaskSlicebox/Client.fs
@@ -117,10 +117,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/anonymization/keys/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAnonymizationKeysById.OK(Serializer.deserialize content)
-            else
-                return GetAnonymizationKeysById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetAnonymizationKeysById.OK(Serializer.deserialize content)
+            | _ -> return GetAnonymizationKeysById.NotFound
         }
 
     ///<summary>
@@ -135,10 +134,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/anonymization/keys/{id}/keyvalues" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
-            else
-                return GetAnonymizationKeysKeyvaluesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
+            | _ -> return GetAnonymizationKeysKeyvaluesById.NotFound
         }
 
     ///<summary>
@@ -245,10 +243,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/boxes/incoming/{id}/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
-            else
-                return GetBoxesIncomingImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetBoxesIncomingImagesById.NotFound
         }
 
     ///<summary>
@@ -296,10 +293,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/boxes/outgoing/{id}/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
-            else
-                return GetBoxesOutgoingImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetBoxesOutgoingImagesById.NotFound
         }
 
     ///<summary>
@@ -333,10 +329,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/boxes/{id}/send" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostBoxesSendById.Created
-            else
-                return PostBoxesSendById.NotFound
+            match status with
+            | HttpStatusCode.Created -> return PostBoxesSendById.Created
+            | _ -> return PostBoxesSendById.NotFound
         }
 
     ///<summary>
@@ -607,10 +602,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostImages.OK(Serializer.deserialize content)
-            else
-                return PostImages.Created(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PostImages.OK(Serializer.deserialize content)
+            | _ -> return PostImages.Created(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -650,10 +644,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/images/export" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostImagesExport.OK(Serializer.deserialize content)
-            else
-                return PostImagesExport.Created
+            match status with
+            | HttpStatusCode.OK -> return PostImagesExport.OK(Serializer.deserialize content)
+            | _ -> return PostImagesExport.Created
         }
 
     ///<summary>
@@ -706,10 +699,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/images/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImagesById.OK contentBinary
-            else
-                return GetImagesById.NotFound contentBinary
+            match status with
+            | HttpStatusCode.OK -> return GetImagesById.OK contentBinary
+            | _ -> return GetImagesById.NotFound contentBinary
         }
 
     ///<summary>
@@ -732,10 +724,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/images/{id}/anonymize" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutImagesAnonymizeById.OK(Serializer.deserialize content)
-            else
-                return PutImagesAnonymizeById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PutImagesAnonymizeById.OK(Serializer.deserialize content)
+            | _ -> return PutImagesAnonymizeById.NotFound
         }
 
     ///<summary>
@@ -758,10 +749,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/images/{id}/anonymized" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostImagesAnonymizedById.OK
-            else
-                return PostImagesAnonymizedById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PostImagesAnonymizedById.OK
+            | _ -> return PostImagesAnonymizedById.NotFound
         }
 
     ///<summary>
@@ -776,10 +766,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/images/{id}/attributes" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImagesAttributesById.OK(Serializer.deserialize content)
-            else
-                return GetImagesAttributesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetImagesAttributesById.OK(Serializer.deserialize content)
+            | _ -> return GetImagesAttributesById.NotFound
         }
 
     ///<summary>
@@ -794,10 +783,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/images/{id}/imageinformation" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImagesImageinformationById.OK(Serializer.deserialize content)
-            else
-                return GetImagesImageinformationById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetImagesImageinformationById.OK(Serializer.deserialize content)
+            | _ -> return GetImagesImageinformationById.NotFound
         }
 
     ///<summary>
@@ -856,10 +844,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/images/{id}/png" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImagesPngById.OK contentBinary
-            else
-                return GetImagesPngById.NotFound contentBinary
+            match status with
+            | HttpStatusCode.OK -> return GetImagesPngById.OK contentBinary
+            | _ -> return GetImagesPngById.NotFound contentBinary
         }
 
     ///<summary>
@@ -919,10 +906,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/import/sessions/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImportSessionsById.OK(Serializer.deserialize content)
-            else
-                return GetImportSessionsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetImportSessionsById.OK(Serializer.deserialize content)
+            | _ -> return GetImportSessionsById.NotFound
         }
 
     ///<summary>
@@ -937,10 +923,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/import/sessions/{id}/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetImportSessionsImagesById.OK(Serializer.deserialize content)
-            else
-                return GetImportSessionsImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetImportSessionsImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetImportSessionsImagesById.NotFound
         }
 
     ///<summary>
@@ -958,12 +943,10 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/import/sessions/{id}/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostImportSessionsImagesById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return PostImportSessionsImagesById.Created(Serializer.deserialize content)
-            else
-                return PostImportSessionsImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PostImportSessionsImagesById.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return PostImportSessionsImagesById.Created(Serializer.deserialize content)
+            | _ -> return PostImportSessionsImagesById.NotFound
         }
 
     ///<summary>
@@ -1093,10 +1076,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/flatseries/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataFlatseriesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataFlatseriesById.NotFound
         }
 
     ///<summary>
@@ -1150,10 +1132,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/images/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataImagesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataImagesById.NotFound
         }
 
     ///<summary>
@@ -1228,10 +1209,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/patients/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataPatientsById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataPatientsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataPatientsById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataPatientsById.NotFound
         }
 
     ///<summary>
@@ -1329,10 +1309,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataSeriesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataSeriesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesById.NotFound
         }
 
     ///<summary>
@@ -1347,10 +1326,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/seriestags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesSeriestagsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesSeriestagsById.NotFound
         }
 
     ///<summary>
@@ -1368,10 +1346,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/metadata/series/{id}/seriestags" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
-            else
-                return PostMetadataSeriesSeriestagsById.NotFound
+            match status with
+            | HttpStatusCode.Created -> return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
+            | _ -> return PostMetadataSeriesSeriestagsById.NotFound
         }
 
     ///<summary>
@@ -1401,10 +1378,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/seriestypes" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesSeriestypesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesSeriestypesById.NotFound
         }
 
     ///<summary>
@@ -1419,10 +1395,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/source" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataSeriesSourceById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataSeriesSourceById.NotFound
         }
 
     ///<summary>
@@ -1503,10 +1478,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
-            else
-                return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NotFound
+            match status with
+            | HttpStatusCode.NoContent -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
+            | _ -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NotFound
         }
 
     ///<summary>
@@ -1585,10 +1559,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/studies/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataStudiesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataStudiesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataStudiesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataStudiesById.NotFound
         }
 
     ///<summary>
@@ -1620,10 +1593,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/studies/{id}/images" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
-            else
-                return GetMetadataStudiesImagesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
+            | _ -> return GetMetadataStudiesImagesById.NotFound
         }
 
     ///<summary>
@@ -1652,10 +1624,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent scp ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scps" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostScps.Created(Serializer.deserialize content)
-            else
-                return PostScps.BadRequest
+            match status with
+            | HttpStatusCode.Created -> return PostScps.Created(Serializer.deserialize content)
+            | _ -> return PostScps.BadRequest
         }
 
     ///<summary>
@@ -1696,10 +1667,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent scu ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scus" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostScus.Created(Serializer.deserialize content)
-            else
-                return PostScus.BadRequest
+            match status with
+            | HttpStatusCode.Created -> return PostScus.Created(Serializer.deserialize content)
+            | _ -> return PostScus.BadRequest
         }
 
     ///<summary>
@@ -1728,10 +1698,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scus/{id}/send" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PostScusSendById.NoContent
-            else
-                return PostScusSendById.NotFound
+            match status with
+            | HttpStatusCode.NoContent -> return PostScusSendById.NoContent
+            | _ -> return PostScusSendById.NotFound
         }
 
     ///<summary>
@@ -1983,10 +1952,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/image" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PostTransactionsImageByToken.NoContent
-            else
-                return PostTransactionsImageByToken.Unauthorized
+            match status with
+            | HttpStatusCode.NoContent -> return PostTransactionsImageByToken.NoContent
+            | _ -> return PostTransactionsImageByToken.Unauthorized
         }
 
     ///<summary>
@@ -2012,12 +1980,10 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/transactions/{token}/outgoing" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTransactionsOutgoingByToken.OK contentBinary
-            else if status = HttpStatusCode.Unauthorized then
-                return GetTransactionsOutgoingByToken.Unauthorized contentBinary
-            else
-                return GetTransactionsOutgoingByToken.NotFound contentBinary
+            match status with
+            | HttpStatusCode.OK -> return GetTransactionsOutgoingByToken.OK contentBinary
+            | HttpStatusCode.Unauthorized -> return GetTransactionsOutgoingByToken.Unauthorized contentBinary
+            | _ -> return GetTransactionsOutgoingByToken.NotFound contentBinary
         }
 
     ///<summary>
@@ -2040,10 +2006,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/outgoing/done" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PostTransactionsOutgoingDoneByToken.NoContent
-            else
-                return PostTransactionsOutgoingDoneByToken.Unauthorized
+            match status with
+            | HttpStatusCode.NoContent -> return PostTransactionsOutgoingDoneByToken.NoContent
+            | _ -> return PostTransactionsOutgoingDoneByToken.Unauthorized
         }
 
     ///<summary>
@@ -2066,10 +2031,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/outgoing/failed" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PostTransactionsOutgoingFailedByToken.NoContent
-            else
-                return PostTransactionsOutgoingFailedByToken.Unauthorized
+            match status with
+            | HttpStatusCode.NoContent -> return PostTransactionsOutgoingFailedByToken.NoContent
+            | _ -> return PostTransactionsOutgoingFailedByToken.Unauthorized
         }
 
     ///<summary>
@@ -2084,12 +2048,10 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/transactions/{token}/outgoing/poll" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return GetTransactionsOutgoingPollByToken.Unauthorized
-            else
-                return GetTransactionsOutgoingPollByToken.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return GetTransactionsOutgoingPollByToken.Unauthorized
+            | _ -> return GetTransactionsOutgoingPollByToken.NotFound
         }
 
     ///<summary>
@@ -2112,12 +2074,10 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/transactions/{token}/status" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTransactionsStatusByToken.OK
-            else if status = HttpStatusCode.Unauthorized then
-                return GetTransactionsStatusByToken.Unauthorized
-            else
-                return GetTransactionsStatusByToken.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetTransactionsStatusByToken.OK
+            | HttpStatusCode.Unauthorized -> return GetTransactionsStatusByToken.Unauthorized
+            | _ -> return GetTransactionsStatusByToken.NotFound
         }
 
     ///<summary>
@@ -2143,10 +2103,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/transactions/{token}/status" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PutTransactionsStatusByToken.NoContent
-            else
-                return PutTransactionsStatusByToken.NotFound
+            match status with
+            | HttpStatusCode.NoContent -> return PutTransactionsStatusByToken.NoContent
+            | _ -> return PutTransactionsStatusByToken.NotFound
         }
 
     ///<summary>
@@ -2185,10 +2144,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/current" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUsersCurrent.OK(Serializer.deserialize content)
-            else
-                return GetUsersCurrent.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetUsersCurrent.OK(Serializer.deserialize content)
+            | _ -> return GetUsersCurrent.NotFound
         }
 
     ///<summary>
@@ -2199,10 +2157,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent userPass ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/users/login" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostUsersLogin.Created
-            else
-                return PostUsersLogin.Unauthorized
+            match status with
+            | HttpStatusCode.Created -> return PostUsersLogin.Created
+            | _ -> return PostUsersLogin.Unauthorized
         }
 
     ///<summary>

--- a/examples/TaskSlicebox/Client.fs
+++ b/examples/TaskSlicebox/Client.fs
@@ -117,8 +117,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/anonymization/keys/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAnonymizationKeysById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAnonymizationKeysById.OK(Serializer.deserialize content)
             | _ -> return GetAnonymizationKeysById.NotFound
         }
 
@@ -134,8 +134,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/anonymization/keys/{id}/keyvalues" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAnonymizationKeysKeyvaluesById.OK(Serializer.deserialize content)
             | _ -> return GetAnonymizationKeysKeyvaluesById.NotFound
         }
 
@@ -243,8 +243,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/boxes/incoming/{id}/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetBoxesIncomingImagesById.OK(Serializer.deserialize content)
             | _ -> return GetBoxesIncomingImagesById.NotFound
         }
 
@@ -293,8 +293,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/boxes/outgoing/{id}/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetBoxesOutgoingImagesById.OK(Serializer.deserialize content)
             | _ -> return GetBoxesOutgoingImagesById.NotFound
         }
 
@@ -329,8 +329,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/boxes/{id}/send" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostBoxesSendById.Created
+            match int status with
+            | 201 -> return PostBoxesSendById.Created
             | _ -> return PostBoxesSendById.NotFound
         }
 
@@ -602,8 +602,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostImages.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostImages.OK(Serializer.deserialize content)
             | _ -> return PostImages.Created(Serializer.deserialize content)
         }
 
@@ -644,8 +644,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/images/export" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostImagesExport.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostImagesExport.OK(Serializer.deserialize content)
             | _ -> return PostImagesExport.Created
         }
 
@@ -699,8 +699,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/images/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImagesById.OK contentBinary
+            match int status with
+            | 200 -> return GetImagesById.OK contentBinary
             | _ -> return GetImagesById.NotFound contentBinary
         }
 
@@ -724,8 +724,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/images/{id}/anonymize" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutImagesAnonymizeById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PutImagesAnonymizeById.OK(Serializer.deserialize content)
             | _ -> return PutImagesAnonymizeById.NotFound
         }
 
@@ -749,8 +749,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/images/{id}/anonymized" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostImagesAnonymizedById.OK
+            match int status with
+            | 200 -> return PostImagesAnonymizedById.OK
             | _ -> return PostImagesAnonymizedById.NotFound
         }
 
@@ -766,8 +766,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/images/{id}/attributes" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImagesAttributesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetImagesAttributesById.OK(Serializer.deserialize content)
             | _ -> return GetImagesAttributesById.NotFound
         }
 
@@ -783,8 +783,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/images/{id}/imageinformation" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImagesImageinformationById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetImagesImageinformationById.OK(Serializer.deserialize content)
             | _ -> return GetImagesImageinformationById.NotFound
         }
 
@@ -844,8 +844,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/images/{id}/png" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImagesPngById.OK contentBinary
+            match int status with
+            | 200 -> return GetImagesPngById.OK contentBinary
             | _ -> return GetImagesPngById.NotFound contentBinary
         }
 
@@ -906,8 +906,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/import/sessions/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImportSessionsById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetImportSessionsById.OK(Serializer.deserialize content)
             | _ -> return GetImportSessionsById.NotFound
         }
 
@@ -923,8 +923,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/import/sessions/{id}/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetImportSessionsImagesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetImportSessionsImagesById.OK(Serializer.deserialize content)
             | _ -> return GetImportSessionsImagesById.NotFound
         }
 
@@ -943,9 +943,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/import/sessions/{id}/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostImportSessionsImagesById.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return PostImportSessionsImagesById.Created(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PostImportSessionsImagesById.OK(Serializer.deserialize content)
+            | 201 -> return PostImportSessionsImagesById.Created(Serializer.deserialize content)
             | _ -> return PostImportSessionsImagesById.NotFound
         }
 
@@ -1076,8 +1076,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/flatseries/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataFlatseriesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataFlatseriesById.NotFound
         }
 
@@ -1132,8 +1132,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/images/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataImagesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataImagesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataImagesById.NotFound
         }
 
@@ -1209,8 +1209,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/patients/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataPatientsById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataPatientsById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataPatientsById.NotFound
         }
 
@@ -1309,8 +1309,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataSeriesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataSeriesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesById.NotFound
         }
 
@@ -1326,8 +1326,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/seriestags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataSeriesSeriestagsById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesSeriestagsById.NotFound
         }
 
@@ -1346,8 +1346,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/metadata/series/{id}/seriestags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PostMetadataSeriesSeriestagsById.Created(Serializer.deserialize content)
             | _ -> return PostMetadataSeriesSeriestagsById.NotFound
         }
 
@@ -1378,8 +1378,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/seriestypes" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataSeriesSeriestypesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesSeriestypesById.NotFound
         }
 
@@ -1395,8 +1395,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/series/{id}/source" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataSeriesSourceById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataSeriesSourceById.NotFound
         }
 
@@ -1478,8 +1478,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
+            match int status with
+            | 204 -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NoContent
             | _ -> return PutMetadataSeriesSeriestypesBySeriesIdAndSeriesTypeId.NotFound
         }
 
@@ -1559,8 +1559,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/studies/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataStudiesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataStudiesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataStudiesById.NotFound
         }
 
@@ -1593,8 +1593,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/metadata/studies/{id}/images" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetMetadataStudiesImagesById.OK(Serializer.deserialize content)
             | _ -> return GetMetadataStudiesImagesById.NotFound
         }
 
@@ -1624,8 +1624,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent scp ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scps" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostScps.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PostScps.Created(Serializer.deserialize content)
             | _ -> return PostScps.BadRequest
         }
 
@@ -1667,8 +1667,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent scu ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scus" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostScus.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PostScus.Created(Serializer.deserialize content)
             | _ -> return PostScus.BadRequest
         }
 
@@ -1698,8 +1698,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/scus/{id}/send" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PostScusSendById.NoContent
+            match int status with
+            | 204 -> return PostScusSendById.NoContent
             | _ -> return PostScusSendById.NotFound
         }
 
@@ -1952,8 +1952,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/image" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PostTransactionsImageByToken.NoContent
+            match int status with
+            | 204 -> return PostTransactionsImageByToken.NoContent
             | _ -> return PostTransactionsImageByToken.Unauthorized
         }
 
@@ -1980,9 +1980,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/transactions/{token}/outgoing" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTransactionsOutgoingByToken.OK contentBinary
-            | HttpStatusCode.Unauthorized -> return GetTransactionsOutgoingByToken.Unauthorized contentBinary
+            match int status with
+            | 200 -> return GetTransactionsOutgoingByToken.OK contentBinary
+            | 401 -> return GetTransactionsOutgoingByToken.Unauthorized contentBinary
             | _ -> return GetTransactionsOutgoingByToken.NotFound contentBinary
         }
 
@@ -2006,8 +2006,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/outgoing/done" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PostTransactionsOutgoingDoneByToken.NoContent
+            match int status with
+            | 204 -> return PostTransactionsOutgoingDoneByToken.NoContent
             | _ -> return PostTransactionsOutgoingDoneByToken.Unauthorized
         }
 
@@ -2031,8 +2031,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/transactions/{token}/outgoing/failed" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PostTransactionsOutgoingFailedByToken.NoContent
+            match int status with
+            | 204 -> return PostTransactionsOutgoingFailedByToken.NoContent
             | _ -> return PostTransactionsOutgoingFailedByToken.Unauthorized
         }
 
@@ -2048,9 +2048,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/transactions/{token}/outgoing/poll" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return GetTransactionsOutgoingPollByToken.Unauthorized
+            match int status with
+            | 200 -> return GetTransactionsOutgoingPollByToken.OK(Serializer.deserialize content)
+            | 401 -> return GetTransactionsOutgoingPollByToken.Unauthorized
             | _ -> return GetTransactionsOutgoingPollByToken.NotFound
         }
 
@@ -2074,9 +2074,9 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/transactions/{token}/status" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTransactionsStatusByToken.OK
-            | HttpStatusCode.Unauthorized -> return GetTransactionsStatusByToken.Unauthorized
+            match int status with
+            | 200 -> return GetTransactionsStatusByToken.OK
+            | 401 -> return GetTransactionsStatusByToken.Unauthorized
             | _ -> return GetTransactionsStatusByToken.NotFound
         }
 
@@ -2103,8 +2103,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/transactions/{token}/status" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PutTransactionsStatusByToken.NoContent
+            match int status with
+            | 204 -> return PutTransactionsStatusByToken.NoContent
             | _ -> return PutTransactionsStatusByToken.NotFound
         }
 
@@ -2144,8 +2144,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/users/current" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUsersCurrent.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetUsersCurrent.OK(Serializer.deserialize content)
             | _ -> return GetUsersCurrent.NotFound
         }
 
@@ -2157,8 +2157,8 @@ type TaskSliceboxClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent userPass ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/users/login" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostUsersLogin.Created
+            match int status with
+            | 201 -> return PostUsersLogin.Created
             | _ -> return PostUsersLogin.Unauthorized
         }
 

--- a/examples/TaskSwashbuckle/Client.fs
+++ b/examples/TaskSwashbuckle/Client.fs
@@ -14,10 +14,8 @@ type TaskSwashbuckleClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Time" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTime.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetTime.BadRequest(Serializer.deserialize content)
-            else
-                return GetTime.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return GetTime.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetTime.BadRequest(Serializer.deserialize content)
+            | _ -> return GetTime.Forbidden(Serializer.deserialize content)
         }

--- a/examples/TaskSwashbuckle/Client.fs
+++ b/examples/TaskSwashbuckle/Client.fs
@@ -14,8 +14,8 @@ type TaskSwashbuckleClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Time" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTime.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetTime.BadRequest(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetTime.OK(Serializer.deserialize content)
+            | 400 -> return GetTime.BadRequest(Serializer.deserialize content)
             | _ -> return GetTime.Forbidden(Serializer.deserialize content)
         }

--- a/examples/TaskTripPinService/Client.fs
+++ b/examples/TaskTripPinService/Client.fs
@@ -52,10 +52,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Airlines" headers requestParts
 
-            if status = 200 then
-                return AirlinesAirlineListAirline.OK(Serializer.deserialize content)
-            else
-                return AirlinesAirlineListAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return AirlinesAirlineListAirline.OK(Serializer.deserialize content)
+            | _ -> return AirlinesAirlineListAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -66,10 +65,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/Airlines" headers requestParts
 
-            if status = 201 then
-                return AirlinesAirlineCreateAirline.Created(Serializer.deserialize content)
-            else
-                return AirlinesAirlineCreateAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 201 -> return AirlinesAirlineCreateAirline.Created(Serializer.deserialize content)
+            | _ -> return AirlinesAirlineCreateAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -89,10 +87,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Airlines({AirlineCode})" headers requestParts
 
-            if status = 200 then
-                return AirlinesAirlineGetAirline.OK(Serializer.deserialize content)
-            else
-                return AirlinesAirlineGetAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return AirlinesAirlineGetAirline.OK(Serializer.deserialize content)
+            | _ -> return AirlinesAirlineGetAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -112,10 +109,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/Airlines({AirlineCode})" headers requestParts
 
-            if status = 204 then
-                return AirlinesAirlineUpdateAirline.NoContent
-            else
-                return AirlinesAirlineUpdateAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return AirlinesAirlineUpdateAirline.NoContent
+            | _ -> return AirlinesAirlineUpdateAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -132,10 +128,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/Airlines({AirlineCode})" headers requestParts
 
-            if status = 204 then
-                return AirlinesAirlineDeleteAirline.NoContent
-            else
-                return AirlinesAirlineDeleteAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return AirlinesAirlineDeleteAirline.NoContent
+            | _ -> return AirlinesAirlineDeleteAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -181,10 +176,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Airports" headers requestParts
 
-            if status = 200 then
-                return AirportsAirportListAirport.OK(Serializer.deserialize content)
-            else
-                return AirportsAirportListAirport.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return AirportsAirportListAirport.OK(Serializer.deserialize content)
+            | _ -> return AirportsAirportListAirport.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -204,10 +198,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Airports({IcaoCode})" headers requestParts
 
-            if status = 200 then
-                return AirportsAirportGetAirport.OK(Serializer.deserialize content)
-            else
-                return AirportsAirportGetAirport.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return AirportsAirportGetAirport.OK(Serializer.deserialize content)
+            | _ -> return AirportsAirportGetAirport.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -223,10 +216,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/Airports({IcaoCode})" headers requestParts
 
-            if status = 204 then
-                return AirportsAirportUpdateAirport.NoContent
-            else
-                return AirportsAirportUpdateAirport.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return AirportsAirportUpdateAirport.NoContent
+            | _ -> return AirportsAirportUpdateAirport.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -241,10 +233,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/GetNearestAirport(lat={lat},lon={lon})" headers requestParts
 
-            if status = 200 then
-                return FunctionImportGetNearestAirport.OK(Serializer.deserialize content)
-            else
-                return FunctionImportGetNearestAirport.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return FunctionImportGetNearestAirport.OK(Serializer.deserialize content)
+            | _ -> return FunctionImportGetNearestAirport.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -262,10 +253,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me" headers requestParts
 
-            if status = 200 then
-                return MePersonGetPerson.OK(Serializer.deserialize content)
-            else
-                return MePersonGetPerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MePersonGetPerson.OK(Serializer.deserialize content)
+            | _ -> return MePersonGetPerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -276,10 +266,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.patchAsync url "/Me" headers requestParts
 
-            if status = 204 then
-                return MePersonUpdatePerson.NoContent
-            else
-                return MePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return MePersonUpdatePerson.NoContent
+            | _ -> return MePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -325,10 +314,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Friends" headers requestParts
 
-            if status = 200 then
-                return MeListFriends.OK(Serializer.deserialize content)
-            else
-                return MeListFriends.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeListFriends.OK(Serializer.deserialize content)
+            | _ -> return MeListFriends.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -366,10 +354,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Friends/$ref" headers requestParts
 
-            if status = 200 then
-                return MeListRefFriends.OK(Serializer.deserialize content)
-            else
-                return MeListRefFriends.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeListRefFriends.OK(Serializer.deserialize content)
+            | _ -> return MeListRefFriends.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -380,10 +367,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync url "/Me/Friends/$ref" headers requestParts
 
-            if status = 201 then
-                return MeCreateRefFriends.Created(Serializer.deserialize content)
-            else
-                return MeCreateRefFriends.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 201 -> return MeCreateRefFriends.Created(Serializer.deserialize content)
+            | _ -> return MeCreateRefFriends.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -400,10 +386,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            if status = 200 then
-                return MeGetFavoriteAirline.OK(Serializer.deserialize content)
-            else
-                return MeGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeGetFavoriteAirline.OK(Serializer.deserialize content)
+            | _ -> return MeGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -422,10 +407,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            if status = 200 then
-                return MeGetFriendsTrips.OK(Serializer.deserialize content)
-            else
-                return MeGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeGetFriendsTrips.OK(Serializer.deserialize content)
+            | _ -> return MeGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -442,10 +426,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            if status = 204 then
-                return MeShareTrip.NoContent
-            else
-                return MeShareTrip.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return MeShareTrip.NoContent
+            | _ -> return MeShareTrip.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -463,10 +446,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Photo" headers requestParts
 
-            if status = 200 then
-                return MeGetPhoto.OK(Serializer.deserialize content)
-            else
-                return MeGetPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeGetPhoto.OK(Serializer.deserialize content)
+            | _ -> return MeGetPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -477,10 +459,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Photo/$ref" headers requestParts
 
-            if status = 200 then
-                return MeGetRefPhoto.OK(Serializer.deserialize content)
-            else
-                return MeGetRefPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeGetRefPhoto.OK(Serializer.deserialize content)
+            | _ -> return MeGetRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -491,10 +472,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.putAsync url "/Me/Photo/$ref" headers requestParts
 
-            if status = 204 then
-                return MeUpdateRefPhoto.NoContent
-            else
-                return MeUpdateRefPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return MeUpdateRefPhoto.NoContent
+            | _ -> return MeUpdateRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -509,10 +489,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/Me/Photo/$ref" headers requestParts
 
-            if status = 204 then
-                return MeDeleteRefPhoto.NoContent
-            else
-                return MeDeleteRefPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return MeDeleteRefPhoto.NoContent
+            | _ -> return MeDeleteRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -558,10 +537,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Trips" headers requestParts
 
-            if status = 200 then
-                return MeListTrips.OK(Serializer.deserialize content)
-            else
-                return MeListTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeListTrips.OK(Serializer.deserialize content)
+            | _ -> return MeListTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -572,10 +550,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/Me/Trips" headers requestParts
 
-            if status = 201 then
-                return MeCreateTrips.Created(Serializer.deserialize content)
-            else
-                return MeCreateTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 201 -> return MeCreateTrips.Created(Serializer.deserialize content)
+            | _ -> return MeCreateTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -595,10 +572,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Trips({TripId})" headers requestParts
 
-            if status = 200 then
-                return MeGetTrips.OK(Serializer.deserialize content)
-            else
-                return MeGetTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeGetTrips.OK(Serializer.deserialize content)
+            | _ -> return MeGetTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -614,10 +590,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/Me/Trips({TripId})" headers requestParts
 
-            if status = 204 then
-                return MeUpdateTrips.NoContent
-            else
-                return MeUpdateTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return MeUpdateTrips.NoContent
+            | _ -> return MeUpdateTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -634,10 +609,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/Me/Trips({TripId})" headers requestParts
 
-            if status = 204 then
-                return MeDeleteTrips.NoContent
-            else
-                return MeDeleteTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return MeDeleteTrips.NoContent
+            | _ -> return MeDeleteTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -655,10 +629,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            if status = 200 then
-                return MeTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
-            else
-                return MeTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
+            | _ -> return MeTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -707,10 +680,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Trips({TripId})/Photos" headers requestParts
 
-            if status = 200 then
-                return MeTripsListPhotos.OK(Serializer.deserialize content)
-            else
-                return MeTripsListPhotos.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeTripsListPhotos.OK(Serializer.deserialize content)
+            | _ -> return MeTripsListPhotos.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -751,10 +723,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Trips({TripId})/Photos/$ref" headers requestParts
 
-            if status = 200 then
-                return MeTripsListRefPhotos.OK(Serializer.deserialize content)
-            else
-                return MeTripsListRefPhotos.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeTripsListRefPhotos.OK(Serializer.deserialize content)
+            | _ -> return MeTripsListRefPhotos.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -766,10 +737,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("TripId", tripId) ]
             let! (status, content) = OpenApiHttp.postAsync url "/Me/Trips({TripId})/Photos/$ref" headers requestParts
 
-            if status = 201 then
-                return MeTripsCreateRefPhotos.Created(Serializer.deserialize content)
-            else
-                return MeTripsCreateRefPhotos.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 201 -> return MeTripsCreateRefPhotos.Created(Serializer.deserialize content)
+            | _ -> return MeTripsCreateRefPhotos.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -818,10 +788,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Trips({TripId})/PlanItems" headers requestParts
 
-            if status = 200 then
-                return MeTripsListPlanItems.OK(Serializer.deserialize content)
-            else
-                return MeTripsListPlanItems.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeTripsListPlanItems.OK(Serializer.deserialize content)
+            | _ -> return MeTripsListPlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -837,10 +806,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/Me/Trips({TripId})/PlanItems" headers requestParts
 
-            if status = 201 then
-                return MeTripsCreatePlanItems.Created(Serializer.deserialize content)
-            else
-                return MeTripsCreatePlanItems.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 201 -> return MeTripsCreatePlanItems.Created(Serializer.deserialize content)
+            | _ -> return MeTripsCreatePlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -863,10 +831,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/Me/Trips({TripId})/PlanItems({PlanItemId})" headers requestParts
 
-            if status = 200 then
-                return MeTripsGetPlanItems.OK(Serializer.deserialize content)
-            else
-                return MeTripsGetPlanItems.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return MeTripsGetPlanItems.OK(Serializer.deserialize content)
+            | _ -> return MeTripsGetPlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -890,10 +857,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.patchAsync url "/Me/Trips({TripId})/PlanItems({PlanItemId})" headers requestParts
 
-            if status = 204 then
-                return MeTripsUpdatePlanItems.NoContent
-            else
-                return MeTripsUpdatePlanItems.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return MeTripsUpdatePlanItems.NoContent
+            | _ -> return MeTripsUpdatePlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -913,10 +879,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync url "/Me/Trips({TripId})/PlanItems({PlanItemId})" headers requestParts
 
-            if status = 204 then
-                return MeTripsDeletePlanItems.NoContent
-            else
-                return MeTripsDeletePlanItems.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return MeTripsDeletePlanItems.NoContent
+            | _ -> return MeTripsDeletePlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -958,10 +923,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/People" headers requestParts
 
-            if status = 200 then
-                return PeoplePersonListPerson.OK(Serializer.deserialize content)
-            else
-                return PeoplePersonListPerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return PeoplePersonListPerson.OK(Serializer.deserialize content)
+            | _ -> return PeoplePersonListPerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -972,10 +936,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/People" headers requestParts
 
-            if status = 201 then
-                return PeoplePersonCreatePerson.Created(Serializer.deserialize content)
-            else
-                return PeoplePersonCreatePerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 201 -> return PeoplePersonCreatePerson.Created(Serializer.deserialize content)
+            | _ -> return PeoplePersonCreatePerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -992,10 +955,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/People({UserName})" headers requestParts
 
-            if status = 200 then
-                return PeoplePersonGetPerson.OK(Serializer.deserialize content)
-            else
-                return PeoplePersonGetPerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return PeoplePersonGetPerson.OK(Serializer.deserialize content)
+            | _ -> return PeoplePersonGetPerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1011,10 +973,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/People({UserName})" headers requestParts
 
-            if status = 204 then
-                return PeoplePersonUpdatePerson.NoContent
-            else
-                return PeoplePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return PeoplePersonUpdatePerson.NoContent
+            | _ -> return PeoplePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1031,10 +992,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/People({UserName})" headers requestParts
 
-            if status = 204 then
-                return PeoplePersonDeletePerson.NoContent
-            else
-                return PeoplePersonDeletePerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return PeoplePersonDeletePerson.NoContent
+            | _ -> return PeoplePersonDeletePerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1083,10 +1043,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/People({UserName})/Friends" headers requestParts
 
-            if status = 200 then
-                return PeopleListFriends.OK(Serializer.deserialize content)
-            else
-                return PeopleListFriends.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return PeopleListFriends.OK(Serializer.deserialize content)
+            | _ -> return PeopleListFriends.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1105,10 +1064,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            if status = 200 then
-                return PeoplePersonGetFavoriteAirline.OK(Serializer.deserialize content)
-            else
-                return PeoplePersonGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return PeoplePersonGetFavoriteAirline.OK(Serializer.deserialize content)
+            | _ -> return PeoplePersonGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1129,10 +1087,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            if status = 200 then
-                return PeoplePersonGetFriendsTrips.OK(Serializer.deserialize content)
-            else
-                return PeoplePersonGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return PeoplePersonGetFriendsTrips.OK(Serializer.deserialize content)
+            | _ -> return PeoplePersonGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1153,10 +1110,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            if status = 204 then
-                return PeoplePersonShareTrip.NoContent
-            else
-                return PeoplePersonShareTrip.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return PeoplePersonShareTrip.NoContent
+            | _ -> return PeoplePersonShareTrip.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1177,10 +1133,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            if status = 200 then
-                return PeoplePersonTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
-            else
-                return PeoplePersonTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return PeoplePersonTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
+            | _ -> return PeoplePersonTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1226,10 +1181,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Photos" headers requestParts
 
-            if status = 200 then
-                return PhotosPhotoListPhoto.OK(Serializer.deserialize content)
-            else
-                return PhotosPhotoListPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return PhotosPhotoListPhoto.OK(Serializer.deserialize content)
+            | _ -> return PhotosPhotoListPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1240,10 +1194,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/Photos" headers requestParts
 
-            if status = 201 then
-                return PhotosPhotoCreatePhoto.Created(Serializer.deserialize content)
-            else
-                return PhotosPhotoCreatePhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 201 -> return PhotosPhotoCreatePhoto.Created(Serializer.deserialize content)
+            | _ -> return PhotosPhotoCreatePhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1263,10 +1216,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Photos({Id})" headers requestParts
 
-            if status = 200 then
-                return PhotosPhotoGetPhoto.OK(Serializer.deserialize content)
-            else
-                return PhotosPhotoGetPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 200 -> return PhotosPhotoGetPhoto.OK(Serializer.deserialize content)
+            | _ -> return PhotosPhotoGetPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1282,10 +1234,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/Photos({Id})" headers requestParts
 
-            if status = 204 then
-                return PhotosPhotoUpdatePhoto.NoContent
-            else
-                return PhotosPhotoUpdatePhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return PhotosPhotoUpdatePhoto.NoContent
+            | _ -> return PhotosPhotoUpdatePhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1302,10 +1253,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/Photos({Id})" headers requestParts
 
-            if status = 204 then
-                return PhotosPhotoDeletePhoto.NoContent
-            else
-                return PhotosPhotoDeletePhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return PhotosPhotoDeletePhoto.NoContent
+            | _ -> return PhotosPhotoDeletePhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1317,9 +1267,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("Id", id) ]
             let! (status, contentBinary) = OpenApiHttp.getBinaryAsync url "/Photos({Id})/$value" headers requestParts
 
-            if status = 200 then
-                return PhotosPhotoGetContent.OK contentBinary
-            else
+            match status with
+            | 200 -> return PhotosPhotoGetContent.OK contentBinary
+            | _ ->
                 let! content = Utilities.readBytesAsText contentBinary
                 return PhotosPhotoGetContent.DefaultResponse(Serializer.deserialize content)
         }
@@ -1338,10 +1288,9 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/Photos({Id})/$value" headers requestParts
 
-            if status = 204 then
-                return PhotosPhotoUpdateContent.NoContent
-            else
-                return PhotosPhotoUpdateContent.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return PhotosPhotoUpdateContent.NoContent
+            | _ -> return PhotosPhotoUpdateContent.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1352,8 +1301,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync url "/ResetDataSource" headers requestParts
 
-            if status = 204 then
-                return ActionImportResetDataSource.NoContent
-            else
-                return ActionImportResetDataSource.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | 204 -> return ActionImportResetDataSource.NoContent
+            | _ -> return ActionImportResetDataSource.DefaultResponse(Serializer.deserialize content)
         }

--- a/examples/TaskTripPinService/Client.fs
+++ b/examples/TaskTripPinService/Client.fs
@@ -52,7 +52,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Airlines" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return AirlinesAirlineListAirline.OK(Serializer.deserialize content)
             | _ -> return AirlinesAirlineListAirline.DefaultResponse(Serializer.deserialize content)
         }
@@ -65,7 +65,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/Airlines" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return AirlinesAirlineCreateAirline.Created(Serializer.deserialize content)
             | _ -> return AirlinesAirlineCreateAirline.DefaultResponse(Serializer.deserialize content)
         }
@@ -87,7 +87,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Airlines({AirlineCode})" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return AirlinesAirlineGetAirline.OK(Serializer.deserialize content)
             | _ -> return AirlinesAirlineGetAirline.DefaultResponse(Serializer.deserialize content)
         }
@@ -109,7 +109,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/Airlines({AirlineCode})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return AirlinesAirlineUpdateAirline.NoContent
             | _ -> return AirlinesAirlineUpdateAirline.DefaultResponse(Serializer.deserialize content)
         }
@@ -128,7 +128,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/Airlines({AirlineCode})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return AirlinesAirlineDeleteAirline.NoContent
             | _ -> return AirlinesAirlineDeleteAirline.DefaultResponse(Serializer.deserialize content)
         }
@@ -176,7 +176,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Airports" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return AirportsAirportListAirport.OK(Serializer.deserialize content)
             | _ -> return AirportsAirportListAirport.DefaultResponse(Serializer.deserialize content)
         }
@@ -198,7 +198,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Airports({IcaoCode})" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return AirportsAirportGetAirport.OK(Serializer.deserialize content)
             | _ -> return AirportsAirportGetAirport.DefaultResponse(Serializer.deserialize content)
         }
@@ -216,7 +216,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/Airports({IcaoCode})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return AirportsAirportUpdateAirport.NoContent
             | _ -> return AirportsAirportUpdateAirport.DefaultResponse(Serializer.deserialize content)
         }
@@ -233,7 +233,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/GetNearestAirport(lat={lat},lon={lon})" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return FunctionImportGetNearestAirport.OK(Serializer.deserialize content)
             | _ -> return FunctionImportGetNearestAirport.DefaultResponse(Serializer.deserialize content)
         }
@@ -253,7 +253,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MePersonGetPerson.OK(Serializer.deserialize content)
             | _ -> return MePersonGetPerson.DefaultResponse(Serializer.deserialize content)
         }
@@ -266,7 +266,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.patchAsync url "/Me" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return MePersonUpdatePerson.NoContent
             | _ -> return MePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
         }
@@ -314,7 +314,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Friends" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeListFriends.OK(Serializer.deserialize content)
             | _ -> return MeListFriends.DefaultResponse(Serializer.deserialize content)
         }
@@ -354,7 +354,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Friends/$ref" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeListRefFriends.OK(Serializer.deserialize content)
             | _ -> return MeListRefFriends.DefaultResponse(Serializer.deserialize content)
         }
@@ -367,7 +367,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync url "/Me/Friends/$ref" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return MeCreateRefFriends.Created(Serializer.deserialize content)
             | _ -> return MeCreateRefFriends.DefaultResponse(Serializer.deserialize content)
         }
@@ -386,7 +386,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeGetFavoriteAirline.OK(Serializer.deserialize content)
             | _ -> return MeGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
         }
@@ -407,7 +407,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeGetFriendsTrips.OK(Serializer.deserialize content)
             | _ -> return MeGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
         }
@@ -426,7 +426,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            match status with
+            match int status with
             | 204 -> return MeShareTrip.NoContent
             | _ -> return MeShareTrip.DefaultResponse(Serializer.deserialize content)
         }
@@ -446,7 +446,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Photo" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeGetPhoto.OK(Serializer.deserialize content)
             | _ -> return MeGetPhoto.DefaultResponse(Serializer.deserialize content)
         }
@@ -459,7 +459,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Photo/$ref" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeGetRefPhoto.OK(Serializer.deserialize content)
             | _ -> return MeGetRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
@@ -472,7 +472,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.putAsync url "/Me/Photo/$ref" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return MeUpdateRefPhoto.NoContent
             | _ -> return MeUpdateRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
@@ -489,7 +489,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/Me/Photo/$ref" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return MeDeleteRefPhoto.NoContent
             | _ -> return MeDeleteRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
@@ -537,7 +537,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Trips" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeListTrips.OK(Serializer.deserialize content)
             | _ -> return MeListTrips.DefaultResponse(Serializer.deserialize content)
         }
@@ -550,7 +550,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/Me/Trips" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return MeCreateTrips.Created(Serializer.deserialize content)
             | _ -> return MeCreateTrips.DefaultResponse(Serializer.deserialize content)
         }
@@ -572,7 +572,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Trips({TripId})" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeGetTrips.OK(Serializer.deserialize content)
             | _ -> return MeGetTrips.DefaultResponse(Serializer.deserialize content)
         }
@@ -590,7 +590,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/Me/Trips({TripId})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return MeUpdateTrips.NoContent
             | _ -> return MeUpdateTrips.DefaultResponse(Serializer.deserialize content)
         }
@@ -609,7 +609,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/Me/Trips({TripId})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return MeDeleteTrips.NoContent
             | _ -> return MeDeleteTrips.DefaultResponse(Serializer.deserialize content)
         }
@@ -629,7 +629,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
             | _ -> return MeTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
         }
@@ -680,7 +680,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Trips({TripId})/Photos" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeTripsListPhotos.OK(Serializer.deserialize content)
             | _ -> return MeTripsListPhotos.DefaultResponse(Serializer.deserialize content)
         }
@@ -723,7 +723,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Trips({TripId})/Photos/$ref" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeTripsListRefPhotos.OK(Serializer.deserialize content)
             | _ -> return MeTripsListRefPhotos.DefaultResponse(Serializer.deserialize content)
         }
@@ -737,7 +737,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("TripId", tripId) ]
             let! (status, content) = OpenApiHttp.postAsync url "/Me/Trips({TripId})/Photos/$ref" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return MeTripsCreateRefPhotos.Created(Serializer.deserialize content)
             | _ -> return MeTripsCreateRefPhotos.DefaultResponse(Serializer.deserialize content)
         }
@@ -788,7 +788,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Me/Trips({TripId})/PlanItems" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeTripsListPlanItems.OK(Serializer.deserialize content)
             | _ -> return MeTripsListPlanItems.DefaultResponse(Serializer.deserialize content)
         }
@@ -806,7 +806,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.postAsync url "/Me/Trips({TripId})/PlanItems" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return MeTripsCreatePlanItems.Created(Serializer.deserialize content)
             | _ -> return MeTripsCreatePlanItems.DefaultResponse(Serializer.deserialize content)
         }
@@ -831,7 +831,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.getAsync url "/Me/Trips({TripId})/PlanItems({PlanItemId})" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return MeTripsGetPlanItems.OK(Serializer.deserialize content)
             | _ -> return MeTripsGetPlanItems.DefaultResponse(Serializer.deserialize content)
         }
@@ -857,7 +857,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.patchAsync url "/Me/Trips({TripId})/PlanItems({PlanItemId})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return MeTripsUpdatePlanItems.NoContent
             | _ -> return MeTripsUpdatePlanItems.DefaultResponse(Serializer.deserialize content)
         }
@@ -879,7 +879,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync url "/Me/Trips({TripId})/PlanItems({PlanItemId})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return MeTripsDeletePlanItems.NoContent
             | _ -> return MeTripsDeletePlanItems.DefaultResponse(Serializer.deserialize content)
         }
@@ -923,7 +923,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/People" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PeoplePersonListPerson.OK(Serializer.deserialize content)
             | _ -> return PeoplePersonListPerson.DefaultResponse(Serializer.deserialize content)
         }
@@ -936,7 +936,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/People" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return PeoplePersonCreatePerson.Created(Serializer.deserialize content)
             | _ -> return PeoplePersonCreatePerson.DefaultResponse(Serializer.deserialize content)
         }
@@ -955,7 +955,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/People({UserName})" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PeoplePersonGetPerson.OK(Serializer.deserialize content)
             | _ -> return PeoplePersonGetPerson.DefaultResponse(Serializer.deserialize content)
         }
@@ -973,7 +973,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/People({UserName})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PeoplePersonUpdatePerson.NoContent
             | _ -> return PeoplePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
         }
@@ -992,7 +992,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/People({UserName})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PeoplePersonDeletePerson.NoContent
             | _ -> return PeoplePersonDeletePerson.DefaultResponse(Serializer.deserialize content)
         }
@@ -1043,7 +1043,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/People({UserName})/Friends" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PeopleListFriends.OK(Serializer.deserialize content)
             | _ -> return PeopleListFriends.DefaultResponse(Serializer.deserialize content)
         }
@@ -1064,7 +1064,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            match status with
+            match int status with
             | 200 -> return PeoplePersonGetFavoriteAirline.OK(Serializer.deserialize content)
             | _ -> return PeoplePersonGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
         }
@@ -1087,7 +1087,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            match status with
+            match int status with
             | 200 -> return PeoplePersonGetFriendsTrips.OK(Serializer.deserialize content)
             | _ -> return PeoplePersonGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
         }
@@ -1110,7 +1110,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            match status with
+            match int status with
             | 204 -> return PeoplePersonShareTrip.NoContent
             | _ -> return PeoplePersonShareTrip.DefaultResponse(Serializer.deserialize content)
         }
@@ -1133,7 +1133,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
                     headers
                     requestParts
 
-            match status with
+            match int status with
             | 200 -> return PeoplePersonTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
             | _ -> return PeoplePersonTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
         }
@@ -1181,7 +1181,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Photos" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PhotosPhotoListPhoto.OK(Serializer.deserialize content)
             | _ -> return PhotosPhotoListPhoto.DefaultResponse(Serializer.deserialize content)
         }
@@ -1194,7 +1194,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync url "/Photos" headers requestParts
 
-            match status with
+            match int status with
             | 201 -> return PhotosPhotoCreatePhoto.Created(Serializer.deserialize content)
             | _ -> return PhotosPhotoCreatePhoto.DefaultResponse(Serializer.deserialize content)
         }
@@ -1216,7 +1216,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.getAsync url "/Photos({Id})" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PhotosPhotoGetPhoto.OK(Serializer.deserialize content)
             | _ -> return PhotosPhotoGetPhoto.DefaultResponse(Serializer.deserialize content)
         }
@@ -1234,7 +1234,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.patchAsync url "/Photos({Id})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PhotosPhotoUpdatePhoto.NoContent
             | _ -> return PhotosPhotoUpdatePhoto.DefaultResponse(Serializer.deserialize content)
         }
@@ -1253,7 +1253,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.deleteAsync url "/Photos({Id})" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PhotosPhotoDeletePhoto.NoContent
             | _ -> return PhotosPhotoDeletePhoto.DefaultResponse(Serializer.deserialize content)
         }
@@ -1267,7 +1267,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = [ RequestPart.path ("Id", id) ]
             let! (status, contentBinary) = OpenApiHttp.getBinaryAsync url "/Photos({Id})/$value" headers requestParts
 
-            match status with
+            match int status with
             | 200 -> return PhotosPhotoGetContent.OK contentBinary
             | _ ->
                 let! content = Utilities.readBytesAsText contentBinary
@@ -1288,7 +1288,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
 
             let! (status, content) = OpenApiHttp.putAsync url "/Photos({Id})/$value" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return PhotosPhotoUpdateContent.NoContent
             | _ -> return PhotosPhotoUpdateContent.DefaultResponse(Serializer.deserialize content)
         }
@@ -1301,7 +1301,7 @@ type TaskTripPinServiceClient(url: string, headers: list<Header>) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync url "/ResetDataSource" headers requestParts
 
-            match status with
+            match int status with
             | 204 -> return ActionImportResetDataSource.NoContent
             | _ -> return ActionImportResetDataSource.DefaultResponse(Serializer.deserialize content)
         }

--- a/examples/TripPinService/Client.fs
+++ b/examples/TripPinService/Client.fs
@@ -54,10 +54,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Airlines" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return AirlinesAirlineListAirline.OK(Serializer.deserialize content)
-            else
-                return AirlinesAirlineListAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return AirlinesAirlineListAirline.OK(Serializer.deserialize content)
+            | _ -> return AirlinesAirlineListAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -72,10 +71,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/Airlines" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return AirlinesAirlineCreateAirline.Created(Serializer.deserialize content)
-            else
-                return AirlinesAirlineCreateAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return AirlinesAirlineCreateAirline.Created(Serializer.deserialize content)
+            | _ -> return AirlinesAirlineCreateAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -103,10 +101,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Airlines({AirlineCode})" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return AirlinesAirlineGetAirline.OK(Serializer.deserialize content)
-            else
-                return AirlinesAirlineGetAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return AirlinesAirlineGetAirline.OK(Serializer.deserialize content)
+            | _ -> return AirlinesAirlineGetAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -129,10 +126,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/Airlines({AirlineCode})" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return AirlinesAirlineUpdateAirline.NoContent
-            else
-                return AirlinesAirlineUpdateAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return AirlinesAirlineUpdateAirline.NoContent
+            | _ -> return AirlinesAirlineUpdateAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -156,10 +152,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/Airlines({AirlineCode})" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return AirlinesAirlineDeleteAirline.NoContent
-            else
-                return AirlinesAirlineDeleteAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return AirlinesAirlineDeleteAirline.NoContent
+            | _ -> return AirlinesAirlineDeleteAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -207,10 +202,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Airports" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return AirportsAirportListAirport.OK(Serializer.deserialize content)
-            else
-                return AirportsAirportListAirport.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return AirportsAirportListAirport.OK(Serializer.deserialize content)
+            | _ -> return AirportsAirportListAirport.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -238,10 +232,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Airports({IcaoCode})" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return AirportsAirportGetAirport.OK(Serializer.deserialize content)
-            else
-                return AirportsAirportGetAirport.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return AirportsAirportGetAirport.OK(Serializer.deserialize content)
+            | _ -> return AirportsAirportGetAirport.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -264,10 +257,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/Airports({IcaoCode})" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return AirportsAirportUpdateAirport.NoContent
-            else
-                return AirportsAirportUpdateAirport.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return AirportsAirportUpdateAirport.NoContent
+            | _ -> return AirportsAirportUpdateAirport.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -282,10 +274,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/GetNearestAirport(lat={lat},lon={lon})" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FunctionImportGetNearestAirport.OK(Serializer.deserialize content)
-            else
-                return FunctionImportGetNearestAirport.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FunctionImportGetNearestAirport.OK(Serializer.deserialize content)
+            | _ -> return FunctionImportGetNearestAirport.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -304,10 +295,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MePersonGetPerson.OK(Serializer.deserialize content)
-            else
-                return MePersonGetPerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MePersonGetPerson.OK(Serializer.deserialize content)
+            | _ -> return MePersonGetPerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -322,10 +312,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.patchAsync httpClient "/Me" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return MePersonUpdatePerson.NoContent
-            else
-                return MePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return MePersonUpdatePerson.NoContent
+            | _ -> return MePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -373,10 +362,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me/Friends" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeListFriends.OK(Serializer.deserialize content)
-            else
-                return MeListFriends.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeListFriends.OK(Serializer.deserialize content)
+            | _ -> return MeListFriends.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -416,10 +404,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me/Friends/$ref" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeListRefFriends.OK(Serializer.deserialize content)
-            else
-                return MeListRefFriends.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeListRefFriends.OK(Serializer.deserialize content)
+            | _ -> return MeListRefFriends.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -430,10 +417,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync httpClient "/Me/Friends/$ref" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return MeCreateRefFriends.Created(Serializer.deserialize content)
-            else
-                return MeCreateRefFriends.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return MeCreateRefFriends.Created(Serializer.deserialize content)
+            | _ -> return MeCreateRefFriends.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -450,10 +436,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeGetFavoriteAirline.OK(Serializer.deserialize content)
-            else
-                return MeGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeGetFavoriteAirline.OK(Serializer.deserialize content)
+            | _ -> return MeGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -473,10 +458,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeGetFriendsTrips.OK(Serializer.deserialize content)
-            else
-                return MeGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeGetFriendsTrips.OK(Serializer.deserialize content)
+            | _ -> return MeGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -493,10 +477,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return MeShareTrip.NoContent
-            else
-                return MeShareTrip.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return MeShareTrip.NoContent
+            | _ -> return MeShareTrip.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -515,10 +498,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me/Photo" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeGetPhoto.OK(Serializer.deserialize content)
-            else
-                return MeGetPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeGetPhoto.OK(Serializer.deserialize content)
+            | _ -> return MeGetPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -529,10 +511,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me/Photo/$ref" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeGetRefPhoto.OK(Serializer.deserialize content)
-            else
-                return MeGetRefPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeGetRefPhoto.OK(Serializer.deserialize content)
+            | _ -> return MeGetRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -543,10 +524,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.putAsync httpClient "/Me/Photo/$ref" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return MeUpdateRefPhoto.NoContent
-            else
-                return MeUpdateRefPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return MeUpdateRefPhoto.NoContent
+            | _ -> return MeUpdateRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -562,10 +542,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/Me/Photo/$ref" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return MeDeleteRefPhoto.NoContent
-            else
-                return MeDeleteRefPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return MeDeleteRefPhoto.NoContent
+            | _ -> return MeDeleteRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -613,10 +592,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me/Trips" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeListTrips.OK(Serializer.deserialize content)
-            else
-                return MeListTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeListTrips.OK(Serializer.deserialize content)
+            | _ -> return MeListTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -631,10 +609,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/Me/Trips" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return MeCreateTrips.Created(Serializer.deserialize content)
-            else
-                return MeCreateTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return MeCreateTrips.Created(Serializer.deserialize content)
+            | _ -> return MeCreateTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -662,10 +639,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Me/Trips({TripId})" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeGetTrips.OK(Serializer.deserialize content)
-            else
-                return MeGetTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeGetTrips.OK(Serializer.deserialize content)
+            | _ -> return MeGetTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -688,10 +664,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/Me/Trips({TripId})" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return MeUpdateTrips.NoContent
-            else
-                return MeUpdateTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return MeUpdateTrips.NoContent
+            | _ -> return MeUpdateTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -710,10 +685,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/Me/Trips({TripId})" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return MeDeleteTrips.NoContent
-            else
-                return MeDeleteTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return MeDeleteTrips.NoContent
+            | _ -> return MeDeleteTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -732,10 +706,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
-            else
-                return MeTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
+            | _ -> return MeTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -787,10 +760,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Me/Trips({TripId})/Photos" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeTripsListPhotos.OK(Serializer.deserialize content)
-            else
-                return MeTripsListPhotos.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeTripsListPhotos.OK(Serializer.deserialize content)
+            | _ -> return MeTripsListPhotos.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -834,10 +806,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Me/Trips({TripId})/Photos/$ref" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeTripsListRefPhotos.OK(Serializer.deserialize content)
-            else
-                return MeTripsListRefPhotos.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeTripsListRefPhotos.OK(Serializer.deserialize content)
+            | _ -> return MeTripsListRefPhotos.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -852,10 +823,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/Me/Trips({TripId})/Photos/$ref" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return MeTripsCreateRefPhotos.Created(Serializer.deserialize content)
-            else
-                return MeTripsCreateRefPhotos.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return MeTripsCreateRefPhotos.Created(Serializer.deserialize content)
+            | _ -> return MeTripsCreateRefPhotos.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -907,10 +877,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Me/Trips({TripId})/PlanItems" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeTripsListPlanItems.OK(Serializer.deserialize content)
-            else
-                return MeTripsListPlanItems.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeTripsListPlanItems.OK(Serializer.deserialize content)
+            | _ -> return MeTripsListPlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -933,10 +902,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/Me/Trips({TripId})/PlanItems" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return MeTripsCreatePlanItems.Created(Serializer.deserialize content)
-            else
-                return MeTripsCreatePlanItems.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return MeTripsCreatePlanItems.Created(Serializer.deserialize content)
+            | _ -> return MeTripsCreatePlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -971,10 +939,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return MeTripsGetPlanItems.OK(Serializer.deserialize content)
-            else
-                return MeTripsGetPlanItems.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return MeTripsGetPlanItems.OK(Serializer.deserialize content)
+            | _ -> return MeTripsGetPlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1004,10 +971,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return MeTripsUpdatePlanItems.NoContent
-            else
-                return MeTripsUpdatePlanItems.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return MeTripsUpdatePlanItems.NoContent
+            | _ -> return MeTripsUpdatePlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1038,10 +1004,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return MeTripsDeletePlanItems.NoContent
-            else
-                return MeTripsDeletePlanItems.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return MeTripsDeletePlanItems.NoContent
+            | _ -> return MeTripsDeletePlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1085,10 +1050,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/People" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PeoplePersonListPerson.OK(Serializer.deserialize content)
-            else
-                return PeoplePersonListPerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PeoplePersonListPerson.OK(Serializer.deserialize content)
+            | _ -> return PeoplePersonListPerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1103,10 +1067,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/People" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PeoplePersonCreatePerson.Created(Serializer.deserialize content)
-            else
-                return PeoplePersonCreatePerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return PeoplePersonCreatePerson.Created(Serializer.deserialize content)
+            | _ -> return PeoplePersonCreatePerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1125,10 +1088,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/People({UserName})" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PeoplePersonGetPerson.OK(Serializer.deserialize content)
-            else
-                return PeoplePersonGetPerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PeoplePersonGetPerson.OK(Serializer.deserialize content)
+            | _ -> return PeoplePersonGetPerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1151,10 +1113,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/People({UserName})" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PeoplePersonUpdatePerson.NoContent
-            else
-                return PeoplePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return PeoplePersonUpdatePerson.NoContent
+            | _ -> return PeoplePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1173,10 +1134,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/People({UserName})" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PeoplePersonDeletePerson.NoContent
-            else
-                return PeoplePersonDeletePerson.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return PeoplePersonDeletePerson.NoContent
+            | _ -> return PeoplePersonDeletePerson.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1228,10 +1188,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/People({UserName})/Friends" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PeopleListFriends.OK(Serializer.deserialize content)
-            else
-                return PeopleListFriends.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PeopleListFriends.OK(Serializer.deserialize content)
+            | _ -> return PeopleListFriends.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1251,10 +1210,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PeoplePersonGetFavoriteAirline.OK(Serializer.deserialize content)
-            else
-                return PeoplePersonGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PeoplePersonGetFavoriteAirline.OK(Serializer.deserialize content)
+            | _ -> return PeoplePersonGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1281,10 +1239,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PeoplePersonGetFriendsTrips.OK(Serializer.deserialize content)
-            else
-                return PeoplePersonGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PeoplePersonGetFriendsTrips.OK(Serializer.deserialize content)
+            | _ -> return PeoplePersonGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1311,10 +1268,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PeoplePersonShareTrip.NoContent
-            else
-                return PeoplePersonShareTrip.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return PeoplePersonShareTrip.NoContent
+            | _ -> return PeoplePersonShareTrip.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1341,10 +1297,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PeoplePersonTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
-            else
-                return PeoplePersonTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PeoplePersonTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
+            | _ -> return PeoplePersonTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1392,10 +1347,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Photos" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PhotosPhotoListPhoto.OK(Serializer.deserialize content)
-            else
-                return PhotosPhotoListPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PhotosPhotoListPhoto.OK(Serializer.deserialize content)
+            | _ -> return PhotosPhotoListPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1410,10 +1364,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/Photos" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PhotosPhotoCreatePhoto.Created(Serializer.deserialize content)
-            else
-                return PhotosPhotoCreatePhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return PhotosPhotoCreatePhoto.Created(Serializer.deserialize content)
+            | _ -> return PhotosPhotoCreatePhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1440,10 +1393,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Photos({Id})" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PhotosPhotoGetPhoto.OK(Serializer.deserialize content)
-            else
-                return PhotosPhotoGetPhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return PhotosPhotoGetPhoto.OK(Serializer.deserialize content)
+            | _ -> return PhotosPhotoGetPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1465,10 +1417,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.patchAsync httpClient "/Photos({Id})" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PhotosPhotoUpdatePhoto.NoContent
-            else
-                return PhotosPhotoUpdatePhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return PhotosPhotoUpdatePhoto.NoContent
+            | _ -> return PhotosPhotoUpdatePhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1486,10 +1437,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/Photos({Id})" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PhotosPhotoDeletePhoto.NoContent
-            else
-                return PhotosPhotoDeletePhoto.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return PhotosPhotoDeletePhoto.NoContent
+            | _ -> return PhotosPhotoDeletePhoto.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1504,9 +1454,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/Photos({Id})/$value" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PhotosPhotoGetContent.OK contentBinary
-            else
+            match status with
+            | HttpStatusCode.OK -> return PhotosPhotoGetContent.OK contentBinary
+            | _ ->
                 let content = Encoding.UTF8.GetString contentBinary
                 return PhotosPhotoGetContent.DefaultResponse(Serializer.deserialize content)
         }
@@ -1527,10 +1477,9 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/Photos({Id})/$value" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return PhotosPhotoUpdateContent.NoContent
-            else
-                return PhotosPhotoUpdateContent.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return PhotosPhotoUpdateContent.NoContent
+            | _ -> return PhotosPhotoUpdateContent.DefaultResponse(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1541,8 +1490,7 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync httpClient "/ResetDataSource" requestParts cancellationToken
 
-            if status = HttpStatusCode.NoContent then
-                return ActionImportResetDataSource.NoContent
-            else
-                return ActionImportResetDataSource.DefaultResponse(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.NoContent -> return ActionImportResetDataSource.NoContent
+            | _ -> return ActionImportResetDataSource.DefaultResponse(Serializer.deserialize content)
         }

--- a/examples/TripPinService/Client.fs
+++ b/examples/TripPinService/Client.fs
@@ -54,8 +54,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Airlines" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return AirlinesAirlineListAirline.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return AirlinesAirlineListAirline.OK(Serializer.deserialize content)
             | _ -> return AirlinesAirlineListAirline.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -71,8 +71,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/Airlines" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return AirlinesAirlineCreateAirline.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return AirlinesAirlineCreateAirline.Created(Serializer.deserialize content)
             | _ -> return AirlinesAirlineCreateAirline.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -101,8 +101,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Airlines({AirlineCode})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return AirlinesAirlineGetAirline.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return AirlinesAirlineGetAirline.OK(Serializer.deserialize content)
             | _ -> return AirlinesAirlineGetAirline.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -126,8 +126,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/Airlines({AirlineCode})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return AirlinesAirlineUpdateAirline.NoContent
+            match int status with
+            | 204 -> return AirlinesAirlineUpdateAirline.NoContent
             | _ -> return AirlinesAirlineUpdateAirline.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -152,8 +152,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/Airlines({AirlineCode})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return AirlinesAirlineDeleteAirline.NoContent
+            match int status with
+            | 204 -> return AirlinesAirlineDeleteAirline.NoContent
             | _ -> return AirlinesAirlineDeleteAirline.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -202,8 +202,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Airports" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return AirportsAirportListAirport.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return AirportsAirportListAirport.OK(Serializer.deserialize content)
             | _ -> return AirportsAirportListAirport.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -232,8 +232,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Airports({IcaoCode})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return AirportsAirportGetAirport.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return AirportsAirportGetAirport.OK(Serializer.deserialize content)
             | _ -> return AirportsAirportGetAirport.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -257,8 +257,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/Airports({IcaoCode})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return AirportsAirportUpdateAirport.NoContent
+            match int status with
+            | 204 -> return AirportsAirportUpdateAirport.NoContent
             | _ -> return AirportsAirportUpdateAirport.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -274,8 +274,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/GetNearestAirport(lat={lat},lon={lon})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FunctionImportGetNearestAirport.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FunctionImportGetNearestAirport.OK(Serializer.deserialize content)
             | _ -> return FunctionImportGetNearestAirport.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -295,8 +295,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MePersonGetPerson.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MePersonGetPerson.OK(Serializer.deserialize content)
             | _ -> return MePersonGetPerson.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -312,8 +312,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.patchAsync httpClient "/Me" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return MePersonUpdatePerson.NoContent
+            match int status with
+            | 204 -> return MePersonUpdatePerson.NoContent
             | _ -> return MePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -362,8 +362,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me/Friends" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeListFriends.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeListFriends.OK(Serializer.deserialize content)
             | _ -> return MeListFriends.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -404,8 +404,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me/Friends/$ref" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeListRefFriends.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeListRefFriends.OK(Serializer.deserialize content)
             | _ -> return MeListRefFriends.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -417,8 +417,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync httpClient "/Me/Friends/$ref" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return MeCreateRefFriends.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return MeCreateRefFriends.Created(Serializer.deserialize content)
             | _ -> return MeCreateRefFriends.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -436,8 +436,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeGetFavoriteAirline.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeGetFavoriteAirline.OK(Serializer.deserialize content)
             | _ -> return MeGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -458,8 +458,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeGetFriendsTrips.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeGetFriendsTrips.OK(Serializer.deserialize content)
             | _ -> return MeGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -477,8 +477,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return MeShareTrip.NoContent
+            match int status with
+            | 204 -> return MeShareTrip.NoContent
             | _ -> return MeShareTrip.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -498,8 +498,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me/Photo" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeGetPhoto.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeGetPhoto.OK(Serializer.deserialize content)
             | _ -> return MeGetPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -511,8 +511,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me/Photo/$ref" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeGetRefPhoto.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeGetRefPhoto.OK(Serializer.deserialize content)
             | _ -> return MeGetRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -524,8 +524,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.putAsync httpClient "/Me/Photo/$ref" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return MeUpdateRefPhoto.NoContent
+            match int status with
+            | 204 -> return MeUpdateRefPhoto.NoContent
             | _ -> return MeUpdateRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -542,8 +542,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/Me/Photo/$ref" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return MeDeleteRefPhoto.NoContent
+            match int status with
+            | 204 -> return MeDeleteRefPhoto.NoContent
             | _ -> return MeDeleteRefPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -592,8 +592,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Me/Trips" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeListTrips.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeListTrips.OK(Serializer.deserialize content)
             | _ -> return MeListTrips.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -609,8 +609,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/Me/Trips" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return MeCreateTrips.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return MeCreateTrips.Created(Serializer.deserialize content)
             | _ -> return MeCreateTrips.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -639,8 +639,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Me/Trips({TripId})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeGetTrips.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeGetTrips.OK(Serializer.deserialize content)
             | _ -> return MeGetTrips.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -664,8 +664,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/Me/Trips({TripId})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return MeUpdateTrips.NoContent
+            match int status with
+            | 204 -> return MeUpdateTrips.NoContent
             | _ -> return MeUpdateTrips.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -685,8 +685,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/Me/Trips({TripId})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return MeDeleteTrips.NoContent
+            match int status with
+            | 204 -> return MeDeleteTrips.NoContent
             | _ -> return MeDeleteTrips.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -706,8 +706,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
             | _ -> return MeTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -760,8 +760,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Me/Trips({TripId})/Photos" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeTripsListPhotos.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeTripsListPhotos.OK(Serializer.deserialize content)
             | _ -> return MeTripsListPhotos.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -806,8 +806,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Me/Trips({TripId})/Photos/$ref" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeTripsListRefPhotos.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeTripsListRefPhotos.OK(Serializer.deserialize content)
             | _ -> return MeTripsListRefPhotos.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -823,8 +823,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/Me/Trips({TripId})/Photos/$ref" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return MeTripsCreateRefPhotos.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return MeTripsCreateRefPhotos.Created(Serializer.deserialize content)
             | _ -> return MeTripsCreateRefPhotos.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -877,8 +877,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/Me/Trips({TripId})/PlanItems" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeTripsListPlanItems.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeTripsListPlanItems.OK(Serializer.deserialize content)
             | _ -> return MeTripsListPlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -902,8 +902,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/Me/Trips({TripId})/PlanItems" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return MeTripsCreatePlanItems.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return MeTripsCreatePlanItems.Created(Serializer.deserialize content)
             | _ -> return MeTripsCreatePlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -939,8 +939,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return MeTripsGetPlanItems.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return MeTripsGetPlanItems.OK(Serializer.deserialize content)
             | _ -> return MeTripsGetPlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -971,8 +971,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return MeTripsUpdatePlanItems.NoContent
+            match int status with
+            | 204 -> return MeTripsUpdatePlanItems.NoContent
             | _ -> return MeTripsUpdatePlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1004,8 +1004,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return MeTripsDeletePlanItems.NoContent
+            match int status with
+            | 204 -> return MeTripsDeletePlanItems.NoContent
             | _ -> return MeTripsDeletePlanItems.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1050,8 +1050,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/People" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PeoplePersonListPerson.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PeoplePersonListPerson.OK(Serializer.deserialize content)
             | _ -> return PeoplePersonListPerson.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1067,8 +1067,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/People" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PeoplePersonCreatePerson.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PeoplePersonCreatePerson.Created(Serializer.deserialize content)
             | _ -> return PeoplePersonCreatePerson.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1088,8 +1088,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/People({UserName})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PeoplePersonGetPerson.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PeoplePersonGetPerson.OK(Serializer.deserialize content)
             | _ -> return PeoplePersonGetPerson.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1113,8 +1113,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/People({UserName})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PeoplePersonUpdatePerson.NoContent
+            match int status with
+            | 204 -> return PeoplePersonUpdatePerson.NoContent
             | _ -> return PeoplePersonUpdatePerson.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1134,8 +1134,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/People({UserName})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PeoplePersonDeletePerson.NoContent
+            match int status with
+            | 204 -> return PeoplePersonDeletePerson.NoContent
             | _ -> return PeoplePersonDeletePerson.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1188,8 +1188,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/People({UserName})/Friends" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PeopleListFriends.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PeopleListFriends.OK(Serializer.deserialize content)
             | _ -> return PeopleListFriends.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1210,8 +1210,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PeoplePersonGetFavoriteAirline.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PeoplePersonGetFavoriteAirline.OK(Serializer.deserialize content)
             | _ -> return PeoplePersonGetFavoriteAirline.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1239,8 +1239,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PeoplePersonGetFriendsTrips.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PeoplePersonGetFriendsTrips.OK(Serializer.deserialize content)
             | _ -> return PeoplePersonGetFriendsTrips.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1268,8 +1268,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PeoplePersonShareTrip.NoContent
+            match int status with
+            | 204 -> return PeoplePersonShareTrip.NoContent
             | _ -> return PeoplePersonShareTrip.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1297,8 +1297,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
                     requestParts
                     cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PeoplePersonTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PeoplePersonTripsTripGetInvolvedPeople.OK(Serializer.deserialize content)
             | _ -> return PeoplePersonTripsTripGetInvolvedPeople.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1347,8 +1347,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Photos" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PhotosPhotoListPhoto.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PhotosPhotoListPhoto.OK(Serializer.deserialize content)
             | _ -> return PhotosPhotoListPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1364,8 +1364,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/Photos" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PhotosPhotoCreatePhoto.Created(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PhotosPhotoCreatePhoto.Created(Serializer.deserialize content)
             | _ -> return PhotosPhotoCreatePhoto.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1393,8 +1393,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/Photos({Id})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PhotosPhotoGetPhoto.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PhotosPhotoGetPhoto.OK(Serializer.deserialize content)
             | _ -> return PhotosPhotoGetPhoto.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1417,8 +1417,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.patchAsync httpClient "/Photos({Id})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PhotosPhotoUpdatePhoto.NoContent
+            match int status with
+            | 204 -> return PhotosPhotoUpdatePhoto.NoContent
             | _ -> return PhotosPhotoUpdatePhoto.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1437,8 +1437,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/Photos({Id})" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PhotosPhotoDeletePhoto.NoContent
+            match int status with
+            | 204 -> return PhotosPhotoDeletePhoto.NoContent
             | _ -> return PhotosPhotoDeletePhoto.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1454,8 +1454,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/Photos({Id})/$value" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PhotosPhotoGetContent.OK contentBinary
+            match int status with
+            | 200 -> return PhotosPhotoGetContent.OK contentBinary
             | _ ->
                 let content = Encoding.UTF8.GetString contentBinary
                 return PhotosPhotoGetContent.DefaultResponse(Serializer.deserialize content)
@@ -1477,8 +1477,8 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.putAsync httpClient "/Photos({Id})/$value" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return PhotosPhotoUpdateContent.NoContent
+            match int status with
+            | 204 -> return PhotosPhotoUpdateContent.NoContent
             | _ -> return PhotosPhotoUpdateContent.DefaultResponse(Serializer.deserialize content)
         }
 
@@ -1490,7 +1490,7 @@ type TripPinServiceClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.postAsync httpClient "/ResetDataSource" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.NoContent -> return ActionImportResetDataSource.NoContent
+            match int status with
+            | 204 -> return ActionImportResetDataSource.NoContent
             | _ -> return ActionImportResetDataSource.DefaultResponse(Serializer.deserialize content)
         }

--- a/examples/Twinehealth/Client.fs
+++ b/examples/Twinehealth/Client.fs
@@ -52,10 +52,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/action" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return CreateAction.Created(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return CreateAction.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreateAction.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 201 -> return CreateAction.Created(Serializer.deserialize content)
+            | 401 -> return CreateAction.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateAction.Forbidden(Serializer.deserialize content)
             | _ -> return CreateAction.Conflict(Serializer.deserialize content)
         }
 
@@ -69,9 +69,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/action/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchAction.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchAction.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchAction.OK(Serializer.deserialize content)
+            | 401 -> return FetchAction.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchAction.Forbidden(Serializer.deserialize content)
         }
 
@@ -89,10 +89,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.patchAsync httpClient "/action/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateAction.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return UpdateAction.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return UpdateAction.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return UpdateAction.OK(Serializer.deserialize content)
+            | 401 -> return UpdateAction.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpdateAction.Forbidden(Serializer.deserialize content)
             | _ -> return UpdateAction.Conflict(Serializer.deserialize content)
         }
 
@@ -104,10 +104,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/bundle" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateBundle.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return CreateBundle.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreateBundle.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return CreateBundle.OK(Serializer.deserialize content)
+            | 401 -> return CreateBundle.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateBundle.Forbidden(Serializer.deserialize content)
             | _ -> return CreateBundle.Conflict(Serializer.deserialize content)
         }
 
@@ -121,9 +121,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/bundle/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchBundle.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchBundle.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchBundle.OK(Serializer.deserialize content)
+            | 401 -> return FetchBundle.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchBundle.Forbidden(Serializer.deserialize content)
         }
 
@@ -141,10 +141,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.patchAsync httpClient "/bundle/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateBundle.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return UpdateBundle.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return UpdateBundle.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return UpdateBundle.OK(Serializer.deserialize content)
+            | 401 -> return UpdateBundle.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpdateBundle.Forbidden(Serializer.deserialize content)
             | _ -> return UpdateBundle.Conflict(Serializer.deserialize content)
         }
 
@@ -225,10 +225,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/calendar_event" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchCalendarEvents.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchCalendarEvents.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return FetchCalendarEvents.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchCalendarEvents.OK(Serializer.deserialize content)
+            | 401 -> return FetchCalendarEvents.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchCalendarEvents.Forbidden(Serializer.deserialize content)
             | _ -> return FetchCalendarEvents.Conflict(Serializer.deserialize content)
         }
 
@@ -240,10 +240,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/calendar_event" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return CreateCalendarEvent.Created(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return CreateCalendarEvent.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreateCalendarEvent.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 201 -> return CreateCalendarEvent.Created(Serializer.deserialize content)
+            | 401 -> return CreateCalendarEvent.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateCalendarEvent.Forbidden(Serializer.deserialize content)
             | _ -> return CreateCalendarEvent.Conflict(Serializer.deserialize content)
         }
 
@@ -259,9 +259,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/calendar_event/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteCalendarEvent.OK
-            | HttpStatusCode.Unauthorized -> return DeleteCalendarEvent.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return DeleteCalendarEvent.OK
+            | 401 -> return DeleteCalendarEvent.Unauthorized(Serializer.deserialize content)
             | _ -> return DeleteCalendarEvent.Forbidden(Serializer.deserialize content)
         }
 
@@ -277,9 +277,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/calendar_event/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchCalendarEvent.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchCalendarEvent.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchCalendarEvent.OK(Serializer.deserialize content)
+            | 401 -> return FetchCalendarEvent.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchCalendarEvent.Forbidden(Serializer.deserialize content)
         }
 
@@ -303,10 +303,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/calendar_event/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateCalendarEvent.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return UpdateCalendarEvent.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return UpdateCalendarEvent.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return UpdateCalendarEvent.OK(Serializer.deserialize content)
+            | 401 -> return UpdateCalendarEvent.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpdateCalendarEvent.Forbidden(Serializer.deserialize content)
             | _ -> return UpdateCalendarEvent.Conflict(Serializer.deserialize content)
         }
 
@@ -324,12 +324,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/calendar_event_response" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return PostCreateCalendarEventResponse.Created(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return PostCreateCalendarEventResponse.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden ->
-                return PostCreateCalendarEventResponse.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 201 -> return PostCreateCalendarEventResponse.Created(Serializer.deserialize content)
+            | 401 -> return PostCreateCalendarEventResponse.Unauthorized(Serializer.deserialize content)
+            | 403 -> return PostCreateCalendarEventResponse.Forbidden(Serializer.deserialize content)
             | _ -> return PostCreateCalendarEventResponse.Conflict(Serializer.deserialize content)
         }
 
@@ -354,9 +352,9 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/coach" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchCoaches.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchCoaches.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchCoaches.OK(Serializer.deserialize content)
+            | 401 -> return FetchCoaches.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchCoaches.Forbidden(Serializer.deserialize content)
         }
 
@@ -370,9 +368,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/coach/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchCoach.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchCoach.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchCoach.OK(Serializer.deserialize content)
+            | 401 -> return FetchCoach.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchCoach.Forbidden(Serializer.deserialize content)
         }
 
@@ -409,10 +407,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/email_history" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchEmailHistories.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchEmailHistories.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return FetchEmailHistories.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchEmailHistories.OK(Serializer.deserialize content)
+            | 401 -> return FetchEmailHistories.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchEmailHistories.Forbidden(Serializer.deserialize content)
             | _ -> return FetchEmailHistories.Conflict(Serializer.deserialize content)
         }
 
@@ -428,9 +426,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/email_history/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchEmailHistory.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchEmailHistory.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchEmailHistory.OK(Serializer.deserialize content)
+            | 401 -> return FetchEmailHistory.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchEmailHistory.Forbidden(Serializer.deserialize content)
         }
 
@@ -449,9 +447,9 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/group" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchGroups.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchGroups.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchGroups.OK(Serializer.deserialize content)
+            | 401 -> return FetchGroups.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchGroups.Forbidden(Serializer.deserialize content)
         }
 
@@ -463,10 +461,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/group" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return CreateGroup.Created(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return CreateGroup.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreateGroup.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 201 -> return CreateGroup.Created(Serializer.deserialize content)
+            | 401 -> return CreateGroup.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateGroup.Forbidden(Serializer.deserialize content)
             | _ -> return CreateGroup.Conflict(Serializer.deserialize content)
         }
 
@@ -480,9 +478,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/group/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchGroup.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchGroup.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchGroup.OK(Serializer.deserialize content)
+            | 401 -> return FetchGroup.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchGroup.Forbidden(Serializer.deserialize content)
         }
 
@@ -531,10 +529,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/health_profile" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchHealthProfiles.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchHealthProfiles.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return FetchHealthProfiles.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchHealthProfiles.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfiles.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchHealthProfiles.Forbidden(Serializer.deserialize content)
             | _ -> return FetchHealthProfiles.Conflict(Serializer.deserialize content)
         }
 
@@ -554,9 +552,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_profile/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchHealthProfile.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchHealthProfile.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchHealthProfile.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfile.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchHealthProfile.Forbidden(Serializer.deserialize content)
         }
 
@@ -606,11 +604,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_profile_answer" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchHealthProfileAnswers.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchHealthProfileAnswers.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return FetchHealthProfileAnswers.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchHealthProfileAnswers.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfileAnswers.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchHealthProfileAnswers.Forbidden(Serializer.deserialize content)
             | _ -> return FetchHealthProfileAnswers.Conflict(Serializer.deserialize content)
         }
 
@@ -630,10 +627,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_profile_answer/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchHealthProfileAnswer.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchHealthProfileAnswer.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchHealthProfileAnswer.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfileAnswer.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchHealthProfileAnswer.Forbidden(Serializer.deserialize content)
         }
 
@@ -667,11 +663,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_profile_question" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchHealthProfileQuestions.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchHealthProfileQuestions.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return FetchHealthProfileQuestions.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchHealthProfileQuestions.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfileQuestions.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchHealthProfileQuestions.Forbidden(Serializer.deserialize content)
             | _ -> return FetchHealthProfileQuestions.Conflict(Serializer.deserialize content)
         }
 
@@ -691,10 +686,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_profile_question/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchHealthProfileQuestion.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchHealthProfileQuestion.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchHealthProfileQuestion.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthProfileQuestion.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchHealthProfileQuestion.Forbidden(Serializer.deserialize content)
         }
 
@@ -708,12 +702,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_question_definition" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchHealthQuestionDefinitions.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchHealthQuestionDefinitions.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden ->
-                return FetchHealthQuestionDefinitions.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchHealthQuestionDefinitions.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthQuestionDefinitions.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchHealthQuestionDefinitions.Forbidden(Serializer.deserialize content)
             | _ -> return FetchHealthQuestionDefinitions.Conflict(Serializer.deserialize content)
         }
 
@@ -729,10 +721,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_question_definition/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchHealthQuestionDefinition.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchHealthQuestionDefinition.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchHealthQuestionDefinition.OK(Serializer.deserialize content)
+            | 401 -> return FetchHealthQuestionDefinition.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchHealthQuestionDefinition.Forbidden(Serializer.deserialize content)
         }
 
@@ -762,10 +753,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/oauth/token" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return CreateToken.Created(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return CreateToken.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreateToken.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 201 -> return CreateToken.Created(Serializer.deserialize content)
+            | 401 -> return CreateToken.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateToken.Forbidden(Serializer.deserialize content)
             | _ -> return CreateToken.Conflict(Serializer.deserialize content)
         }
 
@@ -781,9 +772,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/oauth/token/{id}/groups" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchTokenGroups.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchTokenGroups.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchTokenGroups.OK(Serializer.deserialize content)
+            | 401 -> return FetchTokenGroups.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchTokenGroups.Forbidden(Serializer.deserialize content)
         }
 
@@ -799,9 +790,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/oauth/token/{id}/organization" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchTokenOrganization.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchTokenOrganization.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchTokenOrganization.OK(Serializer.deserialize content)
+            | 401 -> return FetchTokenOrganization.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchTokenOrganization.Forbidden(Serializer.deserialize content)
         }
 
@@ -815,9 +806,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/organization/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchOrganization.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchOrganization.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchOrganization.OK(Serializer.deserialize content)
+            | 401 -> return FetchOrganization.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchOrganization.Forbidden(Serializer.deserialize content)
         }
 
@@ -878,10 +869,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/patient" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchPatients.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchPatients.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return FetchPatients.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchPatients.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatients.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchPatients.Forbidden(Serializer.deserialize content)
             | _ -> return FetchPatients.Conflict(Serializer.deserialize content)
         }
 
@@ -920,10 +911,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/patient" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.Created -> return CreatePatient.Created(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return CreatePatient.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreatePatient.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 201 -> return CreatePatient.Created(Serializer.deserialize content)
+            | 401 -> return CreatePatient.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreatePatient.Forbidden(Serializer.deserialize content)
             | _ -> return CreatePatient.Conflict(Serializer.deserialize content)
         }
 
@@ -935,10 +926,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/patient" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpsertPatient.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return UpsertPatient.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return UpsertPatient.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return UpsertPatient.OK(Serializer.deserialize content)
+            | 401 -> return UpsertPatient.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpsertPatient.Forbidden(Serializer.deserialize content)
             | _ -> return UpsertPatient.Conflict(Serializer.deserialize content)
         }
 
@@ -952,9 +943,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/patient/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchPatient.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchPatient.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchPatient.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatient.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatient.Forbidden(Serializer.deserialize content)
         }
 
@@ -972,10 +963,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.patchAsync httpClient "/patient/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdatePatient.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return UpdatePatient.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return UpdatePatient.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return UpdatePatient.OK(Serializer.deserialize content)
+            | 401 -> return UpdatePatient.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpdatePatient.Forbidden(Serializer.deserialize content)
             | _ -> return UpdatePatient.Conflict(Serializer.deserialize content)
         }
 
@@ -991,9 +982,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient/{id}/coaches" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchPatientCoaches.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchPatientCoaches.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchPatientCoaches.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientCoaches.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientCoaches.Forbidden(Serializer.deserialize content)
         }
 
@@ -1009,9 +1000,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient/{id}/groups" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchPatientGroups.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchPatientGroups.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchPatientGroups.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientGroups.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientGroups.Forbidden(Serializer.deserialize content)
         }
 
@@ -1057,11 +1048,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient_health_metric" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchPatientHealthMetrics.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchPatientHealthMetrics.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return FetchPatientHealthMetrics.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchPatientHealthMetrics.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientHealthMetrics.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchPatientHealthMetrics.Forbidden(Serializer.deserialize content)
             | _ -> return FetchPatientHealthMetrics.Conflict(Serializer.deserialize content)
         }
 
@@ -1113,11 +1103,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/patient_health_metric" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreatePatientHealthMetric.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return CreatePatientHealthMetric.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreatePatientHealthMetric.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return CreatePatientHealthMetric.OK(Serializer.deserialize content)
+            | 401 -> return CreatePatientHealthMetric.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreatePatientHealthMetric.Forbidden(Serializer.deserialize content)
             | _ -> return CreatePatientHealthMetric.Conflict(Serializer.deserialize content)
         }
 
@@ -1133,10 +1122,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient_health_metric/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchPatientHealthMetric.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchPatientHealthMetric.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchPatientHealthMetric.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientHealthMetric.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientHealthMetric.Forbidden(Serializer.deserialize content)
         }
 
@@ -1170,10 +1158,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient_plan_summary" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchPatientPlanSummaries.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchPatientPlanSummaries.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchPatientPlanSummaries.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientPlanSummaries.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientPlanSummaries.Forbidden(Serializer.deserialize content)
         }
 
@@ -1193,9 +1180,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient_plan_summary/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchPatientPlanSummary.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchPatientPlanSummary.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchPatientPlanSummary.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientPlanSummary.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientPlanSummary.Forbidden(Serializer.deserialize content)
         }
 
@@ -1219,11 +1206,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/patient_plan_summary/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdatePatientPlanSummary.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return UpdatePatientPlanSummary.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return UpdatePatientPlanSummary.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return UpdatePatientPlanSummary.OK(Serializer.deserialize content)
+            | 401 -> return UpdatePatientPlanSummary.Unauthorized(Serializer.deserialize content)
+            | 403 -> return UpdatePatientPlanSummary.Forbidden(Serializer.deserialize content)
             | _ -> return UpdatePatientPlanSummary.Conflict(Serializer.deserialize content)
         }
 
@@ -1283,11 +1269,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/result" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchPatientHealthResults.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchPatientHealthResults.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return FetchPatientHealthResults.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchPatientHealthResults.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientHealthResults.Unauthorized(Serializer.deserialize content)
+            | 403 -> return FetchPatientHealthResults.Forbidden(Serializer.deserialize content)
             | _ -> return FetchPatientHealthResults.Conflict(Serializer.deserialize content)
         }
 
@@ -1301,10 +1286,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/result/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchPatientHealthResult.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchPatientHealthResult.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchPatientHealthResult.OK(Serializer.deserialize content)
+            | 401 -> return FetchPatientHealthResult.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchPatientHealthResult.Forbidden(Serializer.deserialize content)
         }
 
@@ -1341,9 +1325,9 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reward" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchRewards.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchRewards.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchRewards.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewards.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewards.Forbidden(Serializer.deserialize content)
         }
 
@@ -1355,10 +1339,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/reward" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateReward.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return CreateReward.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreateReward.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return CreateReward.OK(Serializer.deserialize content)
+            | 401 -> return CreateReward.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateReward.Forbidden(Serializer.deserialize content)
             | _ -> return CreateReward.Conflict(Serializer.deserialize content)
         }
 
@@ -1372,9 +1356,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reward/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchReward.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchReward.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchReward.OK(Serializer.deserialize content)
+            | 401 -> return FetchReward.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchReward.Forbidden(Serializer.deserialize content)
         }
 
@@ -1401,9 +1385,9 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reward_earning" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchRewardEarnings.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchRewardEarnings.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchRewardEarnings.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardEarnings.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardEarnings.Forbidden(Serializer.deserialize content)
         }
 
@@ -1415,10 +1399,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/reward_earning" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateRewardEarning.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return CreateRewardEarning.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreateRewardEarning.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return CreateRewardEarning.OK(Serializer.deserialize content)
+            | 401 -> return CreateRewardEarning.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateRewardEarning.Forbidden(Serializer.deserialize content)
             | _ -> return CreateRewardEarning.Conflict(Serializer.deserialize content)
         }
 
@@ -1434,9 +1418,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_earning/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchRewardEarning.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchRewardEarning.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchRewardEarning.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardEarning.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardEarning.Forbidden(Serializer.deserialize content)
         }
 
@@ -1453,10 +1437,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_earning_fulfillment" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchRewardEarningFulfillments.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchRewardEarningFulfillments.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchRewardEarningFulfillments.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardEarningFulfillments.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardEarningFulfillments.Forbidden(Serializer.deserialize content)
         }
 
@@ -1474,12 +1457,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/reward_earning_fulfillment" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateRewardEarningFulfillment.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return CreateRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden ->
-                return CreateRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return CreateRewardEarningFulfillment.OK(Serializer.deserialize content)
+            | 401 -> return CreateRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
             | _ -> return CreateRewardEarningFulfillment.Conflict(Serializer.deserialize content)
         }
 
@@ -1495,10 +1476,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_earning_fulfillment/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchRewardEarningFulfillment.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchRewardEarningFulfillment.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
         }
 
@@ -1523,9 +1503,9 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reward_program" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchRewardPrograms.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchRewardPrograms.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchRewardPrograms.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardPrograms.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardPrograms.Forbidden(Serializer.deserialize content)
         }
 
@@ -1537,10 +1517,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/reward_program" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateRewardProgram.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return CreateRewardProgram.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreateRewardProgram.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return CreateRewardProgram.OK(Serializer.deserialize content)
+            | 401 -> return CreateRewardProgram.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateRewardProgram.Forbidden(Serializer.deserialize content)
             | _ -> return CreateRewardProgram.Conflict(Serializer.deserialize content)
         }
 
@@ -1556,9 +1536,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_program/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchRewardProgram.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchRewardProgram.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchRewardProgram.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardProgram.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardProgram.Forbidden(Serializer.deserialize content)
         }
 
@@ -1574,9 +1554,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_program/{id}/group" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchRewardProgramGroup.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized -> return FetchRewardProgramGroup.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchRewardProgramGroup.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardProgramGroup.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardProgramGroup.Forbidden(Serializer.deserialize content)
         }
 
@@ -1606,10 +1586,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_program_activation" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchRewardProgramActivations.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchRewardProgramActivations.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchRewardProgramActivations.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardProgramActivations.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardProgramActivations.Forbidden(Serializer.deserialize content)
         }
 
@@ -1627,11 +1606,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/reward_program_activation" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateRewardProgramActivation.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return CreateRewardProgramActivation.Unauthorized(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return CreateRewardProgramActivation.Forbidden(Serializer.deserialize content)
+            match int status with
+            | 200 -> return CreateRewardProgramActivation.OK(Serializer.deserialize content)
+            | 401 -> return CreateRewardProgramActivation.Unauthorized(Serializer.deserialize content)
+            | 403 -> return CreateRewardProgramActivation.Forbidden(Serializer.deserialize content)
             | _ -> return CreateRewardProgramActivation.Conflict(Serializer.deserialize content)
         }
 
@@ -1647,9 +1625,8 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_program_activation/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FetchRewardProgramActivation.OK(Serializer.deserialize content)
-            | HttpStatusCode.Unauthorized ->
-                return FetchRewardProgramActivation.Unauthorized(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FetchRewardProgramActivation.OK(Serializer.deserialize content)
+            | 401 -> return FetchRewardProgramActivation.Unauthorized(Serializer.deserialize content)
             | _ -> return FetchRewardProgramActivation.Forbidden(Serializer.deserialize content)
         }

--- a/examples/Twinehealth/Client.fs
+++ b/examples/Twinehealth/Client.fs
@@ -52,14 +52,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/action" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return CreateAction.Created(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return CreateAction.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreateAction.Forbidden(Serializer.deserialize content)
-            else
-                return CreateAction.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return CreateAction.Created(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return CreateAction.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreateAction.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateAction.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -72,12 +69,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/action/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchAction.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchAction.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchAction.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchAction.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchAction.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchAction.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -94,14 +89,11 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.patchAsync httpClient "/action/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateAction.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return UpdateAction.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return UpdateAction.Forbidden(Serializer.deserialize content)
-            else
-                return UpdateAction.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return UpdateAction.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return UpdateAction.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return UpdateAction.Forbidden(Serializer.deserialize content)
+            | _ -> return UpdateAction.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -112,14 +104,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/bundle" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateBundle.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return CreateBundle.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreateBundle.Forbidden(Serializer.deserialize content)
-            else
-                return CreateBundle.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return CreateBundle.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return CreateBundle.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreateBundle.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateBundle.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -132,12 +121,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/bundle/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchBundle.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchBundle.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchBundle.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchBundle.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchBundle.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchBundle.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -154,14 +141,11 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.patchAsync httpClient "/bundle/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateBundle.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return UpdateBundle.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return UpdateBundle.Forbidden(Serializer.deserialize content)
-            else
-                return UpdateBundle.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return UpdateBundle.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return UpdateBundle.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return UpdateBundle.Forbidden(Serializer.deserialize content)
+            | _ -> return UpdateBundle.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -241,14 +225,11 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/calendar_event" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchCalendarEvents.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchCalendarEvents.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return FetchCalendarEvents.Forbidden(Serializer.deserialize content)
-            else
-                return FetchCalendarEvents.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchCalendarEvents.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchCalendarEvents.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return FetchCalendarEvents.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchCalendarEvents.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -259,14 +240,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/calendar_event" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return CreateCalendarEvent.Created(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return CreateCalendarEvent.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreateCalendarEvent.Forbidden(Serializer.deserialize content)
-            else
-                return CreateCalendarEvent.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return CreateCalendarEvent.Created(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return CreateCalendarEvent.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreateCalendarEvent.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateCalendarEvent.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -281,12 +259,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/calendar_event/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteCalendarEvent.OK
-            else if status = HttpStatusCode.Unauthorized then
-                return DeleteCalendarEvent.Unauthorized(Serializer.deserialize content)
-            else
-                return DeleteCalendarEvent.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return DeleteCalendarEvent.OK
+            | HttpStatusCode.Unauthorized -> return DeleteCalendarEvent.Unauthorized(Serializer.deserialize content)
+            | _ -> return DeleteCalendarEvent.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -301,12 +277,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/calendar_event/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchCalendarEvent.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchCalendarEvent.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchCalendarEvent.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchCalendarEvent.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchCalendarEvent.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchCalendarEvent.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -329,14 +303,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/calendar_event/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateCalendarEvent.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return UpdateCalendarEvent.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return UpdateCalendarEvent.Forbidden(Serializer.deserialize content)
-            else
-                return UpdateCalendarEvent.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return UpdateCalendarEvent.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return UpdateCalendarEvent.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return UpdateCalendarEvent.Forbidden(Serializer.deserialize content)
+            | _ -> return UpdateCalendarEvent.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -353,14 +324,13 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/calendar_event_response" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return PostCreateCalendarEventResponse.Created(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.Created -> return PostCreateCalendarEventResponse.Created(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return PostCreateCalendarEventResponse.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
+            | HttpStatusCode.Forbidden ->
                 return PostCreateCalendarEventResponse.Forbidden(Serializer.deserialize content)
-            else
-                return PostCreateCalendarEventResponse.Conflict(Serializer.deserialize content)
+            | _ -> return PostCreateCalendarEventResponse.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -384,12 +354,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/coach" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchCoaches.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchCoaches.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchCoaches.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchCoaches.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchCoaches.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchCoaches.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -402,12 +370,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/coach/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchCoach.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchCoach.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchCoach.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchCoach.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchCoach.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchCoach.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -443,14 +409,11 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/email_history" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchEmailHistories.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchEmailHistories.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return FetchEmailHistories.Forbidden(Serializer.deserialize content)
-            else
-                return FetchEmailHistories.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchEmailHistories.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchEmailHistories.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return FetchEmailHistories.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchEmailHistories.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -465,12 +428,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/email_history/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchEmailHistory.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchEmailHistory.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchEmailHistory.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchEmailHistory.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchEmailHistory.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchEmailHistory.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -488,12 +449,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/group" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchGroups.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchGroups.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchGroups.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchGroups.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchGroups.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchGroups.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -504,14 +463,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/group" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return CreateGroup.Created(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return CreateGroup.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreateGroup.Forbidden(Serializer.deserialize content)
-            else
-                return CreateGroup.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return CreateGroup.Created(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return CreateGroup.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreateGroup.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateGroup.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -524,12 +480,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/group/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchGroup.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchGroup.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchGroup.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchGroup.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchGroup.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchGroup.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -577,14 +531,11 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/health_profile" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchHealthProfiles.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchHealthProfiles.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return FetchHealthProfiles.Forbidden(Serializer.deserialize content)
-            else
-                return FetchHealthProfiles.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchHealthProfiles.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchHealthProfiles.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return FetchHealthProfiles.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchHealthProfiles.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -603,12 +554,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_profile/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchHealthProfile.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchHealthProfile.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchHealthProfile.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchHealthProfile.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchHealthProfile.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchHealthProfile.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -657,14 +606,12 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_profile_answer" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchHealthProfileAnswers.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchHealthProfileAnswers.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchHealthProfileAnswers.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return FetchHealthProfileAnswers.Forbidden(Serializer.deserialize content)
-            else
-                return FetchHealthProfileAnswers.Conflict(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return FetchHealthProfileAnswers.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchHealthProfileAnswers.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -683,12 +630,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_profile_answer/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchHealthProfileAnswer.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchHealthProfileAnswer.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchHealthProfileAnswer.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchHealthProfileAnswer.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchHealthProfileAnswer.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -721,14 +667,12 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_profile_question" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchHealthProfileQuestions.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchHealthProfileQuestions.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchHealthProfileQuestions.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return FetchHealthProfileQuestions.Forbidden(Serializer.deserialize content)
-            else
-                return FetchHealthProfileQuestions.Conflict(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return FetchHealthProfileQuestions.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchHealthProfileQuestions.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -747,12 +691,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_profile_question/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchHealthProfileQuestion.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchHealthProfileQuestion.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchHealthProfileQuestion.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchHealthProfileQuestion.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchHealthProfileQuestion.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -765,14 +708,13 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_question_definition" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchHealthQuestionDefinitions.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchHealthQuestionDefinitions.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchHealthQuestionDefinitions.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
+            | HttpStatusCode.Forbidden ->
                 return FetchHealthQuestionDefinitions.Forbidden(Serializer.deserialize content)
-            else
-                return FetchHealthQuestionDefinitions.Conflict(Serializer.deserialize content)
+            | _ -> return FetchHealthQuestionDefinitions.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -787,12 +729,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/health_question_definition/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchHealthQuestionDefinition.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchHealthQuestionDefinition.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchHealthQuestionDefinition.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchHealthQuestionDefinition.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchHealthQuestionDefinition.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -821,14 +762,11 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/oauth/token" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return CreateToken.Created(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return CreateToken.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreateToken.Forbidden(Serializer.deserialize content)
-            else
-                return CreateToken.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return CreateToken.Created(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return CreateToken.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreateToken.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateToken.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -843,12 +781,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/oauth/token/{id}/groups" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchTokenGroups.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchTokenGroups.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchTokenGroups.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchTokenGroups.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchTokenGroups.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchTokenGroups.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -863,12 +799,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/oauth/token/{id}/organization" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchTokenOrganization.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchTokenOrganization.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchTokenOrganization.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchTokenOrganization.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchTokenOrganization.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchTokenOrganization.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -881,12 +815,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/organization/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchOrganization.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchOrganization.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchOrganization.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchOrganization.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchOrganization.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchOrganization.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -946,14 +878,11 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/patient" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchPatients.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchPatients.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return FetchPatients.Forbidden(Serializer.deserialize content)
-            else
-                return FetchPatients.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchPatients.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchPatients.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return FetchPatients.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchPatients.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -991,14 +920,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/patient" requestParts cancellationToken
 
-            if status = HttpStatusCode.Created then
-                return CreatePatient.Created(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return CreatePatient.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreatePatient.Forbidden(Serializer.deserialize content)
-            else
-                return CreatePatient.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.Created -> return CreatePatient.Created(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return CreatePatient.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreatePatient.Forbidden(Serializer.deserialize content)
+            | _ -> return CreatePatient.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1009,14 +935,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/patient" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpsertPatient.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return UpsertPatient.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return UpsertPatient.Forbidden(Serializer.deserialize content)
-            else
-                return UpsertPatient.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return UpsertPatient.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return UpsertPatient.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return UpsertPatient.Forbidden(Serializer.deserialize content)
+            | _ -> return UpsertPatient.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1029,12 +952,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/patient/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchPatient.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchPatient.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatient.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchPatient.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchPatient.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatient.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1051,14 +972,11 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.patchAsync httpClient "/patient/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdatePatient.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return UpdatePatient.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return UpdatePatient.Forbidden(Serializer.deserialize content)
-            else
-                return UpdatePatient.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return UpdatePatient.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return UpdatePatient.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return UpdatePatient.Forbidden(Serializer.deserialize content)
+            | _ -> return UpdatePatient.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1073,12 +991,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient/{id}/coaches" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchPatientCoaches.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchPatientCoaches.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientCoaches.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchPatientCoaches.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchPatientCoaches.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatientCoaches.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1093,12 +1009,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient/{id}/groups" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchPatientGroups.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchPatientGroups.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientGroups.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchPatientGroups.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchPatientGroups.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatientGroups.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1143,14 +1057,12 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient_health_metric" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchPatientHealthMetrics.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchPatientHealthMetrics.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchPatientHealthMetrics.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return FetchPatientHealthMetrics.Forbidden(Serializer.deserialize content)
-            else
-                return FetchPatientHealthMetrics.Conflict(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return FetchPatientHealthMetrics.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchPatientHealthMetrics.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1201,14 +1113,12 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/patient_health_metric" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreatePatientHealthMetric.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return CreatePatientHealthMetric.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return CreatePatientHealthMetric.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreatePatientHealthMetric.Forbidden(Serializer.deserialize content)
-            else
-                return CreatePatientHealthMetric.Conflict(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreatePatientHealthMetric.Forbidden(Serializer.deserialize content)
+            | _ -> return CreatePatientHealthMetric.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1223,12 +1133,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient_health_metric/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchPatientHealthMetric.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchPatientHealthMetric.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchPatientHealthMetric.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientHealthMetric.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchPatientHealthMetric.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1261,12 +1170,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient_plan_summary" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchPatientPlanSummaries.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchPatientPlanSummaries.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchPatientPlanSummaries.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientPlanSummaries.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchPatientPlanSummaries.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1285,12 +1193,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/patient_plan_summary/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchPatientPlanSummary.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchPatientPlanSummary.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientPlanSummary.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchPatientPlanSummary.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchPatientPlanSummary.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchPatientPlanSummary.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1313,14 +1219,12 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.patchAsync httpClient "/patient_plan_summary/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdatePatientPlanSummary.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return UpdatePatientPlanSummary.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return UpdatePatientPlanSummary.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return UpdatePatientPlanSummary.Forbidden(Serializer.deserialize content)
-            else
-                return UpdatePatientPlanSummary.Conflict(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return UpdatePatientPlanSummary.Forbidden(Serializer.deserialize content)
+            | _ -> return UpdatePatientPlanSummary.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1379,14 +1283,12 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/result" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchPatientHealthResults.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchPatientHealthResults.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchPatientHealthResults.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return FetchPatientHealthResults.Forbidden(Serializer.deserialize content)
-            else
-                return FetchPatientHealthResults.Conflict(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return FetchPatientHealthResults.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchPatientHealthResults.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1399,12 +1301,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/result/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchPatientHealthResult.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchPatientHealthResult.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchPatientHealthResult.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchPatientHealthResult.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchPatientHealthResult.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1440,12 +1341,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reward" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchRewards.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchRewards.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewards.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchRewards.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchRewards.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewards.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1456,14 +1355,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/reward" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateReward.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return CreateReward.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreateReward.Forbidden(Serializer.deserialize content)
-            else
-                return CreateReward.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return CreateReward.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return CreateReward.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreateReward.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateReward.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1476,12 +1372,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reward/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchReward.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchReward.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchReward.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchReward.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchReward.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchReward.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1507,12 +1401,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reward_earning" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchRewardEarnings.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchRewardEarnings.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardEarnings.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchRewardEarnings.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchRewardEarnings.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardEarnings.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1523,14 +1415,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/reward_earning" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateRewardEarning.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return CreateRewardEarning.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreateRewardEarning.Forbidden(Serializer.deserialize content)
-            else
-                return CreateRewardEarning.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return CreateRewardEarning.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return CreateRewardEarning.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreateRewardEarning.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateRewardEarning.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1545,12 +1434,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_earning/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchRewardEarning.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchRewardEarning.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardEarning.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchRewardEarning.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchRewardEarning.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardEarning.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1566,12 +1453,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_earning_fulfillment" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchRewardEarningFulfillments.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchRewardEarningFulfillments.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchRewardEarningFulfillments.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardEarningFulfillments.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchRewardEarningFulfillments.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1588,14 +1474,13 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/reward_earning_fulfillment" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateRewardEarningFulfillment.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return CreateRewardEarningFulfillment.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return CreateRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
+            | HttpStatusCode.Forbidden ->
                 return CreateRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
-            else
-                return CreateRewardEarningFulfillment.Conflict(Serializer.deserialize content)
+            | _ -> return CreateRewardEarningFulfillment.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1610,12 +1495,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_earning_fulfillment/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchRewardEarningFulfillment.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchRewardEarningFulfillment.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchRewardEarningFulfillment.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchRewardEarningFulfillment.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1639,12 +1523,10 @@ type TwinehealthClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/reward_program" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchRewardPrograms.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchRewardPrograms.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardPrograms.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchRewardPrograms.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchRewardPrograms.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardPrograms.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1655,14 +1537,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/reward_program" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateRewardProgram.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return CreateRewardProgram.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreateRewardProgram.Forbidden(Serializer.deserialize content)
-            else
-                return CreateRewardProgram.Conflict(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return CreateRewardProgram.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return CreateRewardProgram.Unauthorized(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreateRewardProgram.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateRewardProgram.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1677,12 +1556,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_program/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchRewardProgram.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchRewardProgram.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardProgram.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchRewardProgram.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchRewardProgram.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardProgram.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1697,12 +1574,10 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_program/{id}/group" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchRewardProgramGroup.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
-                return FetchRewardProgramGroup.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardProgramGroup.Forbidden(Serializer.deserialize content)
+            match status with
+            | HttpStatusCode.OK -> return FetchRewardProgramGroup.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized -> return FetchRewardProgramGroup.Unauthorized(Serializer.deserialize content)
+            | _ -> return FetchRewardProgramGroup.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1731,12 +1606,11 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_program_activation" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchRewardProgramActivations.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchRewardProgramActivations.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchRewardProgramActivations.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardProgramActivations.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchRewardProgramActivations.Forbidden(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1753,14 +1627,12 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/reward_program_activation" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateRewardProgramActivation.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return CreateRewardProgramActivation.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return CreateRewardProgramActivation.Unauthorized(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return CreateRewardProgramActivation.Forbidden(Serializer.deserialize content)
-            else
-                return CreateRewardProgramActivation.Conflict(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return CreateRewardProgramActivation.Forbidden(Serializer.deserialize content)
+            | _ -> return CreateRewardProgramActivation.Conflict(Serializer.deserialize content)
         }
 
     ///<summary>
@@ -1775,10 +1647,9 @@ type TwinehealthClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/reward_program_activation/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FetchRewardProgramActivation.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Unauthorized then
+            match status with
+            | HttpStatusCode.OK -> return FetchRewardProgramActivation.OK(Serializer.deserialize content)
+            | HttpStatusCode.Unauthorized ->
                 return FetchRewardProgramActivation.Unauthorized(Serializer.deserialize content)
-            else
-                return FetchRewardProgramActivation.Forbidden(Serializer.deserialize content)
+            | _ -> return FetchRewardProgramActivation.Forbidden(Serializer.deserialize content)
         }

--- a/examples/Watchful/Client.fs
+++ b/examples/Watchful/Client.fs
@@ -27,8 +27,8 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/audits" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAudits.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetAudits.OK(Serializer.deserialize content)
             | _ -> return GetAudits.Forbidden
         }
 
@@ -52,9 +52,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/audits/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteAuditById.OK content
-            | HttpStatusCode.Forbidden -> return DeleteAuditById.Forbidden
+            match int status with
+            | 200 -> return DeleteAuditById.OK content
+            | 403 -> return DeleteAuditById.Forbidden
             | _ -> return DeleteAuditById.NotFound
         }
 
@@ -73,9 +73,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/audits/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetAuditById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetAuditById.BadRequest
+            match int status with
+            | 200 -> return GetAuditById.OK(Serializer.deserialize content)
+            | 400 -> return GetAuditById.BadRequest
             | _ -> return GetAuditById.Forbidden
         }
 
@@ -128,9 +128,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/extensions" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetExtensions.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetExtensions.Forbidden
+            match int status with
+            | 200 -> return GetExtensions.OK(Serializer.deserialize content)
+            | 403 -> return GetExtensions.Forbidden
             | _ -> return GetExtensions.NotFound
         }
 
@@ -159,8 +159,8 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/ignore" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return IgnoreExtensionUpdate.OK content
+            match int status with
+            | 200 -> return IgnoreExtensionUpdate.OK content
             | _ -> return IgnoreExtensionUpdate.NotFound
         }
 
@@ -176,8 +176,8 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/unignore" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UnignoreExtensionUpdate.OK content
+            match int status with
+            | 200 -> return UnignoreExtensionUpdate.OK content
             | _ -> return UnignoreExtensionUpdate.NotFound
         }
 
@@ -193,8 +193,8 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/update" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateExtension.OK content
+            match int status with
+            | 200 -> return UpdateExtension.OK content
             | _ -> return UpdateExtension.NotFound
         }
 
@@ -211,8 +211,8 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/feedbacks" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetFeedbacks.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetFeedbacks.OK(Serializer.deserialize content)
             | _ -> return GetFeedbacks.Forbidden
         }
 
@@ -224,11 +224,11 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/feedbacks" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateFeedbacks.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateFeedbacks.Created
-            | HttpStatusCode.BadRequest -> return CreateFeedbacks.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateFeedbacks.Forbidden
+            match int status with
+            | 200 -> return CreateFeedbacks.OK(Serializer.deserialize content)
+            | 201 -> return CreateFeedbacks.Created
+            | 400 -> return CreateFeedbacks.BadRequest
+            | 403 -> return CreateFeedbacks.Forbidden
             | _ -> return CreateFeedbacks.NotFound
         }
 
@@ -290,8 +290,8 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/logs" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetLogs.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetLogs.OK(Serializer.deserialize content)
             | _ -> return GetLogs.Forbidden
         }
 
@@ -339,8 +339,8 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/logs/export" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetExportLogs.OK
+            match int status with
+            | 200 -> return GetExportLogs.OK
             | _ -> return GetExportLogs.Forbidden
         }
 
@@ -374,9 +374,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/logs/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteLogById.OK content
-            | HttpStatusCode.Forbidden -> return DeleteLogById.Forbidden
+            match int status with
+            | 200 -> return DeleteLogById.OK content
+            | 403 -> return DeleteLogById.Forbidden
             | _ -> return DeleteLogById.NotFound
         }
 
@@ -424,9 +424,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/reports/sites/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetReportsSitesById.OK contentBinary
-            | HttpStatusCode.Forbidden -> return GetReportsSitesById.Forbidden contentBinary
+            match int status with
+            | 200 -> return GetReportsSitesById.OK contentBinary
+            | 403 -> return GetReportsSitesById.Forbidden contentBinary
             | _ -> return GetReportsSitesById.NotFound contentBinary
         }
 
@@ -467,9 +467,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/reports/tags/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetReportsTagsById.OK contentBinary
-            | HttpStatusCode.Forbidden -> return GetReportsTagsById.Forbidden contentBinary
+            match int status with
+            | 200 -> return GetReportsTagsById.OK contentBinary
+            | 403 -> return GetReportsTagsById.Forbidden contentBinary
             | _ -> return GetReportsTagsById.NotFound contentBinary
         }
 
@@ -546,9 +546,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSites.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSites.Forbidden
+            match int status with
+            | 200 -> return GetSites.OK(Serializer.deserialize content)
+            | 403 -> return GetSites.Forbidden
             | _ -> return GetSites.NotFound
         }
 
@@ -560,11 +560,11 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateSite.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateSite.Created
-            | HttpStatusCode.BadRequest -> return CreateSite.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateSite.Forbidden
+            match int status with
+            | 200 -> return CreateSite.OK(Serializer.deserialize content)
+            | 201 -> return CreateSite.Created
+            | 400 -> return CreateSite.BadRequest
+            | 403 -> return CreateSite.Forbidden
             | _ -> return CreateSite.NotFound
         }
 
@@ -588,9 +588,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteSitesById.OK content
-            | HttpStatusCode.Forbidden -> return DeleteSitesById.Forbidden
+            match int status with
+            | 200 -> return DeleteSitesById.OK content
+            | 403 -> return DeleteSitesById.Forbidden
             | _ -> return DeleteSitesById.NotFound
         }
 
@@ -609,9 +609,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSiteById.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSiteById.Forbidden
+            match int status with
+            | 200 -> return GetSiteById.OK(Serializer.deserialize content)
+            | 403 -> return GetSiteById.Forbidden
             | _ -> return GetSiteById.NotFound
         }
 
@@ -629,10 +629,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PutSitesById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return PutSitesById.BadRequest
-            | HttpStatusCode.Forbidden -> return PutSitesById.Forbidden
+            match int status with
+            | 200 -> return PutSitesById.OK(Serializer.deserialize content)
+            | 400 -> return PutSitesById.BadRequest
+            | 403 -> return PutSitesById.Forbidden
             | _ -> return PutSitesById.NotFound
         }
 
@@ -668,9 +668,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSiteAudits.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSiteAudits.Forbidden
+            match int status with
+            | 200 -> return GetSiteAudits.OK(Serializer.deserialize content)
+            | 403 -> return GetSiteAudits.Forbidden
             | _ -> return GetSiteAudits.NotFound
         }
 
@@ -686,11 +686,11 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateAudits.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateAudits.Created
-            | HttpStatusCode.BadRequest -> return CreateAudits.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateAudits.Forbidden
+            match int status with
+            | 200 -> return CreateAudits.OK(Serializer.deserialize content)
+            | 201 -> return CreateAudits.Created
+            | 400 -> return CreateAudits.BadRequest
+            | 403 -> return CreateAudits.Forbidden
             | _ -> return CreateAudits.NotFound
         }
 
@@ -706,9 +706,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupnow" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return AddSiteToBackupQueue.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return AddSiteToBackupQueue.Forbidden
+            match int status with
+            | 200 -> return AddSiteToBackupQueue.OK(Serializer.deserialize content)
+            | 403 -> return AddSiteToBackupQueue.Forbidden
             | _ -> return AddSiteToBackupQueue.NotFound
         }
 
@@ -724,9 +724,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/backupprofiles" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetBackupProfiles.OK
-            | HttpStatusCode.Forbidden -> return GetBackupProfiles.Forbidden
+            match int status with
+            | 200 -> return GetBackupProfiles.OK
+            | 403 -> return GetBackupProfiles.Forbidden
             | _ -> return GetBackupProfiles.NotFound
         }
 
@@ -742,9 +742,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/backups" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetListBackups.OK
-            | HttpStatusCode.Forbidden -> return GetListBackups.Forbidden
+            match int status with
+            | 200 -> return GetListBackups.OK
+            | 403 -> return GetListBackups.Forbidden
             | _ -> return GetListBackups.NotFound
         }
 
@@ -760,9 +760,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupstart" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return StartSiteBackup.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return StartSiteBackup.Forbidden
+            match int status with
+            | 200 -> return StartSiteBackup.OK(Serializer.deserialize content)
+            | 403 -> return StartSiteBackup.Forbidden
             | _ -> return StartSiteBackup.NotFound
         }
 
@@ -778,9 +778,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupstep" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return StepSiteBackup.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return StepSiteBackup.Forbidden
+            match int status with
+            | 200 -> return StepSiteBackup.OK(Serializer.deserialize content)
+            | 403 -> return StepSiteBackup.Forbidden
             | _ -> return StepSiteBackup.NotFound
         }
 
@@ -817,9 +817,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSitesExtensionsById.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSitesExtensionsById.Forbidden
+            match int status with
+            | 200 -> return GetSitesExtensionsById.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesExtensionsById.Forbidden
             | _ -> return GetSitesExtensionsById.NotFound
         }
 
@@ -838,9 +838,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return InstallExtension.OK
-            | HttpStatusCode.Forbidden -> return InstallExtension.Forbidden
+            match int status with
+            | 200 -> return InstallExtension.OK
+            | 403 -> return InstallExtension.Forbidden
             | _ -> return InstallExtension.NotFound
         }
 
@@ -892,9 +892,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSitesLogsById.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSitesLogsById.Forbidden
+            match int status with
+            | 200 -> return GetSitesLogsById.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesLogsById.Forbidden
             | _ -> return GetSitesLogsById.NotFound
         }
 
@@ -912,11 +912,11 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateLog.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateLog.Created
-            | HttpStatusCode.BadRequest -> return CreateLog.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateLog.Forbidden
+            match int status with
+            | 200 -> return CreateLog.OK(Serializer.deserialize content)
+            | 201 -> return CreateLog.Created
+            | 400 -> return CreateLog.BadRequest
+            | 403 -> return CreateLog.Forbidden
             | _ -> return CreateLog.NotFound
         }
 
@@ -932,9 +932,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteMonitor.OK
-            | HttpStatusCode.Forbidden -> return DeleteMonitor.Forbidden
+            match int status with
+            | 200 -> return DeleteMonitor.OK
+            | 403 -> return DeleteMonitor.Forbidden
             | _ -> return DeleteMonitor.NotFound
         }
 
@@ -950,9 +950,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostMonitor.OK
-            | HttpStatusCode.Forbidden -> return PostMonitor.Forbidden
+            match int status with
+            | 200 -> return PostMonitor.OK
+            | 403 -> return PostMonitor.Forbidden
             | _ -> return PostMonitor.NotFound
         }
 
@@ -968,9 +968,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/scanner" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return Scanner.OK content
-            | HttpStatusCode.Forbidden -> return Scanner.Forbidden
+            match int status with
+            | 200 -> return Scanner.OK content
+            | 403 -> return Scanner.Forbidden
             | _ -> return Scanner.NotFound
         }
 
@@ -984,9 +984,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/seo" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return SeoAnalyze.OK content
-            | HttpStatusCode.Forbidden -> return SeoAnalyze.Forbidden
+            match int status with
+            | 200 -> return SeoAnalyze.OK content
+            | 403 -> return SeoAnalyze.Forbidden
             | _ -> return SeoAnalyze.NotFound
         }
 
@@ -1030,9 +1030,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSitesTagsById.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSitesTagsById.Forbidden
+            match int status with
+            | 200 -> return GetSitesTagsById.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesTagsById.Forbidden
             | _ -> return GetSitesTagsById.NotFound
         }
 
@@ -1050,10 +1050,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PostTags.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return PostTags.Created
-            | HttpStatusCode.Forbidden -> return PostTags.Forbidden
+            match int status with
+            | 200 -> return PostTags.OK(Serializer.deserialize content)
+            | 201 -> return PostTags.Created
+            | 403 -> return PostTags.Forbidden
             | _ -> return PostTags.NotFound
         }
 
@@ -1069,9 +1069,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/updatejoomla" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateJoomla.OK content
-            | HttpStatusCode.Forbidden -> return UpdateJoomla.Forbidden
+            match int status with
+            | 200 -> return UpdateJoomla.OK content
+            | 403 -> return UpdateJoomla.Forbidden
             | _ -> return UpdateJoomla.NotFound
         }
 
@@ -1085,9 +1085,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/uptime" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUptime.OK
-            | HttpStatusCode.Forbidden -> return GetUptime.Forbidden
+            match int status with
+            | 200 -> return GetUptime.OK
+            | 403 -> return GetUptime.Forbidden
             | _ -> return GetUptime.NotFound
         }
 
@@ -1103,9 +1103,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/validate" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return ValidateSite.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return ValidateSite.Forbidden
+            match int status with
+            | 200 -> return ValidateSite.OK(Serializer.deserialize content)
+            | 403 -> return ValidateSite.Forbidden
             | _ -> return ValidateSite.NotFound
         }
 
@@ -1121,9 +1121,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/validatedebug" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return ValidateDebugSite.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return ValidateDebugSite.Forbidden
+            match int status with
+            | 200 -> return ValidateDebugSite.OK(Serializer.deserialize content)
+            | 403 -> return ValidateDebugSite.Forbidden
             | _ -> return ValidateDebugSite.NotFound
         }
 
@@ -1135,8 +1135,8 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/ssousers" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSsoUsers.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetSsoUsers.OK(Serializer.deserialize content)
             | _ -> return GetSsoUsers.Forbidden
         }
 
@@ -1148,11 +1148,11 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/ssousers" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateSsoUsers.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateSsoUsers.Created
-            | HttpStatusCode.BadRequest -> return CreateSsoUsers.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateSsoUsers.Forbidden
+            match int status with
+            | 200 -> return CreateSsoUsers.OK(Serializer.deserialize content)
+            | 201 -> return CreateSsoUsers.Created
+            | 400 -> return CreateSsoUsers.BadRequest
+            | 403 -> return CreateSsoUsers.Forbidden
             | _ -> return CreateSsoUsers.NotFound
         }
 
@@ -1166,9 +1166,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteSsoUserById.OK content
-            | HttpStatusCode.Forbidden -> return DeleteSsoUserById.Forbidden
+            match int status with
+            | 200 -> return DeleteSsoUserById.OK content
+            | 403 -> return DeleteSsoUserById.Forbidden
             | _ -> return DeleteSsoUserById.NotFound
         }
 
@@ -1187,9 +1187,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSsoUsersById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetSsoUsersById.BadRequest
+            match int status with
+            | 200 -> return GetSsoUsersById.OK(Serializer.deserialize content)
+            | 400 -> return GetSsoUsersById.BadRequest
             | _ -> return GetSsoUsersById.Forbidden
         }
 
@@ -1207,11 +1207,11 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateSsoUsers.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return UpdateSsoUsers.Created
-            | HttpStatusCode.BadRequest -> return UpdateSsoUsers.BadRequest
-            | HttpStatusCode.Forbidden -> return UpdateSsoUsers.Forbidden
+            match int status with
+            | 200 -> return UpdateSsoUsers.OK(Serializer.deserialize content)
+            | 201 -> return UpdateSsoUsers.Created
+            | 400 -> return UpdateSsoUsers.BadRequest
+            | 403 -> return UpdateSsoUsers.Forbidden
             | _ -> return UpdateSsoUsers.NotFound
         }
 
@@ -1252,8 +1252,8 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTags.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return GetTags.OK(Serializer.deserialize content)
             | _ -> return GetTags.Forbidden
         }
 
@@ -1265,11 +1265,11 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/tags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateTags.OK(Serializer.deserialize content)
-            | HttpStatusCode.Created -> return CreateTags.Created
-            | HttpStatusCode.BadRequest -> return CreateTags.BadRequest
-            | HttpStatusCode.Forbidden -> return CreateTags.Forbidden
+            match int status with
+            | 200 -> return CreateTags.OK(Serializer.deserialize content)
+            | 201 -> return CreateTags.Created
+            | 400 -> return CreateTags.BadRequest
+            | 403 -> return CreateTags.Forbidden
             | _ -> return CreateTags.NotFound
         }
 
@@ -1293,9 +1293,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return DeleteTagsById.OK content
-            | HttpStatusCode.Forbidden -> return DeleteTagsById.Forbidden
+            match int status with
+            | 200 -> return DeleteTagsById.OK content
+            | 403 -> return DeleteTagsById.Forbidden
             | _ -> return DeleteTagsById.NotFound
         }
 
@@ -1314,9 +1314,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetTagById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetTagById.BadRequest
+            match int status with
+            | 200 -> return GetTagById.OK(Serializer.deserialize content)
+            | 400 -> return GetTagById.BadRequest
             | _ -> return GetTagById.Forbidden
         }
 
@@ -1334,10 +1334,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdateTag.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return UpdateTag.BadRequest
-            | HttpStatusCode.Forbidden -> return UpdateTag.Forbidden
+            match int status with
+            | 200 -> return UpdateTag.OK(Serializer.deserialize content)
+            | 400 -> return UpdateTag.BadRequest
+            | 403 -> return UpdateTag.Forbidden
             | _ -> return UpdateTag.NotFound
         }
 
@@ -1409,8 +1409,8 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags/{id}/sites" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetSitesByTags.OK(Serializer.deserialize content)
-            | HttpStatusCode.Forbidden -> return GetSitesByTags.Forbidden
+            match int status with
+            | 200 -> return GetSitesByTags.OK(Serializer.deserialize content)
+            | 403 -> return GetSitesByTags.Forbidden
             | _ -> return GetSitesByTags.NotFound
         }

--- a/examples/Watchful/Client.fs
+++ b/examples/Watchful/Client.fs
@@ -27,10 +27,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/audits" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAudits.OK(Serializer.deserialize content)
-            else
-                return GetAudits.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetAudits.OK(Serializer.deserialize content)
+            | _ -> return GetAudits.Forbidden
         }
 
     ///<summary>
@@ -53,12 +52,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/audits/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteAuditById.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteAuditById.Forbidden
-            else
-                return DeleteAuditById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteAuditById.OK content
+            | HttpStatusCode.Forbidden -> return DeleteAuditById.Forbidden
+            | _ -> return DeleteAuditById.NotFound
         }
 
     ///<summary>
@@ -76,12 +73,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/audits/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetAuditById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetAuditById.BadRequest
-            else
-                return GetAuditById.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetAuditById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetAuditById.BadRequest
+            | _ -> return GetAuditById.Forbidden
         }
 
     ///<summary>
@@ -133,12 +128,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/extensions" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetExtensions.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetExtensions.Forbidden
-            else
-                return GetExtensions.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetExtensions.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetExtensions.Forbidden
+            | _ -> return GetExtensions.NotFound
         }
 
     ///<summary>
@@ -166,10 +159,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/ignore" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return IgnoreExtensionUpdate.OK content
-            else
-                return IgnoreExtensionUpdate.NotFound
+            match status with
+            | HttpStatusCode.OK -> return IgnoreExtensionUpdate.OK content
+            | _ -> return IgnoreExtensionUpdate.NotFound
         }
 
     ///<summary>
@@ -184,10 +176,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/unignore" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UnignoreExtensionUpdate.OK content
-            else
-                return UnignoreExtensionUpdate.NotFound
+            match status with
+            | HttpStatusCode.OK -> return UnignoreExtensionUpdate.OK content
+            | _ -> return UnignoreExtensionUpdate.NotFound
         }
 
     ///<summary>
@@ -202,10 +193,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/extensions/{id}/update" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateExtension.OK content
-            else
-                return UpdateExtension.NotFound
+            match status with
+            | HttpStatusCode.OK -> return UpdateExtension.OK content
+            | _ -> return UpdateExtension.NotFound
         }
 
     ///<summary>
@@ -221,10 +211,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/feedbacks" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetFeedbacks.OK(Serializer.deserialize content)
-            else
-                return GetFeedbacks.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetFeedbacks.OK(Serializer.deserialize content)
+            | _ -> return GetFeedbacks.Forbidden
         }
 
     ///<summary>
@@ -235,16 +224,12 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/feedbacks" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateFeedbacks.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateFeedbacks.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateFeedbacks.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateFeedbacks.Forbidden
-            else
-                return CreateFeedbacks.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateFeedbacks.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateFeedbacks.Created
+            | HttpStatusCode.BadRequest -> return CreateFeedbacks.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateFeedbacks.Forbidden
+            | _ -> return CreateFeedbacks.NotFound
         }
 
     ///<summary>
@@ -305,10 +290,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/logs" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetLogs.OK(Serializer.deserialize content)
-            else
-                return GetLogs.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetLogs.OK(Serializer.deserialize content)
+            | _ -> return GetLogs.Forbidden
         }
 
     ///<summary>
@@ -355,10 +339,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/logs/export" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetExportLogs.OK
-            else
-                return GetExportLogs.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetExportLogs.OK
+            | _ -> return GetExportLogs.Forbidden
         }
 
     ///<summary>
@@ -391,12 +374,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/logs/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteLogById.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteLogById.Forbidden
-            else
-                return DeleteLogById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteLogById.OK content
+            | HttpStatusCode.Forbidden -> return DeleteLogById.Forbidden
+            | _ -> return DeleteLogById.NotFound
         }
 
     member this.PostPackages(?cancellationToken: CancellationToken) =
@@ -443,12 +424,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/reports/sites/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetReportsSitesById.OK contentBinary
-            else if status = HttpStatusCode.Forbidden then
-                return GetReportsSitesById.Forbidden contentBinary
-            else
-                return GetReportsSitesById.NotFound contentBinary
+            match status with
+            | HttpStatusCode.OK -> return GetReportsSitesById.OK contentBinary
+            | HttpStatusCode.Forbidden -> return GetReportsSitesById.Forbidden contentBinary
+            | _ -> return GetReportsSitesById.NotFound contentBinary
         }
 
     ///<summary>
@@ -488,12 +467,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, contentBinary) =
                 OpenApiHttp.getBinaryAsync httpClient "/reports/tags/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetReportsTagsById.OK contentBinary
-            else if status = HttpStatusCode.Forbidden then
-                return GetReportsTagsById.Forbidden contentBinary
-            else
-                return GetReportsTagsById.NotFound contentBinary
+            match status with
+            | HttpStatusCode.OK -> return GetReportsTagsById.OK contentBinary
+            | HttpStatusCode.Forbidden -> return GetReportsTagsById.Forbidden contentBinary
+            | _ -> return GetReportsTagsById.NotFound contentBinary
         }
 
     ///<summary>
@@ -569,12 +546,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSites.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSites.Forbidden
-            else
-                return GetSites.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSites.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSites.Forbidden
+            | _ -> return GetSites.NotFound
         }
 
     ///<summary>
@@ -585,16 +560,12 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateSite.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateSite.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateSite.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateSite.Forbidden
-            else
-                return CreateSite.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateSite.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateSite.Created
+            | HttpStatusCode.BadRequest -> return CreateSite.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateSite.Forbidden
+            | _ -> return CreateSite.NotFound
         }
 
     ///<summary>
@@ -617,12 +588,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteSitesById.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteSitesById.Forbidden
-            else
-                return DeleteSitesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteSitesById.OK content
+            | HttpStatusCode.Forbidden -> return DeleteSitesById.Forbidden
+            | _ -> return DeleteSitesById.NotFound
         }
 
     ///<summary>
@@ -640,12 +609,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSiteById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSiteById.Forbidden
-            else
-                return GetSiteById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSiteById.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSiteById.Forbidden
+            | _ -> return GetSiteById.NotFound
         }
 
     ///<summary>
@@ -662,14 +629,11 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/sites/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PutSitesById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return PutSitesById.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return PutSitesById.Forbidden
-            else
-                return PutSitesById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PutSitesById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return PutSitesById.BadRequest
+            | HttpStatusCode.Forbidden -> return PutSitesById.Forbidden
+            | _ -> return PutSitesById.NotFound
         }
 
     ///<summary>
@@ -704,12 +668,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSiteAudits.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSiteAudits.Forbidden
-            else
-                return GetSiteAudits.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSiteAudits.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSiteAudits.Forbidden
+            | _ -> return GetSiteAudits.NotFound
         }
 
     ///<summary>
@@ -724,16 +686,12 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/audits" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateAudits.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateAudits.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateAudits.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateAudits.Forbidden
-            else
-                return CreateAudits.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateAudits.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateAudits.Created
+            | HttpStatusCode.BadRequest -> return CreateAudits.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateAudits.Forbidden
+            | _ -> return CreateAudits.NotFound
         }
 
     ///<summary>
@@ -748,12 +706,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupnow" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return AddSiteToBackupQueue.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return AddSiteToBackupQueue.Forbidden
-            else
-                return AddSiteToBackupQueue.NotFound
+            match status with
+            | HttpStatusCode.OK -> return AddSiteToBackupQueue.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return AddSiteToBackupQueue.Forbidden
+            | _ -> return AddSiteToBackupQueue.NotFound
         }
 
     ///<summary>
@@ -768,12 +724,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/backupprofiles" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetBackupProfiles.OK
-            else if status = HttpStatusCode.Forbidden then
-                return GetBackupProfiles.Forbidden
-            else
-                return GetBackupProfiles.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetBackupProfiles.OK
+            | HttpStatusCode.Forbidden -> return GetBackupProfiles.Forbidden
+            | _ -> return GetBackupProfiles.NotFound
         }
 
     ///<summary>
@@ -788,12 +742,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/backups" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetListBackups.OK
-            else if status = HttpStatusCode.Forbidden then
-                return GetListBackups.Forbidden
-            else
-                return GetListBackups.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetListBackups.OK
+            | HttpStatusCode.Forbidden -> return GetListBackups.Forbidden
+            | _ -> return GetListBackups.NotFound
         }
 
     ///<summary>
@@ -808,12 +760,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupstart" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return StartSiteBackup.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return StartSiteBackup.Forbidden
-            else
-                return StartSiteBackup.NotFound
+            match status with
+            | HttpStatusCode.OK -> return StartSiteBackup.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return StartSiteBackup.Forbidden
+            | _ -> return StartSiteBackup.NotFound
         }
 
     ///<summary>
@@ -828,12 +778,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/backupstep" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return StepSiteBackup.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return StepSiteBackup.Forbidden
-            else
-                return StepSiteBackup.NotFound
+            match status with
+            | HttpStatusCode.OK -> return StepSiteBackup.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return StepSiteBackup.Forbidden
+            | _ -> return StepSiteBackup.NotFound
         }
 
     ///<summary>
@@ -869,12 +817,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSitesExtensionsById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSitesExtensionsById.Forbidden
-            else
-                return GetSitesExtensionsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSitesExtensionsById.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSitesExtensionsById.Forbidden
+            | _ -> return GetSitesExtensionsById.NotFound
         }
 
     ///<summary>
@@ -892,12 +838,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/extensions" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return InstallExtension.OK
-            else if status = HttpStatusCode.Forbidden then
-                return InstallExtension.Forbidden
-            else
-                return InstallExtension.NotFound
+            match status with
+            | HttpStatusCode.OK -> return InstallExtension.OK
+            | HttpStatusCode.Forbidden -> return InstallExtension.Forbidden
+            | _ -> return InstallExtension.NotFound
         }
 
     ///<summary>
@@ -948,12 +892,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSitesLogsById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSitesLogsById.Forbidden
-            else
-                return GetSitesLogsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSitesLogsById.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSitesLogsById.Forbidden
+            | _ -> return GetSitesLogsById.NotFound
         }
 
     ///<summary>
@@ -970,16 +912,12 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites/{id}/logs" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateLog.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateLog.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateLog.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateLog.Forbidden
-            else
-                return CreateLog.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateLog.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateLog.Created
+            | HttpStatusCode.BadRequest -> return CreateLog.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateLog.Forbidden
+            | _ -> return CreateLog.NotFound
         }
 
     ///<summary>
@@ -994,12 +932,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteMonitor.OK
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteMonitor.Forbidden
-            else
-                return DeleteMonitor.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteMonitor.OK
+            | HttpStatusCode.Forbidden -> return DeleteMonitor.Forbidden
+            | _ -> return DeleteMonitor.NotFound
         }
 
     ///<summary>
@@ -1014,12 +950,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/monitor" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostMonitor.OK
-            else if status = HttpStatusCode.Forbidden then
-                return PostMonitor.Forbidden
-            else
-                return PostMonitor.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PostMonitor.OK
+            | HttpStatusCode.Forbidden -> return PostMonitor.Forbidden
+            | _ -> return PostMonitor.NotFound
         }
 
     ///<summary>
@@ -1034,12 +968,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/scanner" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return Scanner.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return Scanner.Forbidden
-            else
-                return Scanner.NotFound
+            match status with
+            | HttpStatusCode.OK -> return Scanner.OK content
+            | HttpStatusCode.Forbidden -> return Scanner.Forbidden
+            | _ -> return Scanner.NotFound
         }
 
     ///<summary>
@@ -1052,12 +984,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/seo" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return SeoAnalyze.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return SeoAnalyze.Forbidden
-            else
-                return SeoAnalyze.NotFound
+            match status with
+            | HttpStatusCode.OK -> return SeoAnalyze.OK content
+            | HttpStatusCode.Forbidden -> return SeoAnalyze.Forbidden
+            | _ -> return SeoAnalyze.NotFound
         }
 
     ///<summary>
@@ -1100,12 +1030,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSitesTagsById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSitesTagsById.Forbidden
-            else
-                return GetSitesTagsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSitesTagsById.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSitesTagsById.Forbidden
+            | _ -> return GetSitesTagsById.NotFound
         }
 
     ///<summary>
@@ -1122,14 +1050,11 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/sites/{id}/tags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PostTags.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return PostTags.Created
-            else if status = HttpStatusCode.Forbidden then
-                return PostTags.Forbidden
-            else
-                return PostTags.NotFound
+            match status with
+            | HttpStatusCode.OK -> return PostTags.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return PostTags.Created
+            | HttpStatusCode.Forbidden -> return PostTags.Forbidden
+            | _ -> return PostTags.NotFound
         }
 
     ///<summary>
@@ -1144,12 +1069,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/sites/{id}/updatejoomla" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateJoomla.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return UpdateJoomla.Forbidden
-            else
-                return UpdateJoomla.NotFound
+            match status with
+            | HttpStatusCode.OK -> return UpdateJoomla.OK content
+            | HttpStatusCode.Forbidden -> return UpdateJoomla.Forbidden
+            | _ -> return UpdateJoomla.NotFound
         }
 
     ///<summary>
@@ -1162,12 +1085,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/sites/{id}/uptime" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUptime.OK
-            else if status = HttpStatusCode.Forbidden then
-                return GetUptime.Forbidden
-            else
-                return GetUptime.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetUptime.OK
+            | HttpStatusCode.Forbidden -> return GetUptime.Forbidden
+            | _ -> return GetUptime.NotFound
         }
 
     ///<summary>
@@ -1182,12 +1103,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/validate" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return ValidateSite.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return ValidateSite.Forbidden
-            else
-                return ValidateSite.NotFound
+            match status with
+            | HttpStatusCode.OK -> return ValidateSite.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return ValidateSite.Forbidden
+            | _ -> return ValidateSite.NotFound
         }
 
     ///<summary>
@@ -1202,12 +1121,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/sites/{id}/validatedebug" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return ValidateDebugSite.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return ValidateDebugSite.Forbidden
-            else
-                return ValidateDebugSite.NotFound
+            match status with
+            | HttpStatusCode.OK -> return ValidateDebugSite.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return ValidateDebugSite.Forbidden
+            | _ -> return ValidateDebugSite.NotFound
         }
 
     ///<summary>
@@ -1218,10 +1135,9 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = []
             let! (status, content) = OpenApiHttp.getAsync httpClient "/ssousers" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSsoUsers.OK(Serializer.deserialize content)
-            else
-                return GetSsoUsers.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetSsoUsers.OK(Serializer.deserialize content)
+            | _ -> return GetSsoUsers.Forbidden
         }
 
     ///<summary>
@@ -1232,16 +1148,12 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/ssousers" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateSsoUsers.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateSsoUsers.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateSsoUsers.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateSsoUsers.Forbidden
-            else
-                return CreateSsoUsers.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateSsoUsers.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateSsoUsers.Created
+            | HttpStatusCode.BadRequest -> return CreateSsoUsers.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateSsoUsers.Forbidden
+            | _ -> return CreateSsoUsers.NotFound
         }
 
     ///<summary>
@@ -1254,12 +1166,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteSsoUserById.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteSsoUserById.Forbidden
-            else
-                return DeleteSsoUserById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteSsoUserById.OK content
+            | HttpStatusCode.Forbidden -> return DeleteSsoUserById.Forbidden
+            | _ -> return DeleteSsoUserById.NotFound
         }
 
     ///<summary>
@@ -1277,12 +1187,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSsoUsersById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetSsoUsersById.BadRequest
-            else
-                return GetSsoUsersById.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetSsoUsersById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetSsoUsersById.BadRequest
+            | _ -> return GetSsoUsersById.Forbidden
         }
 
     ///<summary>
@@ -1299,16 +1207,12 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/ssousers/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateSsoUsers.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return UpdateSsoUsers.Created
-            else if status = HttpStatusCode.BadRequest then
-                return UpdateSsoUsers.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return UpdateSsoUsers.Forbidden
-            else
-                return UpdateSsoUsers.NotFound
+            match status with
+            | HttpStatusCode.OK -> return UpdateSsoUsers.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return UpdateSsoUsers.Created
+            | HttpStatusCode.BadRequest -> return UpdateSsoUsers.BadRequest
+            | HttpStatusCode.Forbidden -> return UpdateSsoUsers.Forbidden
+            | _ -> return UpdateSsoUsers.NotFound
         }
 
     ///<summary>
@@ -1348,10 +1252,9 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTags.OK(Serializer.deserialize content)
-            else
-                return GetTags.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetTags.OK(Serializer.deserialize content)
+            | _ -> return GetTags.Forbidden
         }
 
     ///<summary>
@@ -1362,16 +1265,12 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/tags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateTags.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Created then
-                return CreateTags.Created
-            else if status = HttpStatusCode.BadRequest then
-                return CreateTags.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return CreateTags.Forbidden
-            else
-                return CreateTags.NotFound
+            match status with
+            | HttpStatusCode.OK -> return CreateTags.OK(Serializer.deserialize content)
+            | HttpStatusCode.Created -> return CreateTags.Created
+            | HttpStatusCode.BadRequest -> return CreateTags.BadRequest
+            | HttpStatusCode.Forbidden -> return CreateTags.Forbidden
+            | _ -> return CreateTags.NotFound
         }
 
     ///<summary>
@@ -1394,12 +1293,10 @@ type WatchfulClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("id", id) ]
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return DeleteTagsById.OK content
-            else if status = HttpStatusCode.Forbidden then
-                return DeleteTagsById.Forbidden
-            else
-                return DeleteTagsById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return DeleteTagsById.OK content
+            | HttpStatusCode.Forbidden -> return DeleteTagsById.Forbidden
+            | _ -> return DeleteTagsById.NotFound
         }
 
     ///<summary>
@@ -1417,12 +1314,10 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetTagById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetTagById.BadRequest
-            else
-                return GetTagById.Forbidden
+            match status with
+            | HttpStatusCode.OK -> return GetTagById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetTagById.BadRequest
+            | _ -> return GetTagById.Forbidden
         }
 
     ///<summary>
@@ -1439,14 +1334,11 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.putAsync httpClient "/tags/{id}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdateTag.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return UpdateTag.BadRequest
-            else if status = HttpStatusCode.Forbidden then
-                return UpdateTag.Forbidden
-            else
-                return UpdateTag.NotFound
+            match status with
+            | HttpStatusCode.OK -> return UpdateTag.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return UpdateTag.BadRequest
+            | HttpStatusCode.Forbidden -> return UpdateTag.Forbidden
+            | _ -> return UpdateTag.NotFound
         }
 
     ///<summary>
@@ -1517,10 +1409,8 @@ type WatchfulClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/tags/{id}/sites" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetSitesByTags.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.Forbidden then
-                return GetSitesByTags.Forbidden
-            else
-                return GetSitesByTags.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetSitesByTags.OK(Serializer.deserialize content)
+            | HttpStatusCode.Forbidden -> return GetSitesByTags.Forbidden
+            | _ -> return GetSitesByTags.NotFound
         }

--- a/examples/YamlPetStore/Client.fs
+++ b/examples/YamlPetStore/Client.fs
@@ -23,14 +23,11 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/pet" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return UpdatePet.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return UpdatePet.BadRequest
-            else if status = HttpStatusCode.NotFound then
-                return UpdatePet.NotFound
-            else
-                return UpdatePet.MethodNotAllowed
+            match status with
+            | HttpStatusCode.OK -> return UpdatePet.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return UpdatePet.BadRequest
+            | HttpStatusCode.NotFound -> return UpdatePet.NotFound
+            | _ -> return UpdatePet.MethodNotAllowed
         }
 
     ///<summary>
@@ -41,10 +38,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return AddPet.OK(Serializer.deserialize content)
-            else
-                return AddPet.MethodNotAllowed
+            match status with
+            | HttpStatusCode.OK -> return AddPet.OK(Serializer.deserialize content)
+            | _ -> return AddPet.MethodNotAllowed
         }
 
     ///<summary>
@@ -60,10 +56,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByStatus" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FindPetsByStatus.OK(Serializer.deserialize content)
-            else
-                return FindPetsByStatus.BadRequest
+            match status with
+            | HttpStatusCode.OK -> return FindPetsByStatus.OK(Serializer.deserialize content)
+            | _ -> return FindPetsByStatus.BadRequest
         }
 
     ///<summary>
@@ -79,10 +74,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByTags" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return FindPetsByTags.OK(Serializer.deserialize content)
-            else
-                return FindPetsByTags.BadRequest
+            match status with
+            | HttpStatusCode.OK -> return FindPetsByTags.OK(Serializer.deserialize content)
+            | _ -> return FindPetsByTags.BadRequest
         }
 
     ///<summary>
@@ -95,12 +89,10 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("petId", petId) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetPetById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetPetById.BadRequest
-            else
-                return GetPetById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetPetById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetPetById.BadRequest
+            | _ -> return GetPetById.NotFound
         }
 
     ///<summary>
@@ -121,10 +113,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.MethodNotAllowed then
-                return UpdatePetWithForm.MethodNotAllowed
-            else
-                return UpdatePetWithForm.DefaultResponse
+            match status with
+            | HttpStatusCode.MethodNotAllowed -> return UpdatePetWithForm.MethodNotAllowed
+            | _ -> return UpdatePetWithForm.DefaultResponse
         }
 
     ///<summary>
@@ -142,10 +133,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.BadRequest then
-                return DeletePet.BadRequest
-            else
-                return DeletePet.DefaultResponse
+            match status with
+            | HttpStatusCode.BadRequest -> return DeletePet.BadRequest
+            | _ -> return DeletePet.DefaultResponse
         }
 
     ///<summary>
@@ -194,10 +184,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/store/order" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return PlaceOrder.OK(Serializer.deserialize content)
-            else
-                return PlaceOrder.MethodNotAllowed
+            match status with
+            | HttpStatusCode.OK -> return PlaceOrder.OK(Serializer.deserialize content)
+            | _ -> return PlaceOrder.MethodNotAllowed
         }
 
     ///<summary>
@@ -213,12 +202,10 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetOrderById.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetOrderById.BadRequest
-            else
-                return GetOrderById.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetOrderById.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetOrderById.BadRequest
+            | _ -> return GetOrderById.NotFound
         }
 
     ///<summary>
@@ -234,12 +221,10 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            if status = HttpStatusCode.BadRequest then
-                return DeleteOrder.BadRequest
-            else if status = HttpStatusCode.NotFound then
-                return DeleteOrder.NotFound
-            else
-                return DeleteOrder.DefaultResponse
+            match status with
+            | HttpStatusCode.BadRequest -> return DeleteOrder.BadRequest
+            | HttpStatusCode.NotFound -> return DeleteOrder.NotFound
+            | _ -> return DeleteOrder.DefaultResponse
         }
 
     ///<summary>
@@ -262,10 +247,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/user/createWithList" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return CreateUsersWithListInput.OK(Serializer.deserialize content)
-            else
-                return CreateUsersWithListInput.DefaultResponse
+            match status with
+            | HttpStatusCode.OK -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
+            | _ -> return CreateUsersWithListInput.DefaultResponse
         }
 
     ///<summary>
@@ -284,10 +268,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/login" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return LoginUser.OK content
-            else
-                return LoginUser.BadRequest
+            match status with
+            | HttpStatusCode.OK -> return LoginUser.OK content
+            | _ -> return LoginUser.BadRequest
         }
 
     ///<summary>
@@ -312,12 +295,10 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            if status = HttpStatusCode.OK then
-                return GetUserByName.OK(Serializer.deserialize content)
-            else if status = HttpStatusCode.BadRequest then
-                return GetUserByName.BadRequest
-            else
-                return GetUserByName.NotFound
+            match status with
+            | HttpStatusCode.OK -> return GetUserByName.OK(Serializer.deserialize content)
+            | HttpStatusCode.BadRequest -> return GetUserByName.BadRequest
+            | _ -> return GetUserByName.NotFound
         }
 
     ///<summary>
@@ -349,10 +330,8 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            if status = HttpStatusCode.BadRequest then
-                return DeleteUser.BadRequest
-            else if status = HttpStatusCode.NotFound then
-                return DeleteUser.NotFound
-            else
-                return DeleteUser.DefaultResponse
+            match status with
+            | HttpStatusCode.BadRequest -> return DeleteUser.BadRequest
+            | HttpStatusCode.NotFound -> return DeleteUser.NotFound
+            | _ -> return DeleteUser.DefaultResponse
         }

--- a/examples/YamlPetStore/Client.fs
+++ b/examples/YamlPetStore/Client.fs
@@ -23,10 +23,10 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.putAsync httpClient "/pet" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return UpdatePet.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return UpdatePet.BadRequest
-            | HttpStatusCode.NotFound -> return UpdatePet.NotFound
+            match int status with
+            | 200 -> return UpdatePet.OK(Serializer.deserialize content)
+            | 400 -> return UpdatePet.BadRequest
+            | 404 -> return UpdatePet.NotFound
             | _ -> return UpdatePet.MethodNotAllowed
         }
 
@@ -38,8 +38,8 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return AddPet.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return AddPet.OK(Serializer.deserialize content)
             | _ -> return AddPet.MethodNotAllowed
         }
 
@@ -56,8 +56,8 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByStatus" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FindPetsByStatus.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FindPetsByStatus.OK(Serializer.deserialize content)
             | _ -> return FindPetsByStatus.BadRequest
         }
 
@@ -74,8 +74,8 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/findByTags" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return FindPetsByTags.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return FindPetsByTags.OK(Serializer.deserialize content)
             | _ -> return FindPetsByTags.BadRequest
         }
 
@@ -89,9 +89,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.path ("petId", petId) ]
             let! (status, content) = OpenApiHttp.getAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetPetById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetPetById.BadRequest
+            match int status with
+            | 200 -> return GetPetById.OK(Serializer.deserialize content)
+            | 400 -> return GetPetById.BadRequest
             | _ -> return GetPetById.NotFound
         }
 
@@ -113,8 +113,8 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.postAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.MethodNotAllowed -> return UpdatePetWithForm.MethodNotAllowed
+            match int status with
+            | 405 -> return UpdatePetWithForm.MethodNotAllowed
             | _ -> return UpdatePetWithForm.DefaultResponse
         }
 
@@ -133,8 +133,8 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.deleteAsync httpClient "/pet/{petId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.BadRequest -> return DeletePet.BadRequest
+            match int status with
+            | 400 -> return DeletePet.BadRequest
             | _ -> return DeletePet.DefaultResponse
         }
 
@@ -184,8 +184,8 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let requestParts = [ RequestPart.jsonContent body ]
             let! (status, content) = OpenApiHttp.postAsync httpClient "/store/order" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return PlaceOrder.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return PlaceOrder.OK(Serializer.deserialize content)
             | _ -> return PlaceOrder.MethodNotAllowed
         }
 
@@ -202,9 +202,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.getAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetOrderById.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetOrderById.BadRequest
+            match int status with
+            | 200 -> return GetOrderById.OK(Serializer.deserialize content)
+            | 400 -> return GetOrderById.BadRequest
             | _ -> return GetOrderById.NotFound
         }
 
@@ -221,9 +221,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/store/order/{orderId}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.BadRequest -> return DeleteOrder.BadRequest
-            | HttpStatusCode.NotFound -> return DeleteOrder.NotFound
+            match int status with
+            | 400 -> return DeleteOrder.BadRequest
+            | 404 -> return DeleteOrder.NotFound
             | _ -> return DeleteOrder.DefaultResponse
         }
 
@@ -247,8 +247,8 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.postAsync httpClient "/user/createWithList" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
+            match int status with
+            | 200 -> return CreateUsersWithListInput.OK(Serializer.deserialize content)
             | _ -> return CreateUsersWithListInput.DefaultResponse
         }
 
@@ -268,8 +268,8 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/login" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return LoginUser.OK content
+            match int status with
+            | 200 -> return LoginUser.OK content
             | _ -> return LoginUser.BadRequest
         }
 
@@ -295,9 +295,9 @@ type YamlPetStoreClient(httpClient: HttpClient) =
 
             let! (status, content) = OpenApiHttp.getAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.OK -> return GetUserByName.OK(Serializer.deserialize content)
-            | HttpStatusCode.BadRequest -> return GetUserByName.BadRequest
+            match int status with
+            | 200 -> return GetUserByName.OK(Serializer.deserialize content)
+            | 400 -> return GetUserByName.BadRequest
             | _ -> return GetUserByName.NotFound
         }
 
@@ -330,8 +330,8 @@ type YamlPetStoreClient(httpClient: HttpClient) =
             let! (status, content) =
                 OpenApiHttp.deleteAsync httpClient "/user/{username}" requestParts cancellationToken
 
-            match status with
-            | HttpStatusCode.BadRequest -> return DeleteUser.BadRequest
-            | HttpStatusCode.NotFound -> return DeleteUser.NotFound
+            match int status with
+            | 400 -> return DeleteUser.BadRequest
+            | 404 -> return DeleteUser.NotFound
             | _ -> return DeleteUser.DefaultResponse
         }

--- a/src/Hawaii.fsproj
+++ b/src/Hawaii.fsproj
@@ -45,6 +45,7 @@
     <Content Include="schemas\petstore-v3.json" />
     <Content Include="schemas\Podiosuite.json" />
     <Content Include="schemas\SwashbuckleTime.json" />
+    <Content Include="schemas\UnlimitedResponses.json" />
     <Compile Include="./FsAst/AstRcd.fs" />
     <Compile Include="./FsAst/AstCreate.fs" />
     <Compile Include="HttpLibrary.fs" />

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -2461,17 +2461,7 @@ let createOpenApiClient
 
                     let matchClause openApiResponse =
                         let (status, _) = openApiResponse
-                        let ident =
-                            if config.target = Target.FSharp then
-                                SynPat.LongIdent(
-                                    LongIdentWithDots.Create [ "HttpStatusCode"; status ],
-                                    None,
-                                    None,
-                                    SynArgPats.Empty,
-                                    None,
-                                    range0)
-                            else
-                                SynPat.Const(SynConst.Int32 (statusCode status), range0)
+                        let ident = SynPat.Const(SynConst.Int32 (statusCode status), range0)
 
                         SynMatchClause.Clause (
                             ident,
@@ -2509,7 +2499,13 @@ let createOpenApiClient
                             responsesRevSorted |> List.head |> matchWildClause
 
                         let clausesSorted = defaultClause :: allClausesButFirst |> List.rev
-                        SynExpr.CreateMatch(createIdent [ "status" ], clausesSorted)
+
+                        SynExpr.CreateMatch(
+                            SynExpr.CreateApp(
+                                SynExpr.CreateIdent(
+                                    Ident.Create "int") ,
+                                createIdent [ "status" ]),
+                            clausesSorted)
 
                 let asyncBuilder expr =
                     if config.target = Target.Fable then

--- a/src/schemas/UnlimitedResponses.json
+++ b/src/schemas/UnlimitedResponses.json
@@ -1,0 +1,103 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "UnlimitedResponses",
+    "version": "1.0",
+    "description": "Spec containing paths with multiple responses",
+    "contact": {
+      "name": "None"
+    }
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000"
+    }
+  ],
+  "paths": {
+    "/items": {
+      "post": {
+        "summary": "Add an item",
+        "operationId": "post-items",
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "reason": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request Entity Too Large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "prop": {
+                      "type": "string"
+                    },
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error"
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "Add an item",
+        "tags": [
+          "SpecTest"
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  },
+  "tags": [
+    {
+      "name": "SpecTest"
+    }
+  ]
+}


### PR DESCRIPTION
I would like to add support for an unlimited number of response status codes. Before that only a maximum of 6 status codes are distinguished.