### PR TITLE
Fix: treat spaces as separators in operationId normalisation

### DIFF
--- a/src/Program.fs
+++ b/src/Program.fs
@@ -430,8 +430,9 @@ let rec cleanOperationName (operationName: string) =
             |> String.concat ""
             |> cleanOperationName
     else
-        let invalidChars = [| '-'; '#'; '_'; '.'; '+'; '$'; '&'; '['; ']'; '/'; '\\'; '*'; '"'; '`' |]
+        let invalidChars = [| '-'; '#'; '_'; '.'; '+'; '$'; '&'; '['; ']'; '/'; '\\'; '*'; '"'; '`'; ' ' |]
         operation.Split(invalidChars, StringSplitOptions.RemoveEmptyEntries)
+        |> Array.filter (not << String.IsNullOrWhiteSpace)
         |> Array.map capitalize
         |> String.concat ""
 


### PR DESCRIPTION
Some OpenAPI specs use spaces in `operationId` values (e.g. `"List accounts"`).  `cleanOperationName` split on a set of punctuation characters but not on space, so a space-containing fragment survived into the PascalCase assembly step and  produced a mangled or double-spaced identifier.

**Fix** — two small changes to `cleanOperationName`:

```fsharp                                                                                                                                                                                    
// Before
let invalidChars = [| '-'; '#'; '_'; '.'; '+'; '$'; '&'; '['; ']'; '/'; '\\'; '*'; '"'; '`' |]
operation.Split(invalidChars, StringSplitOptions.RemoveEmptyEntries)
|> Array.map capitalize
|> String.concat ""

// After
let invalidChars = [| '-'; '#'; '_'; '.'; '+'; '$'; '&'; '['; ']'; '/'; '\\'; '*'; '"'; '`'; ' ' |]
operation.Split(invalidChars, StringSplitOptions.RemoveEmptyEntries)
|> Array.filter (not << String.IsNullOrWhiteSpace)
|> Array.map capitalize
|> String.concat ""
```

1. ' ' added to invalidChars so spaces are word boundaries.
2. Array.filter (not << String.IsNullOrWhiteSpace) discards any whitespace-only fragments that Split might produce (e.g. from leading/trailing spaces or repeated spaces).

Neither change affects specs whose operationId values contain no spaces.
