### PR TITLE
Fix multi-part form Content-Disposition Headers

### DIFF
--- a/src/HttpLibrary.fs
+++ b/src/HttpLibrary.fs
@@ -232,6 +232,7 @@ module OpenApiHttp =
                 match part with
                 | Primitive value ->
                     let content = new StringContent(serializeValue value, Encoding.UTF8)
+                    content.Headers.Add("Content-Disposition", $"form-data; name=\"{key}\"")
                     multipartFormData.Add(content, key)
                 | File file ->
                     let content = new ByteArrayContent(file)


### PR DESCRIPTION
With the default generation of these headers, Stability API's platform was not correctly handling the content-disposition headers and was rejecting our requests with `BAD REQUEST`.

This patches the behavior to explicitly set these headers - which solves the issue.

This isn't the most elegant solution, but it does address the problem - I'm open to more elegant approaches if you can suggest them.
