### PR TITLE
Fix: nullable required fields should generate Option<T>

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -807,7 +807,8 @@ let rec createRecordFromSchema (recordName: string) (schema: OpenApiSchema) (vis
             None
         else
         let isEnum = isEnumType propertyType
-        let required = schema.Required.Contains propertyName
+        // A field is required only if it's in Required AND not marked as nullable
+        let required = schema.Required.Contains propertyName && not propertyType.Nullable
         let isObjectArray =
             propertyType.Type = "array"
             && isNotNull propertyType.Items


### PR DESCRIPTION
OpenAPI allows a field to appear in `required` *and* carry `nullable: true`.
Currently Hawaii's `createRecordFromSchema` treats such a field as non-optional, generating  a bare `int` where the API can legally return `null`.  The generated code compiles fine but throws at runtime when the field is null.

**Fix** 

```fsharp
// Before
let required = schema.Required.Contains propertyName

// After
let required = schema.Required.Contains propertyName && not propertyType.Nullable
```

A field is only non-optional when the schema both lists it under required and does not mark it nullable.  Any schema without nullable required fields is unaffected.