### PR TITLE
Fix project name generation for project names with '.' in the name.

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -1880,7 +1880,8 @@ let createOpenApiClient
     (config: CodegenConfig) =
 
     let extraTypes = ResizeArray<SynModuleDecl>()
-    let clientTypeName = $"{config.project}Client"
+    let lastProjectName = config.project.Split('.') |> Seq.last
+    let clientTypeName = $"{lastProjectName}Client"
     let info : SynComponentInfoRcd = {
         Access = None
         Attributes = [ ]


### PR DESCRIPTION
This addresses a generation failure if the project name includes periods.

For example:

```json
{
  "schema": "./openapi-stability.json",
  "project": "MyBigSerious.Enterprise.Project.Dependency.Stability",
  "output": "../../gen/MyBigSerious.Enterprise.Project.Dependency.Stability",
  "target": "fsharp",
  "synchronous": true,
}
```
Produces (invalid) code:

```fsharp
type ``MyBigSerious.Enterprise.Project.Dependency.StabilityClient``(httpClient: HttpClient) =
```

This PR fixes it to match the Snowflaqe behavior of:

```fsharp
type ``StabilityClient``(httpClient: HttpClient) =
```

