### PR TITLE
Add support for requestBody of type text/plain

### DIFF
--- a/src/OperationParameters.fs
+++ b/src/OperationParameters.fs
@@ -294,6 +294,19 @@ let private processOperationRequestBody
                 style = "formfield"
                 properties = []
             }]
+
+        elif content.ContainsKey "text/plain" then
+            [{
+                parameterName = "requestBody"
+                parameterIdent = "requestBody"
+                required = false
+                parameterType = SynType.String()
+                docs = ""
+                location = "textContent"
+                style = "formfield"
+                properties = []
+            }]
+
         else []
 
 let operationParameters

--- a/src/Program.fs
+++ b/src/Program.fs
@@ -1990,7 +1990,7 @@ let createOpenApiClient
                         if parameter.required then
                             if parameter.properties.Length = 0 then
                                 yield SynExpr.CreatePartialApp(["RequestPart"; parameter.location], [
-                                    if parameter.location <> "jsonContent" && parameter.location <> "binaryContent" then
+                                    if parameter.location <> "jsonContent" && parameter.location <> "binaryContent" && parameter.location <> "textContent" then
                                         SynExpr.CreateParen(SynExpr.CreateTuple [
                                             stringExpr parameter.parameterName
                                             createIdent [ parameter.parameterIdent ]
@@ -2011,7 +2011,7 @@ let createOpenApiClient
                             let value =
                                 if parameter.properties.Length = 0 then
                                     SynExpr.CreatePartialApp([ "RequestPart"; parameter.location ], [
-                                        if parameter.location <> "jsonContent" && parameter.location <> "binaryContent" then
+                                        if parameter.location <> "jsonContent" && parameter.location <> "binaryContent" && parameter.location <> "textContent" then
                                             SynExpr.CreateParen(SynExpr.CreateTuple [
                                                 stringExpr parameter.parameterName
                                                 createIdent [ parameter.parameterIdent; "Value" ]


### PR DESCRIPTION
This is an attempt at fixing the Hawaii version of the issue described at https://github.com/fsprojects/SwaggerProvider/issues/275, where if you have an OpenApi schema like 

```
"requestBody": {
    "content": {
        "text/plain": {
            "schema": {
                "type": "string"
            }
        }
    }
 },
```

Then the current version of Hawaii generates a client function without a parameter for the body - the requests always get sent with no content.
I've tested the change with an F# client and it seems to work. A Fable client compiles, but I haven't tested it so far.
